### PR TITLE
Simple high-level deferred resolution API on top of `DeferredResolver`.

### DIFF
--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -148,6 +148,7 @@ case class Executor[Ctx, Root](
 
       try {
         val middlewareVal = middleware map (m ⇒ m.beforeQuery(middlewareCtx) → m)
+        val deferredResolverState = deferredResolver.initialQueryState
 
         val resolver = new Resolver[Ctx](
           marshaller,
@@ -162,7 +163,8 @@ case class Executor[Ctx, Root](
           sourceMapper,
           deprecationTracker,
           middlewareVal,
-          maxQueryDepth)
+          maxQueryDepth,
+          deferredResolverState)
 
         val result =
           operation.operationType match {
@@ -276,7 +278,7 @@ case class Executor[Ctx, Root](
       }
 
     val reduced = fields.fields.foldLeft(ListBuffer(initialValues: _*)) {
-      case (acc, CollectedField(_, _, Success(astFields))) if rootTpe.getField(schema, astFields.head.name).nonEmpty =>
+      case (acc, CollectedField(_, _, Success(astFields))) if rootTpe.getField(schema, astFields.head.name).nonEmpty ⇒
         val astField = astFields.head
         val field = rootTpe.getField(schema, astField.name).head
         val path = ExecutionPath.empty + astField

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -26,7 +26,8 @@ class Resolver[Ctx](
     sourceMapper: Option[SourceMapper],
     deprecationTracker: DeprecationTracker,
     middleware: List[(Any, Middleware[_])],
-    maxQueryDepth: Option[Int])(implicit executionContext: ExecutionContext) {
+    maxQueryDepth: Option[Int],
+    deferredResolverState: Any)(implicit executionContext: ExecutionContext) {
 
   val resultResolver = new ResultResolver(marshaller, exceptionHandler)
 
@@ -432,7 +433,7 @@ class Resolver[Ctx](
       }
 
       try {
-        val resolved = deferredResolver.resolve(toResolve map (d ⇒ findActualDeferred(d.deferred)), uc)
+        val resolved = deferredResolver.resolve(toResolve map (d ⇒ findActualDeferred(d.deferred)), uc, deferredResolverState)
 
         if (toResolve.size == resolved.size) {
           val dctx = ParentDeferredContext(uc, toResolve.size)

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -441,7 +441,11 @@ class Resolver[Ctx](
           for (i ← toResolve.indices) {
             val toRes = toResolve(i)
 
-            toRes.promise tryCompleteWith mapAllDeferred(toRes.deferred, resolved(i)).map(dctx.children(i) → _)
+            toRes.promise tryCompleteWith mapAllDeferred(toRes.deferred, resolved(i)).map(dctx.children(i) → _).recover {
+              case NonFatal(e) ⇒
+                dctx.children(i).resolveError(e)
+                throw e
+            }
           }
 
           dctx.init()
@@ -848,6 +852,10 @@ class Resolver[Ctx](
     def resolveResult(res: Result): Future[Result] = {
       promise.success(Vector.empty)
       Future.successful(res)
+    }
+
+    def resolveError(e: Throwable): Unit = {
+      promise.success(Vector.empty)
     }
   }
 }

--- a/src/main/scala/sangria/execution/ValueCollector.scala
+++ b/src/main/scala/sangria/execution/ValueCollector.scala
@@ -88,7 +88,7 @@ class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceM
             resolveMapValue(argDef.argumentType, argPath, argDef.defaultValue, argDef.name, marshaller, fromInput.marshaller, allowErrorsOnDefault = true, errors = errors, valueMap = fromInput.fromResult)(
               acc, astValue map (coerceInputValue(argDef.argumentType, argPath, _, Some(variables), marshaller, fromInput.marshaller)))
           } catch {
-            case InputParsingError(e) =>
+            case InputParsingError(e) ⇒
               errors ++= e.map(InvalidInputValueViolation(argDef.name, _, sourceMapper, astValue.flatMap(_.position).toList))
               acc
           }

--- a/src/main/scala/sangria/execution/deferred/DeferredResolver.scala
+++ b/src/main/scala/sangria/execution/deferred/DeferredResolver.scala
@@ -4,7 +4,7 @@ import sangria.ast
 import sangria.execution.DeferredWithInfo
 import sangria.schema.{Args, Field}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait DeferredResolver[-Ctx] {
   def includeDeferredFromField: Option[(Field[_, _], Vector[ast.Field], Args, Double) ⇒ Boolean] = None
@@ -12,15 +12,34 @@ trait DeferredResolver[-Ctx] {
   def groupDeferred[T <: DeferredWithInfo](deferred: Vector[T]): Vector[Vector[T]] =
     Vector(deferred)
 
-  def resolve(deferred: Vector[Deferred[Any]], ctx: Ctx): Vector[Future[Any]]
+  def initialQueryState: Any = ()
+
+  def resolve(deferred: Vector[Deferred[Any]], ctx: Ctx, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]]
 }
 
 object DeferredResolver {
   val empty = new DeferredResolver[Any] {
-    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map (_ ⇒ Future.failed(UnsupportedDeferError))
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) =
+      deferred map (d ⇒ Future.failed(UnsupportedDeferError(d)))
   }
+
+  def fetchers[Ctx](fetchers: Fetcher[Ctx, _, _]*): DeferredResolver[Ctx] =
+    new FetcherBasedDeferredResolver[Ctx](fetchers.toVector)
 }
 
 trait Deferred[+T]
 
-case object UnsupportedDeferError extends Exception
+trait DeferredOne[Id, +T] extends Deferred[T] {
+  def id: Id
+}
+
+trait DeferredOpt[Id, +T] extends Deferred[Option[T]] {
+  def id: Id
+}
+
+trait DeferredSeq[Id, +T] extends Deferred[Seq[T]] {
+  def ids: Seq[Id]
+}
+
+case class UnsupportedDeferError(deferred: Deferred[Any])
+    extends Exception(s"Deferred resolver is not defined for deferred value: $deferred.")

--- a/src/main/scala/sangria/execution/deferred/DeferredResolver.scala
+++ b/src/main/scala/sangria/execution/deferred/DeferredResolver.scala
@@ -24,7 +24,10 @@ object DeferredResolver {
   }
 
   def fetchers[Ctx](fetchers: Fetcher[Ctx, _, _]*): DeferredResolver[Ctx] =
-    new FetcherBasedDeferredResolver[Ctx](fetchers.toVector)
+    new FetcherBasedDeferredResolver[Ctx](fetchers.toVector, None)
+
+  def fetchersWithFallback[Ctx](fallback: DeferredResolver[Ctx], fetchers: Fetcher[Ctx, _, _]*): DeferredResolver[Ctx] =
+    new FetcherBasedDeferredResolver[Ctx](fetchers.toVector, Some(fallback))
 }
 
 trait Deferred[+T]

--- a/src/main/scala/sangria/execution/deferred/Fetcher.scala
+++ b/src/main/scala/sangria/execution/deferred/Fetcher.scala
@@ -1,0 +1,58 @@
+package sangria.execution.deferred
+
+import scala.collection.mutable.{Set ⇒ MutableSet}
+import scala.concurrent.Future
+import scala.util.Try
+
+class Fetcher[Ctx, Id, Res](val idFn: Res ⇒ Id, val fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]], val maxBatchSize: Option[Int], val cache: Option[() ⇒ FetcherCache]) {
+  def get(id: Id) = FetcherDeferredOne(this, id)
+  def getOpt(id: Id) = FetcherDeferredOpt(this, id)
+  def getSeq(ids: Seq[Id]) = FetcherDeferredSeq(this, ids)
+  def getSeqOpt(ids: Seq[Id]) = FetcherDeferredSeqOpt(this, ids)
+
+  def ids(deferred: Vector[Deferred[Any]]): Vector[Id] = {
+    val allIds =  MutableSet[Id]()
+
+    deferred foreach {
+      case FetcherDeferredOne(s, id) if s eq this ⇒ allIds += id.asInstanceOf[Id]
+      case FetcherDeferredOpt(s, id) if s eq this ⇒ allIds += id.asInstanceOf[Id]
+      case FetcherDeferredSeq(s, ids) if s eq this ⇒ allIds ++= ids.asInstanceOf[Seq[Id]]
+      case FetcherDeferredSeqOpt(s, ids) if s eq this ⇒ allIds ++= ids.asInstanceOf[Seq[Id]]
+      case _ ⇒ // skip
+    }
+
+    allIds.toVector
+  }
+}
+
+object Fetcher {
+  def apply[Ctx, Id, Res](fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, None, None)
+
+  def apply[Ctx, Id, Res](maxBatchSize: Int, fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, Some(maxBatchSize), None)
+
+  def sync[Ctx, Id, Res](fetch: (Ctx, Seq[Id]) ⇒ Seq[Res])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), (ctx: Ctx, ids: Seq[Id]) ⇒ Future.fromTry(Try(fetch(ctx, ids))), None, None)
+
+  def sync[Ctx, Id, Res](maxBatchSize: Int, fetch: (Ctx, Seq[Id]) ⇒ Seq[Res])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), (ctx: Ctx, ids: Seq[Id]) ⇒ Future.fromTry(Try(fetch(ctx, ids))), Some(maxBatchSize), None)
+
+  def caching[Ctx, Id, Res](fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, None, Some(() ⇒ FetcherCache.simple))
+
+  def caching[Ctx, Id, Res](maxBatchSize: Int, fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, Some(maxBatchSize), Some(() ⇒ FetcherCache.simple))
+
+  def caching[Ctx, Id, Res](cache: FetcherCache, fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, None, Some(() ⇒ cache))
+
+  def caching[Ctx, Id, Res](cache: FetcherCache, maxBatchSize: Int, fetch: (Ctx, Seq[Id]) ⇒ Future[Seq[Res]])(implicit id: HasId[Res, Id]): Fetcher[Ctx, Id, Res] =
+    new Fetcher[Ctx, Id, Res](i ⇒ id.id(i), fetch, Some(maxBatchSize), Some(() ⇒ cache))
+}
+
+case class FetcherDeferredOne[Ctx, Id, T](source: Fetcher[Ctx, Id, T], id: Id) extends DeferredOne[Id, T]
+case class FetcherDeferredOpt[Ctx, Id, T](source: Fetcher[Ctx, Id, T], id: Id) extends DeferredOne[Id, T]
+case class FetcherDeferredSeq[Ctx, Id, T](source: Fetcher[Ctx, Id, T], ids: Seq[Id]) extends DeferredSeq[Id, T]
+case class FetcherDeferredSeqOpt[Ctx, Id, T](source: Fetcher[Ctx, Id, T], ids: Seq[Id]) extends DeferredSeq[Id, T]
+

