### PR TITLE
Travis containers and caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: scala
 scala:
   - "2.11.7"
@@ -5,6 +6,13 @@ jdk:
   - oraclejdk7
 script: "sbt clean coverage test"
 after_success: "sbt coveralls"
+before_cache:
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
 env:
   global:
     secure: "ko5RdiI9X097LZxOOFjWimFcV04D/CISaVpEKMzWkvrBQI+DTmVTyzudZD+azLnCXFVxgNbQ71Fuc0JaB1pgVRcfAuYC5ySlUtk1h4zpscZRAldPvtFRK+bM+nVF+dbhhcRQgZ3o1PLpAdxX+g4g/VAy3Oj50eDHmNERRMwtTHWdGUZAwPa3Bur/LVGWxhgmQbsu8R+PbN4zniTxO24a0jQKbPQ5ilT8YKTLEqLJrhKsMX1fhZxVXwMJjHmzvdELvwWiqPO8nvUgz7egrjwtaWF7OkRmT9/MyIeLJELhr+reuh/gj46bQCbHEEov0P0kD1nSPMfhW0tQKgBm9s/9iwp+XcGfgZlB2ZjRPyLCyLun/IC8V5qrK4LeWCJYiCUJhdMK8TcDMvknz7JfBGjjE1Bww57i8LNN5xzyUZhKtUBjjEoLZwBewfIEmSuVGlwrrRPgJks5hiThAt0dzV1RPHr46nJtTxowLWDjA9gVQLDu5tv4+yFZVrowWhfuV5HfOg4yRf7ebFlVlKsHrKxOXQjykCoZJuPLAhAzWxzKSd/MMJ3RGw6ja8arG9w91Wpd4L7yLELrmBuXeKwUIGL64uDBsZ3dx81B2Oj8X2kJBc9ZF25xBhFV0mWHaqRw6mqfXowCaLSrb89+1BGauBmbNblkeGEKm/5NFHmcw5QIUL8="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
- language: scala
- scala:
-   - "2.11.7"
- jdk:
-   - oraclejdk7
- script: "sbt clean coverage test"
- after_success: "sbt coveralls"
- env:
-   global:
-     secure: "ko5RdiI9X097LZxOOFjWimFcV04D/CISaVpEKMzWkvrBQI+DTmVTyzudZD+azLnCXFVxgNbQ71Fuc0JaB1pgVRcfAuYC5ySlUtk1h4zpscZRAldPvtFRK+bM+nVF+dbhhcRQgZ3o1PLpAdxX+g4g/VAy3Oj50eDHmNERRMwtTHWdGUZAwPa3Bur/LVGWxhgmQbsu8R+PbN4zniTxO24a0jQKbPQ5ilT8YKTLEqLJrhKsMX1fhZxVXwMJjHmzvdELvwWiqPO8nvUgz7egrjwtaWF7OkRmT9/MyIeLJELhr+reuh/gj46bQCbHEEov0P0kD1nSPMfhW0tQKgBm9s/9iwp+XcGfgZlB2ZjRPyLCyLun/IC8V5qrK4LeWCJYiCUJhdMK8TcDMvknz7JfBGjjE1Bww57i8LNN5xzyUZhKtUBjjEoLZwBewfIEmSuVGlwrrRPgJks5hiThAt0dzV1RPHr46nJtTxowLWDjA9gVQLDu5tv4+yFZVrowWhfuV5HfOg4yRf7ebFlVlKsHrKxOXQjykCoZJuPLAhAzWxzKSd/MMJ3RGw6ja8arG9w91Wpd4L7yLELrmBuXeKwUIGL64uDBsZ3dx81B2Oj8X2kJBc9ZF25xBhFV0mWHaqRw6mqfXowCaLSrb89+1BGauBmbNblkeGEKm/5NFHmcw5QIUL8="
+language: scala
+scala:
+  - "2.11.7"
+jdk:
+  - oraclejdk7
+script: "sbt clean coverage test"
+after_success: "sbt coveralls"
+env:
+  global:
+    secure: "ko5RdiI9X097LZxOOFjWimFcV04D/CISaVpEKMzWkvrBQI+DTmVTyzudZD+azLnCXFVxgNbQ71Fuc0JaB1pgVRcfAuYC5ySlUtk1h4zpscZRAldPvtFRK+bM+nVF+dbhhcRQgZ3o1PLpAdxX+g4g/VAy3Oj50eDHmNERRMwtTHWdGUZAwPa3Bur/LVGWxhgmQbsu8R+PbN4zniTxO24a0jQKbPQ5ilT8YKTLEqLJrhKsMX1fhZxVXwMJjHmzvdELvwWiqPO8nvUgz7egrjwtaWF7OkRmT9/MyIeLJELhr+reuh/gj46bQCbHEEov0P0kD1nSPMfhW0tQKgBm9s/9iwp+XcGfgZlB2ZjRPyLCyLun/IC8V5qrK4LeWCJYiCUJhdMK8TcDMvknz7JfBGjjE1Bww57i8LNN5xzyUZhKtUBjjEoLZwBewfIEmSuVGlwrrRPgJks5hiThAt0dzV1RPHr46nJtTxowLWDjA9gVQLDu5tv4+yFZVrowWhfuV5HfOg4yRf7ebFlVlKsHrKxOXQjykCoZJuPLAhAzWxzKSd/MMJ3RGw6ja8arG9w91Wpd4L7yLELrmBuXeKwUIGL64uDBsZ3dx81B2Oj8X2kJBc9ZF25xBhFV0mWHaqRw6mqfXowCaLSrb89+1BGauBmbNblkeGEKm/5NFHmcw5QIUL8="

