### PR TITLE
186: add custom subclass for unknown operation name

### DIFF
--- a/src/main/scala/sangria/execution/ExecutionError.scala
+++ b/src/main/scala/sangria/execution/ExecutionError.scala
@@ -44,3 +44,6 @@ case class QueryReducingError(cause: Throwable, exceptionHandler: Executor.Excep
 
 case class OperationSelectionError(message: String, eh: Executor.ExceptionHandler, sm: Option[SourceMapper] = None, pos: List[Position] = Nil)
   extends ExecutionError(message, eh, sm, pos) with QueryAnalysisError
+
+case class UnknownOperationNameError(opName: String, eh: Executor.ExceptionHandler) extends ExecutionError(
+  s"Unknown operation name $opName", eh) with QueryAnalysisError

--- a/src/main/scala/sangria/execution/ExecutionError.scala
+++ b/src/main/scala/sangria/execution/ExecutionError.scala
@@ -44,6 +44,3 @@ case class QueryReducingError(cause: Throwable, exceptionHandler: Executor.Excep
 
 case class OperationSelectionError(message: String, eh: Executor.ExceptionHandler, sm: Option[SourceMapper] = None, pos: List[Position] = Nil)
   extends ExecutionError(message, eh, sm, pos) with QueryAnalysisError
-
-case class UnknownOperationNameError(opName: String, eh: Executor.ExceptionHandler) extends ExecutionError(
-  s"Unknown operation name $opName", eh) with QueryAnalysisError

--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -122,7 +122,7 @@ case class Executor[Ctx, Root](
           operationName match {
             case Some(opName) ⇒
               document.operations get Some(opName) map (Success(_)) getOrElse
-                Failure(new ExecutionError("Unknown operation named \"" + opName + "\"", exceptionHandler))
+                Failure(UnknownOperationNameError(opName, exceptionHandler))
             case None ⇒
               Success(document.operations.values.head)
           }

--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -122,7 +122,7 @@ case class Executor[Ctx, Root](
           operationName match {
             case Some(opName) ⇒
               document.operations get Some(opName) map (Success(_)) getOrElse
-                Failure(UnknownOperationNameError(opName, exceptionHandler))
+                Failure(OperationSelectionError(s"Unknown operation name '$opName'", exceptionHandler))
             case None ⇒
               Success(document.operations.values.head)
           }

--- a/src/test/scala/sangria/execution/ExecutorSpec.scala
+++ b/src/test/scala/sangria/execution/ExecutorSpec.scala
@@ -415,6 +415,16 @@ class ExecutorSpec extends WordSpec with Matchers with FutureResultSupport {
       error.getMessage should be ("Must provide operation name if query contains multiple operations")
     }
 
+    "throw if the operation name is invalid" in {
+      val schema = Schema(ObjectType("Type", fields[Unit, Unit](
+        Field("a", OptionType(StringType), resolve = _ ⇒ "b"))))
+      val Success(doc) = QueryParser.parse("query Example { a }")
+
+      val error = intercept [OperationSelectionError] (Executor.execute(schema, doc, operationName = Some("Eggsample")).await)
+
+      error.getMessage should be ("Unknown operation name 'Eggsample'")
+    }
+
     "use correct schema type schema for operation" in {
       val schema = Schema(
         ObjectType("Q", fields[Unit, Unit](Field("a", OptionType(StringType), resolve = _ ⇒ "b"))),


### PR DESCRIPTION
Based on #186 .

This is my first PR, so I have a bunch of questions:

 - [x] does the code follow established conventions (indentation, naming, etc.)?

 - [x] did I extend the right class and mix-in the right trait?

 - [x] should a source mapper and position be included, as in `OperationSelectionError`?

 - [x] I'm not sure where and how to add tests for the new error

Happy to fix anything, no matter how minor -- thanks for taking a look! :)