--- a/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
+++ b/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
@@ -173,4 +173,4 @@ class FetcherBasedDeferredResolver[-Ctx](fetchers: Vector[Fetcher[Ctx, _, _]], f
 }
 
 case class AbsentDeferredValueError(fetcher: Fetcher[Any, Any, Any], deferred: Deferred[Any], id: Any)
-  extends Exception(s"Fetcher has not resolved non-optional ID: $id.")
+  extends Exception(s"Fetcher has not resolved non-optional ID '$id'.")

--- a/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
+++ b/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
@@ -1,0 +1,161 @@
+package sangria.execution.deferred
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable.VectorBuilder
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+import scala.collection.mutable.{Map => MutableMap}
+
+class FetcherBasedDeferredResolver[-Ctx](fetchers: Vector[Fetcher[Ctx, _, _]]) extends DeferredResolver[Ctx] {
+  private val fetchersMap: Map[AnyRef, Fetcher[Ctx, _, _]] @uncheckedVariance =
+    fetchers.map(f ⇒ f → f).toMap
+
+  override def initialQueryState = fetchers.flatMap(f ⇒ f.cache.map(cacheFn ⇒ (f: AnyRef) → cacheFn())).toMap
+
+  def resolve(deferred: Vector[Deferred[Any]], ctx: Ctx, queryState: Any)(implicit ec: ExecutionContext) =  {
+    val fetcherCaches = queryState.asInstanceOf[Map[AnyRef, FetcherCache]]
+
+    val grouped = deferred groupBy {
+      case FetcherDeferredOne(s, _) ⇒ fetchersMap.get(s)
+      case FetcherDeferredOpt(s, id) ⇒ fetchersMap.get(s)
+      case FetcherDeferredSeq(s, ids) ⇒ fetchersMap.get(s)
+      case FetcherDeferredSeqOpt(s, ids) ⇒ fetchersMap.get(s)
+      case _ ⇒ None
+    }
+
+    val failed: Set[Deferred[Any]] = grouped.get(None).map(_.toSet).getOrElse(Set.empty)
+    val resolved = MutableMap[Deferred[Any], Future[Any]]()
+
+    if (failed.nonEmpty)
+      println(fetchers)
+
+    grouped foreach {
+      case (Some(fetcher), d) ⇒
+        val f = fetcher.asInstanceOf[Fetcher[Ctx, Any, Any]]
+        val fetcherCache = fetcherCaches.get(fetcher)
+        val ids = fetcher.ids(d)
+        val (nonCachedIds, cachedResults) = partitionCached(fetcherCache, ids)
+
+        val groupedIds = fetcher.maxBatchSize match {
+          case Some(size) ⇒ nonCachedIds.grouped(size)
+          case None ⇒ Iterator(nonCachedIds)
+        }
+
+        val results = groupedIds map { group ⇒
+          if (group.nonEmpty)
+            f.fetch(ctx, group).map(r ⇒ group → Success(r): (Vector[Any], Try[Seq[Any]])).recover {case e ⇒ group → Failure(e)}
+          else
+            Future.successful(group → Success(Seq.empty))
+        }
+
+        val futureRes = Future.sequence(results).map { allResults ⇒
+          val byId = MutableMap[Any, Any]() // can contain either exception or actual value! (using `Any` to avoid unnecessary boxing)
+
+          allResults.toVector.foreach { case (group, groupResult) ⇒
+            groupResult match {
+              case Success(values) ⇒
+                values.foreach(v ⇒ byId(f.idFn(v)) = v)
+
+              case Failure(e) ⇒
+                group.foreach(id ⇒ byId(id) = e)
+            }
+          }
+
+          byId
+        }
+
+        d foreach { deferred ⇒
+          resolved(deferred) = futureRes.map { m ⇒
+            val f = fetcher.asInstanceOf[Fetcher[Any, Any, Any]]
+
+            def updateCache[T](id: Any, v: T): T = fetcherCache match {
+              case Some(cache) ⇒
+                cache.update(id, v)
+
+                v
+              case None ⇒ v
+            }
+
+            deferred match {
+              case FetcherDeferredOne(_, id) if cachedResults contains id ⇒
+                cachedResults(id)
+
+              case FetcherDeferredOne(_, id) ⇒
+                m.get(id) match {
+                  case Some(e: Exception) ⇒ throw e
+                  case Some(v) ⇒ updateCache(id, v)
+                  case None ⇒ throw new AbsentDeferredValueError(f, deferred, id)
+                }
+
+              case FetcherDeferredOpt(_, id) if cachedResults contains id ⇒
+                cachedResults.get(id)
+
+              case FetcherDeferredOpt(_, id) ⇒
+                m.get(id) match {
+                  case Some(e: Exception) ⇒ throw e
+                  case v ⇒
+                    v foreach (updateCache(id, _))
+
+                    v
+                }
+
+              case FetcherDeferredSeq(_, ids) ⇒
+                ids map { id ⇒
+                  if (cachedResults contains id)
+                    cachedResults(id)
+                  else
+                    m.get(id) match {
+                      case Some(e: Exception) ⇒ throw e
+                      case Some(v) ⇒ updateCache(id, v)
+                      case None ⇒ throw new AbsentDeferredValueError(f, deferred, id)
+                    }
+                }
+
+              case FetcherDeferredSeqOpt(_, ids) ⇒
+                ids flatMap { id ⇒
+                  if (cachedResults contains id)
+                    cachedResults.get(id)
+                  else
+                    m.get(id) match {
+                      case Some(e: Exception) ⇒ throw e
+                      case v ⇒
+                        v foreach (updateCache(id, _))
+
+                        v
+                    }
+                }
+            }
+          }
+        }
+
+      case (None, _) ⇒ // handled by failed
+    }
+
+    deferred map { d ⇒
+      if (failed contains d) Future.failed(UnsupportedDeferError(d))
+      else resolved(d)
+    }
+  }
+
+  private def partitionCached(cache: Option[FetcherCache], ids: Vector[Any]): (Vector[Any], MutableMap[Any, Any]) =
+    cache match {
+      case Some(c) ⇒
+        val misses = new VectorBuilder[Any]
+        val hits = MutableMap[Any, Any]()
+
+        ids.foreach { id ⇒
+          c.get(id) match {
+            case Some(v) ⇒ hits(id) = v
+            case None ⇒ misses += id
+          }
+        }
+
+        misses.result() → hits
+
+      case None ⇒
+        ids → MutableMap.empty
+    }
+}
+
+case class AbsentDeferredValueError(fetcher: Fetcher[Any, Any, Any], deferred: Deferred[Any], id: Any)
+  extends Exception(s"Fetcher has not resolved non-optional ID: $id.")