--- a/src/test/scala/sangria/renderer/QueryRendererSpec.scala
+++ b/src/test/scala/sangria/renderer/QueryRendererSpec.scala
@@ -1,5 +1,6 @@
 package sangria.renderer
 
+import org.scalactic._
 import org.scalatest.{Matchers, WordSpec}
 import sangria.ast.{Directive, Field, AstNode}
 import sangria.parser.QueryParser
@@ -9,6 +10,11 @@ import sangria.macros._
 import scala.util.Success
 
 class QueryRendererSpec extends WordSpec with Matchers {
+
+  def strippedOfCarriageReturns = new AbstractStringUniformity {
+    def normalized(s: String): String = s.replaceAll("\\r", "")
+  }
+
   "QueryRenderer" should {
     "render kitchen sink" in {
       val Success(ast) = QueryParser.parse(FileUtil loadQuery "kitchen-sink.graphql")
@@ -92,31 +98,31 @@ class QueryRendererSpec extends WordSpec with Matchers {
     "correctly prints query operations without name" in {
       val ast = graphql"query { id, name }"
 
-      QueryRenderer.render(ast).replaceAll("\r", "") should be (
+      QueryRenderer.render(ast) should equal (
         """{
           |  id
           |  name
-          |}""".stripMargin.replaceAll("\r", ""))
+          |}""".stripMargin) (after being strippedOfCarriageReturns)
     }
 
     "correctly prints query operations with artifacts and without name" in {
       val ast = graphql"query ($$foo: TestType) @testDirective { id, name }"
 
-      QueryRenderer.render(ast).replaceAll("\r", "") should be (
+      QueryRenderer.render(ast) should equal (
         """query ($foo: TestType) @testDirective {
           |  id
           |  name
-          |}""".stripMargin.replaceAll("\r", ""))
+          |}""".stripMargin) (after being strippedOfCarriageReturns)
     }
 
     "correctly prints mutation operations with artifacts and without name" in {
       val ast = graphql"mutation ($$foo: TestType) @testDirective { id, name }"
 
-      QueryRenderer.render(ast).replaceAll("\r", "") should be (
+      QueryRenderer.render(ast) should equal (
         """mutation ($foo: TestType) @testDirective {
           |  id
           |  name
-          |}""".stripMargin.replaceAll("\r", ""))
+          |}""".stripMargin) (after being strippedOfCarriageReturns)
     }
   }
 }


### PR DESCRIPTION
I didn't try out `before_cache` but have been using a similar setup to enable Travis' caching in a different project to speed up builds. Split the indentation change in a separate commit in case that matters I can either revert or squash.

Also adds a small improvement to remove some boilerplate from `QueryRendererSpec`.