### PR TITLE
`Prepared Query`

### DIFF
--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -88,7 +88,7 @@ class Resolver[Ctx](
 
                 def resolveError(e: Throwable) = {
                   try {
-                    newUc map (_.onError(e))
+                    newUc foreach (_.onError(e))
                   } catch {
                     case NonFatal(ee) ⇒ ee.printStackTrace()
                   }
@@ -430,7 +430,14 @@ class Resolver[Ctx](
     Result(errorReg, if (canceled) None else Some(marshaller.arrayNode(listBuilder.result())))
   }
 
-  def resolveField(userCtx: Ctx, tpe: ObjectType[Ctx, _], path: Vector[String], value: Any, errors: ErrorRegistry, name: String, astFields: Vector[ast.Field]): (ErrorRegistry, Option[LeafAction[Ctx, Any]], Option[MappedCtxUpdate[Ctx, Any, Any]]) = {
+  def resolveField(
+      userCtx: Ctx,
+      tpe: ObjectType[Ctx, _],
+      path: Vector[String],
+      value: Any,
+      errors: ErrorRegistry,
+      name: String,
+      astFields: Vector[ast.Field]): (ErrorRegistry, Option[LeafAction[Ctx, Any]], Option[MappedCtxUpdate[Ctx, Any, Any]]) = {
     val astField = astFields.head
     val allFields = tpe.getField(schema, astField.name).asInstanceOf[Vector[Field[Ctx, Any]]]
     val field = allFields.head

--- a/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -42,7 +42,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val Success(query) = QueryParser.parse("{ nonDeprecated }")
       val deprecationTracker = new RecordingDeprecationTracker
 
-      Executor(schema, deprecationTracker = deprecationTracker).execute(query).await
+      Executor.execute(schema, query, deprecationTracker = deprecationTracker).await
 
       deprecationTracker.times.get should be (0)
       deprecationTracker.ctx should be (None)
@@ -58,7 +58,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val Success(query) = QueryParser.parse("{ nonDeprecated deprecated}")
       val deprecationTracker = new RecordingDeprecationTracker
 
-      Executor(schema, deprecationTracker = deprecationTracker).execute(query).await
+      Executor.execute(schema, query, deprecationTracker = deprecationTracker).await
 
       deprecationTracker.times.get should be (1)
       deprecationTracker.ctx.get.path should be (List("deprecated"))
@@ -129,7 +129,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
 
       val deprecationTracker = new RecordingDeprecationTracker
 
-      Executor(schema, deprecationTracker = deprecationTracker).execute(query).await
+      Executor.execute(schema, query, deprecationTracker = deprecationTracker).await
 
       deprecationTracker.times.get should be (1)
       deprecationTracker.enum should be (Some("TestEnum"))
@@ -160,7 +160,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
 
       val deprecationTracker = new RecordingDeprecationTracker
 
-      Executor(schema, deprecationTracker = deprecationTracker).execute(query).await
+      Executor.execute(schema, query, deprecationTracker = deprecationTracker).await
 
       deprecationTracker.times.get should be (0)
       deprecationTracker.enum should be (None)
@@ -178,7 +178,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val schema = Schema(testType)
       val Success(query) = QueryParser.parse("{ nonDeprecated }")
 
-      Executor(schema, deprecationTracker = DeprecationTracker.empty).execute(query).await
+      Executor.execute(schema, query, deprecationTracker = DeprecationTracker.empty).await
     }
   }
 
@@ -205,9 +205,8 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
           }
         """)
 
-
       val out = captureConsoleOut {
-        Executor(schema, deprecationTracker = DeprecationTracker.print).execute(query).await
+        Executor.execute(schema, query, deprecationTracker = DeprecationTracker.print).await
       }
 
       out should include ("Deprecated enum value '2' used of enum 'TestEnum'.")
@@ -223,7 +222,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val Success(query) = QueryParser.parse("{ nonDeprecated deprecated}")
 
       val out = captureConsoleOut {
-        Executor(schema, deprecationTracker = DeprecationTracker.print).execute(query).await
+        Executor.execute(schema, query, deprecationTracker = DeprecationTracker.print).await
       }
 
       out should include ("Deprecated field 'TestType.deprecated' used at path 'deprecated'.")

--- a/src/test/scala/sangria/execution/DirectivesSpec.scala
+++ b/src/test/scala/sangria/execution/DirectivesSpec.scala
@@ -24,7 +24,7 @@ class DirectivesSpec extends WordSpec with Matchers with FutureResultSupport {
   def executeTestQuery(query: String) = {
     val Success(doc) = QueryParser.parse(query)
 
-    Executor(schema, data, queryValidator = QueryValidator.empty).execute(doc).await
+    Executor.execute(schema, doc, root = data, queryValidator = QueryValidator.empty).await
   }
 
   "Execute: handles directives" when {

--- a/src/test/scala/sangria/execution/ExceptionHandlingSpec.scala
+++ b/src/test/scala/sangria/execution/ExceptionHandlingSpec.scala
@@ -35,7 +35,7 @@ class ExceptionHandlingSpec extends WordSpec with Matchers with FutureResultSupp
         }
         """)
 