--- a/src/main/scala/sangria/execution/deferred/FetcherCache.scala
+++ b/src/main/scala/sangria/execution/deferred/FetcherCache.scala
@@ -1,0 +1,37 @@
+package sangria.execution.deferred
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Future
+
+trait FetcherCache {
+  def cacheKey(id: Any): Any
+
+  def contains(id: Any): Boolean
+
+  def cacheable(id: Any): Boolean
+
+  def get(id: Any): Option[Any]
+
+  def update(id: Any, value: Any): Unit
+}
+
+object FetcherCache {
+  def simple = new SimpleFetcherCache
+}
+
+class SimpleFetcherCache extends FetcherCache {
+  private val cache = TrieMap[Any, Any]()
+
+  def cacheKey(id: Any) = id
+
+  def contains(id: Any) = cache.contains(cacheKey(id))
+
+  def cacheable(id: Any) = true
+
+  def get(id: Any) = cache.get(cacheKey(id))
+
+  def update(id: Any, value: Any) = {
+    if (cacheable(id))
+      cache.update(cacheKey(id), value)
+  }
+}

--- a/src/main/scala/sangria/execution/deferred/HasId.scala
+++ b/src/main/scala/sangria/execution/deferred/HasId.scala
@@ -1,0 +1,13 @@
+package sangria.execution.deferred
+
+trait HasId[T, Id] {
+  def id(value: T): Id
+}
+
+object HasId {
+  private class SimpleHasId[T, Id](fn: T ⇒ Id) extends HasId[T, Id] {
+    def id(value: T) = fn(value)
+  }
+
+  def apply[T, Id](fn: T ⇒ Id): HasId[T, Id] = new SimpleHasId[T, Id](fn)
+}

