### PR TITLE
Scalar Alias

### DIFF
--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -295,6 +295,7 @@ case class Executor[Ctx, Root](
               })
             .getOrElse (initialValues)
         case s: ScalarType[_] ⇒ reducers map (_.reduceScalar(path, userContext, s))
+        case ScalarAlias(aliasFor, _, _) ⇒ reducers map (_.reduceScalar(path, userContext, aliasFor))
         case e: EnumType[_] ⇒ reducers map (_.reduceEnum(path, userContext, e))
         case _ ⇒ initialValues
       }

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -833,6 +833,8 @@ class Resolver[Ctx](
         } catch {
           case NonFatal(e) ⇒ Result(ErrorRegistry(path, e), None)
         }
+      case scalar: ScalarAlias[Any @unchecked, Any @unchecked] ⇒
+        resolveValue(path, astFields, scalar.aliasFor, field, scalar.toScalar(value), userCtx)
       case enum: EnumType[Any @unchecked] ⇒
         try {
           Result(ErrorRegistry.empty,

--- a/src/main/scala/sangria/introspection/package.scala
+++ b/src/main/scala/sangria/introspection/package.scala
@@ -111,6 +111,7 @@ package object introspection {
       case OptionInputType(ofType) ⇒ identifyKind(ofType, true)
       case _ if !optional ⇒ TypeKind.NonNull
       case _: ScalarType[_] ⇒ TypeKind.Scalar
+      case _: ScalarAlias[_, _] ⇒ TypeKind.Scalar
       case _: ObjectType[_, _] ⇒ TypeKind.Object
       case _: InterfaceType[_, _] ⇒ TypeKind.Interface
       case _: UnionType[_] ⇒ TypeKind.Union

--- a/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -248,6 +248,7 @@ object SchemaRenderer {
       case i: InterfaceType[_, _] ⇒ renderInterface(i)
       case io: InputObjectType[_] ⇒ renderInputObject(io)
       case s: ScalarType[_] ⇒ renderScalar(s)
+      case s: ScalarAlias[_, _] ⇒ renderScalar(s.aliasFor)
       case e: EnumType[_] ⇒ renderEnum(e)
       case _ ⇒ throw new IllegalArgumentException(s"Unsupported type: $tpe")
     }

--- a/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
+++ b/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
@@ -234,6 +234,7 @@ class AstSchemaMaterializer[Ctx] private (document: ast.Document, builder: AstSc
 
   def extendType(existingType: Type with Named): Type with Named = existingType match {
     case tpe: ScalarType[_] ⇒ builder.transformScalarType(tpe, this)
+    case tpe: ScalarAlias[_, _] ⇒ builder.transformScalarType(tpe.aliasFor, this)
     case tpe: EnumType[_] ⇒ builder.transformEnumType(tpe, this)
     case tpe: InputObjectType[_] ⇒ builder.transformInputObjectType(tpe, this)
     case tpe: UnionType[Ctx] ⇒ extendUnionType(tpe)

--- a/src/main/scala/sangria/schema/Context.scala
+++ b/src/main/scala/sangria/schema/Context.scala
@@ -234,6 +234,7 @@ object DefaultValueRenderer {
   def renderCoercedInputValue(t: InputType[_], v: Any): marshaller.Node = t match {
     case _ if v == null ⇒ marshaller.nullNode
     case s: ScalarType[Any @unchecked] ⇒ Resolver.marshalScalarValue(s.coerceOutput(v, marshaller.capabilities), marshaller, s.name, s.scalarInfo)
+    case s: ScalarAlias[Any @unchecked, Any @unchecked] ⇒ renderCoercedInputValue(s.aliasFor, s.toScalar(v))
     case e: EnumType[Any @unchecked] ⇒ Resolver.marshalEnumValue(e.coerceOutput(v), marshaller, e.name)
     case io: InputObjectType[_] ⇒
       val mapValue = v.asInstanceOf[Map[String, Any]]

--- a/src/main/scala/sangria/schema/Schema.scala
+++ b/src/main/scala/sangria/schema/Schema.scala
@@ -722,13 +722,15 @@ case class Schema[Ctx, Val](
 
     def collectTypes(parentInfo: String, priority: Int, tpe: Type, result: Map[String, (Int, Type with Named)]): Map[String, (Int, Type with Named)] = {
       tpe match {
-        case null ⇒ throw new IllegalStateException(
-          s"A `null` value was provided instead of type for $parentInfo.\n" +
-          "This can happen if you have recursive type definition or circular references within your type graph.\n" +
-          "Please use no-arg function to provide fields for such types.\n" +
-          "You can find more info in the docs: http://sangria-graphql.org/learn/#circular-references-and-recursive-types")
+        case null ⇒
+          throw new IllegalStateException(
+            s"A `null` value was provided instead of type for $parentInfo.\n" +
+            "This can happen if you have recursive type definition or circular references within your type graph.\n" +
+            "Please use no-arg function to provide fields for such types.\n" +
+            "You can find more info in the docs: http://sangria-graphql.org/learn/#circular-references-and-recursive-types")
         case t: Named if result contains t.name ⇒
           result get t.name match {
+            case Some(found) if !sameType(found._2, t) && t.isInstanceOf[ScalarAlias[_, _]] && found._2.isInstanceOf[ScalarType[_]] ⇒ result
             case Some(found) if !sameType(found._2, t) ⇒ typeConflict(t.name, found._2, t, parentInfo)
             case _ ⇒ result
           }

--- a/src/main/scala/sangria/schema/SchemaComparator.scala
+++ b/src/main/scala/sangria/schema/SchemaComparator.scala
@@ -510,6 +510,7 @@ object SchemaChange {
     case _: ObjectType[_, _] ⇒ "Object"
     case _: InterfaceType[_, _] ⇒ "Interface"
     case _: ScalarType[_] ⇒ "Scalar"
+    case _: ScalarAlias[_, _] ⇒ "Scalar"
     case _: UnionType[_] ⇒ "Union"
     case _: EnumType[_] ⇒ "Enum"
     case _: InputObjectType[_] ⇒ "InputObject"

--- a/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/src/main/scala/sangria/validation/QueryValidator.scala
@@ -260,6 +260,14 @@ object ValidationContext {
         case Left(violation) ⇒ Vector(violation)
         case _ ⇒ Vector.empty
       }
+    case (s: ScalarAlias[_, _], v) ⇒
+      s.aliasFor.coerceInput(v) match {
+        case Left(violation) ⇒ Vector(violation)
+        case Right(v) ⇒ s.fromScalar(v) match {
+          case Left(violation) ⇒ Vector(violation)
+          case _ ⇒ Vector.empty
+        }
+      }
     case (enum: EnumType[_], v) ⇒
       enum.coerceInput(v) match {
         case Left(violation) ⇒ Vector(violation)

--- a/src/test/scala/sangria/execution/ScalarAliasSpec.scala
+++ b/src/test/scala/sangria/execution/ScalarAliasSpec.scala
@@ -1,0 +1,79 @@
+package sangria.execution
+
+import org.scalatest.{Matchers, WordSpec}
+import sangria.util.{DebugUtil, FutureResultSupport}
+import sangria.schema._
+import sangria.macros._
+import sangria.macros.derive._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class UserId(id: String) extends AnyVal
+
+class ScalarAliasSpec extends WordSpec with Matchers with FutureResultSupport {
+  case class User(id: UserId, name: String)
+
+  "ScalarAlias" should {
+    "represent value class as scalar type" in {
+      implicit val UserIdType = ScalarAlias[UserId, String](StringType, _.id, id ⇒ Right(UserId(id)))
+
+      val UserType = deriveObjectType[Unit, User]()
+
+      val UserIdArg = Argument("id", UserIdType)
+
+      val schema = Schema(ObjectType("Query", fields[Unit, Unit](
+        Field("user", UserType,
+          arguments = UserIdArg :: Nil,
+          resolve = _.withArgs(UserIdArg)(userId ⇒ User(userId, "generated")))
+      )))
+
+      val query =
+        graphql"""
+          {
+            user(id: "1234") {
+              id
+              name
+            }
+
+            __type(name: "User") {
+              name
+              fields {
+                name
+
+                type {
+                  kind
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        """
+
+      Executor.execute(schema, query).await should be (
+        Map(
+          "data" → Map(
+            "user" → Map(
+              "id" → "1234",
+              "name" → "generated"),
+            "__type" → Map(
+              "name" → "User",
+              "fields" → Vector(
+                Map(
+                  "name" → "id",
+                  "type" → Map(
+                    "kind" → "NON_NULL",
+                    "ofType" → Map(
+                      "kind" → "SCALAR",
+                      "name" → "String"))),
+                Map(
+                  "name" → "name",
+                  "type" → Map(
+                    "kind" → "NON_NULL",
+                    "ofType" → Map(
+                      "kind" → "SCALAR",
+                      "name" → "String"))))))))
+    }
+  }
+}


### PR DESCRIPTION
`ScalarAlias` represents some other scalar value (like `string`, `int`, etc.), but has its own scala type. This makes it possible to represent some custom scala class as a standard scalar GraphQL type. This also makes it easy to transparently add validations for standard scalars.

Here is an example of how it will look like in code:

```scala
implicit val UserIdType = ScalarAlias[UserId, String](StringType, _.id, id ⇒ Right(UserId(id)))
```

Closes #210