-        Executor(schema).execute(doc).await should be  (
+        Executor.execute(schema, doc).await should be  (
           Map(
             "data" → Map(
               "success" → "Yay",
@@ -73,7 +73,7 @@ class ExceptionHandlingSpec extends WordSpec with Matchers with FutureResultSupp
         case (m, e: IllegalStateException) ⇒ HandledException(e.getMessage)
       }
 
-      Executor(schema, exceptionHandler = exceptionHandler).execute(doc).await should be  (
+      Executor.execute(schema, doc, exceptionHandler = exceptionHandler).await should be  (
         Map(
           "data" → Map(
             "error" → null,
@@ -103,7 +103,7 @@ class ExceptionHandlingSpec extends WordSpec with Matchers with FutureResultSupp
             Map("foo" → m.arrayNode(Vector(m.stringNode("bar"), m.intNode(1234))), "baz" → m.stringNode("Test")))
       }
 
-      Executor(schema, exceptionHandler = exceptionHandler).execute(doc).await should be  (
+      Executor.execute(schema, doc, exceptionHandler = exceptionHandler).await should be  (
         Map(
           "data" → Map(
             "error" → null,

--- a/src/test/scala/sangria/execution/ExecutorSchemaSpec.scala
+++ b/src/test/scala/sangria/execution/ExecutorSchemaSpec.scala
@@ -154,7 +154,7 @@ class ExecutorSchemaSpec extends WordSpec with Matchers with FutureResultSupport
         }
       }
 
-      Executor(BlogSchema, deferredResolver = resolver, queryValidator = QueryValidator.empty).execute(doc).await should be (expected)
+      Executor.execute(BlogSchema, doc, deferredResolver = resolver, queryValidator = QueryValidator.empty).await should be (expected)
     }
 
     "execute using subscription type" in {

--- a/src/test/scala/sangria/execution/MiddlewareSpec.scala
+++ b/src/test/scala/sangria/execution/MiddlewareSpec.scala
@@ -67,24 +67,24 @@ class MiddlewareSpec extends WordSpec with Matchers with FutureResultSupport {
     var metrics: MutableMap[String, List[Long]] = MutableMap()
   }
 
-  class FieldMetrics extends Middleware[Any] with MiddlewareAfterField[Any] with MiddlewareErrorField[Any] {
+  class FieldMetrics extends Middleware[Count] with MiddlewareAfterField[Count] with MiddlewareErrorField[Count] {
     type QueryVal = MutableMap[String, List[Long]]
     type FieldVal = Long
 
-    def beforeQuery(context: MiddlewareQueryContext[Any, _, _]) =
+    def beforeQuery(context: MiddlewareQueryContext[Count, _, _]) =
       MutableMap()
 
-    def afterQuery(queryVal: QueryVal, context: MiddlewareQueryContext[Any, _, _]) = {
-      context.executor.userContext.asInstanceOf[Count].metrics = queryVal
+    def afterQuery(queryVal: QueryVal, context: MiddlewareQueryContext[Count, _, _]) = {
+      context.ctx.metrics = queryVal
     }
 
-    def beforeField(queryVal: QueryVal, mctx: MiddlewareQueryContext[Any, _, _], ctx: Context[Any, _]) = {
+    def beforeField(queryVal: QueryVal, mctx: MiddlewareQueryContext[Count, _, _], ctx: Context[Count, _]) = {
       if (ctx.field.name == "errorInBefore") throw new IllegalStateException("oops!")
 
       continue(System.currentTimeMillis())
     }
 
-    def afterField(queryVal: QueryVal, fieldVal: FieldVal, value: Any, mctx: MiddlewareQueryContext[Any, _, _], ctx: Context[Any, _]) = {
+    def afterField(queryVal: QueryVal, fieldVal: FieldVal, value: Any, mctx: MiddlewareQueryContext[Count, _, _], ctx: Context[Count, _]) = {
       if (ctx.field.name == "errorInAfter") throw new IllegalStateException("oops!")
 
       queryVal.synchronized {
@@ -97,7 +97,7 @@ class MiddlewareSpec extends WordSpec with Matchers with FutureResultSupport {
       }
     }
 
-    def fieldError(queryVal: QueryVal, fieldVal: FieldVal, error: Throwable, mctx: MiddlewareQueryContext[Any, _, _], ctx: Context[Any, _]) =
+    def fieldError(queryVal: QueryVal, fieldVal: FieldVal, error: Throwable, mctx: MiddlewareQueryContext[Count, _, _], ctx: Context[Count, _]) =
       queryVal.synchronized {
         val key = ctx.parentType.name + "." + ctx.field.name
         val list = queryVal.getOrElse(key, Nil)

--- a/src/test/scala/sangria/execution/ProjectorSpec.scala
+++ b/src/test/scala/sangria/execution/ProjectorSpec.scala
@@ -105,7 +105,7 @@ class ProjectorSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val ctx = new Ctx
 
-      Executor(schema, userContext = ctx, deferredResolver = new ProductResolver).execute(query).await should be (
+      Executor.execute(schema, query, ctx, deferredResolver = new ProductResolver).await should be (
         Map("data" →
           Map(
             "projectAll" →

--- a/src/test/scala/sangria/execution/VariablesSpec.scala
+++ b/src/test/scala/sangria/execution/VariablesSpec.scala
@@ -210,7 +210,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
         "executes with complex input (scala input)" in {
           val args = Map("input" → Map("a" → "foo", "b" → List("bar"), "c" → "baz"))
 
-          Executor(schema).execute(testQuery, variables = mapVars(args)).await should be (Map("data" → Map(
+          Executor.execute(schema, testQuery, variables = mapVars(args)).await should be (Map("data" → Map(
             "fieldWithObjectInput" → """{"a":"foo","b":["bar"],"c":"baz"}"""
           )))
         }
@@ -218,7 +218,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
         "executes with complex input (json input)" in {
           val args = """{"input": {"a": "foo", "b": ["bar"], "c": "baz"}}""".parseJson
 
-          Executor(schema).execute(testQuery, variables = args).await should be (Map("data" → Map(
+          Executor.execute(schema, testQuery, variables = args).await should be (Map("data" → Map(
             "fieldWithObjectInput" → """{"a":"foo","b":["bar"],"c":"baz"}"""
           )))
         }
@@ -238,7 +238,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
         "properly coerces single value to array (scala input)" in {
           val args = Map("input" → Map("a" → "foo", "b" → "bar", "c" → "baz"))
 
-          Executor(schema).execute(testQuery, variables = mapVars(args)).await should be (Map("data" → Map(
+          Executor.execute(schema, testQuery, variables = mapVars(args)).await should be (Map("data" → Map(
             "fieldWithObjectInput" → """{"a":"foo","b":["bar"],"c":"baz"}"""
           )))
         }
@@ -246,13 +246,13 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
         "properly coerces single value to array (json input)" in {
           val args = """{"input": {"a": "foo", "b": "bar", "c": "baz"}}""".parseJson
 
-          Executor(schema).execute(testQuery, variables = args).await should be (Map("data" → Map(
+          Executor.execute(schema, testQuery, variables = args).await should be (Map("data" → Map(
             "fieldWithObjectInput" → """{"a":"foo","b":["bar"],"c":"baz"}"""
           )))
         }
 
         def assertErrorResult[T: InputUnmarshaller](args: T, expectedError: String) = {
-          val result = Executor(schema).execute(testQuery, variables = args).awaitAndRecoverQueryAnalysisScala.asInstanceOf[Map[String, AnyRef]]
+          val result = Executor.execute(schema, testQuery, variables = args).awaitAndRecoverQueryAnalysisScala.asInstanceOf[Map[String, AnyRef]]
 
           result("data") should equal (null)
 
@@ -331,7 +331,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """)
 
-        Executor(schema).execute(query, variables = args).await should be (Map("data" → Map(
+        Executor.execute(schema, query, variables = args).await should be (Map("data" → Map(
           "fieldWithNullableStringInput" → null
         )))
       }
@@ -346,7 +346,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """)
 
-        Executor(schema).execute(query, variables = args).await should be (Map("data" → Map(
+        Executor.execute(schema, query, variables = args).await should be (Map("data" → Map(
           "fieldWithNullableStringInput" → "\"a\""
         )))
       }

--- a/src/test/scala/sangria/introspection/IntrospectionSpec.scala
+++ b/src/test/scala/sangria/introspection/IntrospectionSpec.scala
@@ -15,7 +15,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
     "executes an introspection query" in {
       val schema = Schema(ObjectType[Unit, Unit]("QueryRoot", Nil))
 
-      Executor(schema).execute(introspectionQuery).await should be (Map(
+      Executor.execute(schema, introspectionQuery).await should be (Map(
         "data" → Map(
           "__schema" → Map(
             "queryType" → Map(
@@ -864,7 +864,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         )
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__schema" → Map(
             "types" → (List(
@@ -922,7 +922,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__type" → Map(
             "name" → "TestType"
@@ -954,7 +954,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__type" → Map(
             "name" → "TestType",
@@ -1002,7 +1002,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__type" → Map(
             "name" → "TestType",
@@ -1056,7 +1056,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__type" → Map(
             "name" → "TestEnum",
@@ -1113,7 +1113,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "__type" → Map(
             "name" → "TestEnum",
@@ -1166,7 +1166,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         """
       )
 
-      val result = Executor(schema, queryValidator = QueryValidator.empty).execute(query).await.asInstanceOf[Map[String, Any]]
+      val result = Executor.execute(schema, query, queryValidator = QueryValidator.empty).await.asInstanceOf[Map[String, Any]]
 
       result("data") should be (Map("__type" → null))
       result("errors").asInstanceOf[Seq[Map[String, Any]]](0)("message").asInstanceOf[String] should include (
@@ -1190,7 +1190,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
           }
         """)
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "schemaType" → Map(
             "name" → "__Schema",
@@ -1246,7 +1246,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
           }
         """)
 
-      Executor(schema).execute(query).await should be (Map(
+      Executor.execute(schema, query).await should be (Map(
         "data" → Map(
           "typeKindType" → Map(
             "name" → "__TypeKind",

--- a/src/test/scala/sangria/marshalling/QueryAstMarshallingSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/QueryAstMarshallingSupportSpec.scala
@@ -48,8 +48,9 @@ class QueryAstMarshallingSupportSpec extends WordSpec with Matchers with FutureR
 
       val args = graphqlInput"""{someId: "1000"}"""
 
-      val result = Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-        .execute(query, variables = args).await
+      val result = Executor.execute(StarWarsSchema, query, new CharacterRepo,
+        variables = args,
+        deferredResolver = new FriendsResolver).await
 
       QueryRenderer.render(result, QueryRenderer.PrettyInput) should be (
         """{

--- a/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -77,7 +77,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |type Foo {
         |  str: String
         |}
@@ -190,7 +190,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |type Bar implements Foo {
         |  str: String
         |}
@@ -222,7 +222,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |interface Baaz {
         |  int: Int
         |}
@@ -261,7 +261,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |type Bar {
         |  str: String
         |}
@@ -294,7 +294,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |input InputType {
         |  int: Int
         |}
@@ -325,7 +325,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |scalar Odd
         |
         |type Root {
@@ -346,7 +346,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
 
       val schema = Schema(root)
 
-      renderForTest(Executor(schema).execute(introspectionQuery).await) should be ("""
+      renderForTest(Executor.execute(schema, introspectionQuery).await) should be ("""
         |enum RGB {
         |  RED
         |  GREEN
@@ -382,7 +382,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport {
   "Introspection Schema Renderer" should {
     "Print Introspection Schema" in {
       val schema = Schema(ObjectType[Unit, Unit]("Root", Nil))
-      val rendered = SchemaRenderer.renderIntrospectionSchema(Executor(schema).execute(introspectionQuery).await)
+      val rendered = SchemaRenderer.renderIntrospectionSchema(Executor.execute(schema, introspectionQuery).await)
 
 
         ("\n" + rendered + "\n") should be ("""

--- a/src/test/scala/sangria/starWars/StarWarsIntrospectionSpec.scala
+++ b/src/test/scala/sangria/starWars/StarWarsIntrospectionSpec.scala
@@ -23,7 +23,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__schema" → Map(
@@ -65,7 +65,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__schema" → Map(
@@ -86,7 +86,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(
@@ -106,7 +106,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(
@@ -127,7 +127,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(
@@ -154,7 +154,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(
@@ -221,7 +221,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(
@@ -309,7 +309,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__schema" → Map(
@@ -386,7 +386,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "__type" → Map(

--- a/src/test/scala/sangria/starWars/StarWarsQuerySpec.scala
+++ b/src/test/scala/sangria/starWars/StarWarsQuerySpec.scala
@@ -24,7 +24,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(
@@ -44,7 +44,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(
@@ -79,7 +79,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
 
       val heroOnlySchema = Schema(HeroOnlyQuery, additionalTypes = TestSchema.Human :: TestSchema.Droid :: Nil)
 
-      Executor(heroOnlySchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(heroOnlySchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(
@@ -110,7 +110,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(
@@ -163,7 +163,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver).execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "human" → Map(
@@ -184,8 +184,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
 
       val args = mapVars("someId" → "1000")
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-        .execute(query, variables = args).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, variables = args, deferredResolver = new FriendsResolver).await should be (
           Map(
             "data" → Map(
               "human" → Map(
@@ -206,8 +205,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
 
       val args = mapVars("someId" → "1002")
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-        .execute(query, variables = args).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, variables = args, deferredResolver = new FriendsResolver).await should be (
           Map(
             "data" → Map(
               "human" → Map(
@@ -228,8 +226,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
 
       val args = mapVars("id" → "not a valid id")
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-        .execute(query, variables = args).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, variables = args, deferredResolver = new FriendsResolver).await should be (
           Map(
             "data" → Map(
               "human" → null
@@ -249,8 +246,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "luke" → Map(
@@ -272,8 +268,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "luke" → Map(
@@ -300,8 +295,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "luke" → Map(
@@ -331,8 +325,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "luke" → Map(
@@ -357,8 +350,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(
@@ -378,8 +370,7 @@ class StarWarsQuerySpec extends WordSpec with Matchers with FutureResultSupport 
         }
         """)
 
-      Executor(StarWarsSchema, userContext = new CharacterRepo, deferredResolver = new FriendsResolver)
-          .execute(query).await should be (
+      Executor.execute(StarWarsSchema, query, new CharacterRepo, deferredResolver = new FriendsResolver).await should be (
         Map(
           "data" → Map(
             "hero" → Map(

--- a/src/test/scala/sangria/util/GraphQlSupport.scala
+++ b/src/test/scala/sangria/util/GraphQlSupport.scala
@@ -23,13 +23,15 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
       case (m, e: IllegalStateException) ⇒ HandledException(e.getMessage)
     }
 
-    Executor(
+    Executor.execute(
       schema.asInstanceOf[Schema[Any, T]],
+      doc.copy(sourceMapper = None),
+      userContext,
       data,
+      variables = args,
       exceptionHandler = exceptionHandler,
-      userContext = userContext,
       queryValidator = if (validateQuery) QueryValidator.default else QueryValidator.empty,
-      deferredResolver = resolver).execute(doc.copy(sourceMapper = None), variables = args).awaitAndRecoverQueryAnalysisScala
+      deferredResolver = resolver).awaitAndRecoverQueryAnalysisScala
   }
 
   def check[T](schema: Schema[_, _], data: T, query: String, expected: Any, args: JsValue = JsObject.empty, userContext: Any = (), resolver: DeferredResolver[Any] = DeferredResolver.empty, validateQuery: Boolean = true): Unit = {


### PR DESCRIPTION
This change adds a `prepare` step to an execution making it much easier to make several consequent query execution. `PreparedQuery` also contains useful information abbot top-level field of the query with all of the arguments. This can be useful, for instance, for subscription queries that handled outside of the execution.

As a side-effect, some of the arguments are moved from the `Executor` to the `execute` and `prepare` methods.