--- a/src/test/scala/sangria/execution/ActionMapSpec.scala
+++ b/src/test/scala/sangria/execution/ActionMapSpec.scala
@@ -6,7 +6,7 @@ import sangria.parser.QueryParser
 import sangria.schema._
 import sangria.util.FutureResultSupport
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -16,7 +16,7 @@ class ActionMapSpec extends WordSpec with Matchers with FutureResultSupport {
   case class ColorDefer(num: Int) extends Deferred[String]
 
   class ColorResolver extends DeferredResolver[Any] {
-    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case ColorDefer(num) ⇒ Future.successful("[" + (num + 45) + "]")
     }
   }

--- a/src/test/scala/sangria/execution/ExecutorSchemaSpec.scala
+++ b/src/test/scala/sangria/execution/ExecutorSchemaSpec.scala
@@ -8,7 +8,7 @@ import sangria.util.FutureResultSupport
 import sangria.validation.QueryValidator
 import sangria.macros._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -150,7 +150,7 @@ class ExecutorSchemaSpec extends WordSpec with Matchers with FutureResultSupport
       )
 
       val resolver = new DeferredResolver[Any] {
-        def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+        def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
           case ArticleDeferred(id) ⇒ Future.successful(article(id.toInt))
         }
       }
@@ -190,7 +190,7 @@ class ExecutorSchemaSpec extends WordSpec with Matchers with FutureResultSupport
       """
 
       val resolver = new DeferredResolver[Any] {
-        def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+        def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
           case ArticleDeferred(id) ⇒ Future.successful(article(id.toInt))
         }
       }

--- a/src/test/scala/sangria/execution/ExecutorSpec.scala
+++ b/src/test/scala/sangria/execution/ExecutorSpec.scala
@@ -11,7 +11,7 @@ import InputUnmarshaller.mapVars
 import sangria.execution.deferred.{Deferred, DeferredResolver}
 
 import scala.collection.immutable.ListMap
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -42,14 +42,14 @@ class ExecutorSpec extends WordSpec with Matchers with FutureResultSupport {
   case class FailColor(subj: TestSubject, color: String) extends Deferred[DeepTestSubject]
 
   class LightColorResolver extends DeferredResolver[Any] {
-    def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case LightColor(v, c) ⇒ Future.successful(v.deepColor("light" + c))
       case FailColor(v, c) ⇒ Future.failed(new IllegalStateException("error in resolver"))
     }
   }
 
   class BrokenLightColorResolver extends DeferredResolver[Any] {
-    def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = (deferred ++ deferred) map {
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = (deferred ++ deferred) map {
       case LightColor(v, c) ⇒ Future.successful(v.deepColor("light" + c))
       case FailColor(v, c) ⇒ Future.failed(new IllegalStateException("error in resolver"))
     }
@@ -432,7 +432,7 @@ class ExecutorSpec extends WordSpec with Matchers with FutureResultSupport {
       case class Sum(a: Int, b: Int) extends Deferred[Int]
 
       class MyResolver extends DeferredResolver[Any] {
-        def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+        def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
           case Sum(a, b) ⇒ Future(a + b)
         }
       }
@@ -461,7 +461,7 @@ class ExecutorSpec extends WordSpec with Matchers with FutureResultSupport {
       case class Sum(a: Int, b: Int) extends Deferred[Int]
 
       class MyResolver extends DeferredResolver[Any] {
-        def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+        def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
           case Sum(a, b) ⇒ Future(a + b)
         }
       }

--- a/src/test/scala/sangria/execution/MiddlewareSpec.scala
+++ b/src/test/scala/sangria/execution/MiddlewareSpec.scala
@@ -11,7 +11,7 @@ import sangria.schema._
 import sangria.util.FutureResultSupport
 
 import scala.collection.mutable.{Map => MutableMap}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MiddlewareSpec extends WordSpec with Matchers with FutureResultSupport {
@@ -127,7 +127,7 @@ class MiddlewareSpec extends WordSpec with Matchers with FutureResultSupport {
   case object Fail extends Deferred[String]
 
   class BrokenResolver extends DeferredResolver[Any] {
-    def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case Fail ⇒ Future.failed(new IllegalStateException("error in resolver"))
     }
   }

--- a/src/test/scala/sangria/execution/MutationSpec.scala
+++ b/src/test/scala/sangria/execution/MutationSpec.scala
@@ -8,7 +8,7 @@ import sangria.execution.deferred.{Deferred, DeferredResolver}
 import sangria.schema._
 import sangria.util.{FutureResultSupport, GraphQlSupport, SimpleGraphQlSupport}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Success
 
@@ -17,7 +17,7 @@ class MutationSpec extends WordSpec with Matchers with GraphQlSupport {
   case class FailedDefer(num: NumberHolder) extends Deferred[NumberHolder]
 
   class Resolver extends DeferredResolver[Any] {
-    def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case SuccessfulDefer(n) ⇒ Future.successful(n)
       case FailedDefer(_) ⇒ Future.failed(new IllegalStateException("error in resolver"))
     }

--- a/src/test/scala/sangria/execution/ProjectorSpec.scala
+++ b/src/test/scala/sangria/execution/ProjectorSpec.scala
@@ -7,7 +7,7 @@ import sangria.schema._
 import sangria.util.FutureResultSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
 class ProjectorSpec extends WordSpec with Matchers with FutureResultSupport {
@@ -77,7 +77,7 @@ class ProjectorSpec extends WordSpec with Matchers with FutureResultSupport {
   }
 
   class ProductResolver extends DeferredResolver[WithProducts] {
-    override def resolve(deferred: Vector[Deferred[Any]], ctx: WithProducts) = deferred map {
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: WithProducts, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case ProductDefer(ids) ⇒
         Future.fromTry(Try(ids map (id ⇒ Right(ctx.products.find(_.id == id).get))))
     }

--- a/src/test/scala/sangria/execution/VariablesSpec.scala
+++ b/src/test/scala/sangria/execution/VariablesSpec.scala
@@ -409,7 +409,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
         ))
       )
 
-      "passes along null for non-nullable inputs if explcitly set in the query" in  checkContainsErrors(
+      "passes along null for non-nullable inputs if explicitly set in the query" in  checkContainsErrors(
         (),
         """
           {

--- a/src/test/scala/sangria/execution/deferred/DeferredResolverSpec.scala
+++ b/src/test/scala/sangria/execution/deferred/DeferredResolverSpec.scala
@@ -54,7 +54,7 @@ class DeferredResolverSpec extends WordSpec with Matchers with FutureResultSuppo
         Vector(expensive, cheap)
       }
 
