### PR TITLE
Field name transformer for `deriveObjectType`

### DIFF
--- a/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
@@ -20,3 +20,5 @@ case class IncludeMethods[Ctx, Val](methodNames: String*) extends DeriveObjectSe
 case class ExcludeFields[Ctx, Val](fieldNames: String*) extends DeriveObjectSetting[Ctx, Val]
 case class ReplaceField[Ctx, Val](fieldName: String, field: Field[Ctx, Val]) extends DeriveObjectSetting[Ctx, Val]
 case class AddFields[Ctx, Val](fields: Field[Ctx, Val]*) extends DeriveObjectSetting[Ctx, Val]
+
+case class TransformFieldNames[Ctx, Val](transformer: String => String) extends DeriveObjectSetting[Ctx, Val]

--- a/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -202,6 +202,19 @@ class DeriveObjectTypeMacroSpec extends WordSpec with Matchers with FutureResult
       tpe.fields(2).fieldType should be (IntType)
     }
 
+    "allow field names transformation" in {
+      val transformer1 = (s: String) => s.toUpperCase
+      val tpe = deriveObjectType[Unit, TestSubjectAnnotated](TransformFieldNames(transformer1))
+      tpe.fields.forall(f => f.name == transformer1(f.name)) shouldBe true
+
+      val transformer2 = (s: String) => s.zipWithIndex.map {
+        case (c, i) if i % 2 == 0 => c.toLower
+        case (c, _) => c.toUpper
+      }.mkString("")
+      val tpe2 = deriveObjectType[Unit, TestSubjectAnnotated](TransformFieldNames(transformer2))
+      tpe2.fields.forall(f => f.name == transformer2(f.name)) shouldBe true
+    }
+
     "allow to set name, description, deprecationReason and fieldTags with annotations" in {
       val tpe = deriveObjectType[Unit, TestSubjectAnnotated]()
 


### PR DESCRIPTION
There is an `UppercaseValues` setting for `deriveEnumType`, but no means to transform field names in `deriveObjectType`. This PR is my attempt to provide such methods. I don't really know how this issue should really be approached and this is my first take on macros :)