### PR TITLE
Added SBT-OSGi to allow Sangria to generate an OSGi valid JAR artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,13 @@ scalacOptions ++= {
     Seq("-target:jvm-1.7")
 }
 
+lazy val sangriaOsgiSettings = osgiSettings ++ Seq(
+  OsgiKeys.exportPackage := Seq("sangria.*;version=${Bundle-Version}"),
+  OsgiKeys.privatePackage := Seq()
+)
+
+lazy val sangriaProject = project.in(file(".")).enablePlugins(SbtOsgi).settings(sangriaOsgiSettings:_*)
+
 libraryDependencies ++= Seq(
   // macros
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")


### PR DESCRIPTION
Added SBT-OSGi to allow Sangria to generate an OSGi valid JAR artifact on publish or publishLocal, this allowed Sangria to be used within an OSGi environment. Look at the file MANIFEST.MF inside the artifact JAR (result of publishLocal) before and after this change was added - to see the changes. The changes are that there are import and export packages defined there which allows OSGi to work out what imports and exports the JAR defines.