-      def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = {
+      def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = {
         callsCount.getAndIncrement()
         valueCount.addAndGet(deferred.size)
 

--- a/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
+++ b/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
@@ -1,0 +1,150 @@
+package sangria.execution.deferred
+
+import org.scalatest.{Matchers, WordSpec}
+import sangria.execution.Executor
+import sangria.macros._
+import sangria.schema._
+import sangria.util.{DebugUtil, FutureResultSupport}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FetcherSpec extends WordSpec with Matchers with FutureResultSupport {
+  case class Category(id: String, name: String, children: Seq[String])
+
+  object Category {
+    implicit val hasId = HasId[Category, String](_.id)
+  }
+
+  class CategoryRepo {
+    val categories = Vector(
+      Category("1", "Root", Vector("2", "3", "4")),
+      Category("2", "Cat 2", Vector("5", "6")),
+      Category("3", "Cat 3", Vector("7")),
+      Category("4", "Cat 4", Vector.empty),
+      Category("5", "Cat 5", Vector.empty),
+      Category("6", "Cat 6", Vector.empty),
+      Category("7", "Cat 7", Vector.empty),
+      Category("8", "Cat 8", Vector("4", "5", "foo!")))
+
+    def loadBulk(ids: Seq[String]): Future[Seq[Category]] =
+      Future.successful(ids.flatMap(id ⇒ categories.find(_.id == id)))
+  }
+
+  val categoryFetcher =
+    Fetcher((repo: CategoryRepo, ids: Seq[String]) ⇒ repo.loadBulk(ids))
+
+  val categoryFetcherCaching =
+    Fetcher.caching((repo: CategoryRepo, ids: Seq[String]) ⇒ repo.loadBulk(ids))
+
+  def properFetcher(implicit ec: ExecutionContext) = {
+    lazy val CategoryType: ObjectType[CategoryRepo, Category] = ObjectType("Category", () ⇒ fields(
+      Field("id", StringType, resolve = c ⇒ c.value.id),
+      Field("name", StringType, resolve = c ⇒ c.value.name),
+      Field("self", CategoryType, resolve = c ⇒ c.value),
+      Field("selfFut", CategoryType, resolve = c ⇒ Future(c.value)),
+      Field("childrenSeq", ListType(CategoryType),
+        resolve = c ⇒ categoryFetcher.getSeq(c.value.children)),
+      Field("childrenSeqOpt", ListType(CategoryType),
+        resolve = c ⇒ categoryFetcher.getSeqOpt(c.value.children)),
+      Field("childrenFut", ListType(CategoryType),
+        resolve = c ⇒ DeferredFutureValue(Future.successful(
+          categoryFetcher.getSeq(c.value.children))))))
+
+    val QueryType = ObjectType("Query", fields[CategoryRepo, Unit](
+      Field("category", OptionType(CategoryType),
+        arguments = Argument("id", StringType) :: Nil,
+        resolve = c ⇒ categoryFetcher.getOpt(c.arg[String]("id"))),
+      Field("root", CategoryType, resolve = _ ⇒ categoryFetcher.get("1")),
+      Field("rootFut", CategoryType, resolve = _ ⇒
+        DeferredFutureValue(Future.successful(categoryFetcher.get("1"))))))
+
+    val schema = Schema(QueryType)
+
+    val resolver = DeferredResolver.fetchers(categoryFetcher)
+    val resolverCaching = DeferredResolver.fetchers(categoryFetcherCaching)
+
+    "result in a single resolution of once level" in {
+      val query =
+        graphql"""
+          {
+            c1: category(id: "non-existing") {name}
+            #c2: category(id: "8") {name childrenSeq {id}}
+            c3: category(id: "8") {name childrenSeqOpt {id}}
+
+            root {
+              id
+              name
+              childrenSeq {
+                id
+                name
+                childrenSeq {
+                  id
+                  name
+                  childrenSeq {
+                    id
+                    name
+                    childrenSeq {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """
+
+      val res = Executor.execute(schema, query, new CategoryRepo, deferredResolver = resolver).await
+
+      res should be (
+        Map(
+          "data" → Map(
+            "c1" → null,
+            "c3" → Map(
+              "name" → "Cat 8",
+              "childrenSeqOpt" → Vector(
+                Map(
+                  "id" → "4"),
+                Map(
+                  "id" → "5"))),
+            "root" → Map(
+              "id" → "1",
+              "name" → "Root",
+              "childrenSeq" → Vector(
+                Map(
+                  "id" → "2",
+                  "name" → "Cat 2",
+                  "childrenSeq" → Vector(
+                    Map(
+                      "id" → "5",
+                      "name" → "Cat 5",
+                      "childrenSeq" → Vector.empty),
+                    Map(
+                      "id" → "6",
+                      "name" → "Cat 6",
+                      "childrenSeq" → Vector.empty))),
+                Map(
+                  "id" → "3",
+                  "name" → "Cat 3",
+                  "childrenSeq" → Vector(
+                    Map(
+                      "id" → "7",
+                      "name" → "Cat 7",
+                      "childrenSeq" → Vector.empty))),
+                Map(
+                  "id" → "4",
+                  "name" → "Cat 4",
+                  "childrenSeq" → Vector.empty))))))
+    }
+  }
+
+  "Fetcher" when {
+    "using standard execution context" should {
+      behave like properFetcher (ExecutionContext.Implicits.global)
+    }
+
+    "using sync execution context" should {
+      behave like properFetcher (sync.executionContext)
+    }
+  }
+}

--- a/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
+++ b/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
@@ -26,8 +26,8 @@ class FetcherSpec extends WordSpec with Matchers with FutureResultSupport {
       Category("7", "Cat 7", Vector.empty),
       Category("8", "Cat 8", Vector("4", "5", "foo!")))
 
-    def loadBulk(ids: Seq[String]): Future[Seq[Category]] =
-      Future.successful(ids.flatMap(id ⇒ categories.find(_.id == id)))
+    def loadBulk(ids: Seq[String])(implicit ec: ExecutionContext): Future[Seq[Category]] =
+      Future(ids.flatMap(id ⇒ categories.find(_.id == id)))
   }
 
   def properFetcher(implicit ec: ExecutionContext) = {

--- a/src/test/scala/sangria/marshalling/QueryAstMarshallingSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/QueryAstMarshallingSupportSpec.scala
@@ -1,9 +1,8 @@
 package sangria.marshalling
 
 import org.scalatest.{Matchers, WordSpec}
-
 import sangria.execution.Executor
-import sangria.marshalling.testkit.{ParsingBehaviour, InputHandlingBehaviour, MarshallingBehaviour}
+import sangria.marshalling.testkit.{InputHandlingBehaviour, MarshallingBehaviour, ParsingBehaviour}
 import sangria.parser.QueryParser
 import sangria.renderer.QueryRenderer
 import sangria.starWars.TestData.{CharacterRepo, FriendsResolver}

--- a/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
+++ b/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
@@ -1078,7 +1078,7 @@ class AstSchemaMaterializerSpec extends WordSpec with Matchers with FutureResult
             else if (definition.name endsWith "Null")
               _ ⇒ Value(null)
             else
-              _ => Value(None)
+              _ ⇒ Value(None)
         }
 
         val schema = Schema.buildFromAst(schemaAst, customBuilder)

--- a/src/test/scala/sangria/starWars/TestData.scala
+++ b/src/test/scala/sangria/starWars/TestData.scala
@@ -2,7 +2,7 @@ package sangria.starWars
 
 import sangria.execution.deferred.{Deferred, DeferredResolver}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 object TestData {
@@ -69,7 +69,7 @@ object TestData {
   )
 
   class FriendsResolver extends DeferredResolver[Any] {
-    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any) = deferred map {
+    override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
       case DeferFriends(friendIds) ⇒
         Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
     }
@@ -82,5 +82,7 @@ object TestData {
     def getHuman(id: String): Option[Human] = characters.find(c ⇒ c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
 
     def getDroid(id: String): Option[Droid] = characters.find(c ⇒ c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
+
+    def getCharacters(ids: Seq[String]): Seq[Character] = ids.flatMap(id ⇒ characters.find(_.id == id))
   }
 }

--- a/src/test/scala/sangria/starWars/TestSchema.scala
+++ b/src/test/scala/sangria/starWars/TestSchema.scala
@@ -1,10 +1,12 @@
 package sangria.starWars
 
 import sangria.execution.UserFacingError
+import sangria.execution.deferred.{Deferred, DeferredResolver, Fetcher, HasId}
 import sangria.schema._
 import sangria.starWars.TestData._
 
 import scala.concurrent.Future
+import scala.util.Try
 
 object TestSchema {
   case class PrivacyError(message: String) extends Exception(message) with UserFacingError

--- a/src/test/scala/sangria/util/FutureResultSupport.scala
+++ b/src/test/scala/sangria/util/FutureResultSupport.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait FutureResultSupport {
   implicit class FutureResult[T](f: Future[T]) {
-    def await = Await.result(f, 2 seconds)
+    def await = Await.result(f, 3 seconds)
 
     def awaitAndRecoverQueryAnalysis(implicit m: ResultMarshallerForType[T]): T = Await.result(recoverQueryAnalysis, 2 seconds)
 

--- a/src/test/scala/sangria/util/GraphQlSupport.scala
+++ b/src/test/scala/sangria/util/GraphQlSupport.scala
@@ -33,8 +33,8 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
       deferredResolver = resolver).awaitAndRecoverQueryAnalysisScala
   }
 
-  def check[T](schema: Schema[_, _], data: T, query: String, expected: Any, args: JsValue = JsObject.empty, userContext: Any = (), resolver: DeferredResolver[Any] = DeferredResolver.empty, validateQuery: Boolean = true): Unit = {
-    executeTestQuery(schema, data, query, args, userContext, resolver, validateQuery) should be (expected)
+  def check[T](schema: Schema[_, _], data: T, query: String, expected: Any, args: JsValue = JsObject.empty, userContext: Any = (), resolver: DeferredResolver[_] = DeferredResolver.empty, validateQuery: Boolean = true): Unit = {
+    executeTestQuery(schema, data, query, args, userContext, resolver.asInstanceOf[DeferredResolver[Any]], validateQuery) should be (expected)
   }
 
   def checkErrors[T](schema: Schema[_, _], data: T, query: String, expectedData: Map[String, Any], expectedErrors: List[Map[String, Any]], args: JsValue = JsObject.empty, userContext: Any = (), resolver: DeferredResolver[Any] = DeferredResolver.empty, validateQuery: Boolean = true): Unit = {


### PR DESCRIPTION
It provides following features:

* It supports multiple `Fetcher`s for different entities
* Deduplicates the list of IDs
* Supports `maxBatchSize`
* Provides caching support (independent cache is used for every query execution, but it can be configured)
* has a fallback to some existing `DeferredResolver`