### PR TITLE
Preserve IDL directives at schema materialization time and use them in schema comparator

### DIFF
--- a/src/main/scala/sangria/schema/Context.scala
+++ b/src/main/scala/sangria/schema/Context.scala
@@ -212,7 +212,7 @@ object DefaultValueRenderer {
   def renderInputValuePretty[T, Ctx](value: (_, ToInput[_, _]), tpe: InputType[T], coercionHelper: ValueCoercionHelper[Ctx]): Option[String] =
     renderInputValue(value, tpe, coercionHelper) map marshaller.renderPretty
 
-  private def renderInputValue[T, Ctx](value: (_, ToInput[_, _]), tpe: InputType[T], coercionHelper: ValueCoercionHelper[Ctx]): Option[marshaller.Node] = {
+  def renderInputValue[T, Ctx](value: (_, ToInput[_, _]), tpe: InputType[T], coercionHelper: ValueCoercionHelper[Ctx]): Option[marshaller.Node] = {
     val (v, toInput) = value.asInstanceOf[(Any, ToInput[Any, Any])]
     val (inputValue, iu) = toInput.toInput(v)
 

--- a/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
@@ -119,14 +119,16 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
             description = typeDescription(definition),
             fieldsFn = fields,
             interfaces = interfaces,
-            instanceCheck = (value: Any, clazz: Class[_], _: ObjectType[Ctx, Any]) ⇒ fn(value, clazz))
+            instanceCheck = (value: Any, clazz: Class[_], _: ObjectType[Ctx, Any]) ⇒ fn(value, clazz),
+            astDirectives = Vector.empty)
         case None ⇒
           ObjectType[Ctx, Any](
             name = typeName(definition),
             description = typeDescription(definition),
             fieldsFn = fields,
             interfaces = interfaces,
-            instanceCheck = ObjectType.defaultInstanceCheck[Ctx, Any])
+            instanceCheck = ObjectType.defaultInstanceCheck[Ctx, Any],
+            astDirectives = Vector.empty)
       }
 
     Some(objectType)
@@ -139,7 +141,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
     Some(InputObjectType(
       name = typeName(definition),
       description = typeDescription(definition),
-      fieldsFn = fields))
+      fieldsFn = fields,
+      astDirectives = Vector.empty))
 
   def buildInterfaceType(
       definition: IntrospectionInterfaceType,
@@ -150,7 +153,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       description = typeDescription(definition),
       fieldsFn = fields,
       interfaces = Nil,
-      manualPossibleTypes = () ⇒ Nil))
+      manualPossibleTypes = () ⇒ Nil,
+      astDirectives = Vector.empty))
 
   def buildUnionType(
       definition: IntrospectionUnionType,
@@ -207,7 +211,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       tags = fieldTags(typeDefinition, definition),
       deprecationReason = fieldDeprecationReason(definition),
       complexity = fieldComplexity(typeDefinition, definition),
-      manualPossibleTypes = () ⇒ Nil))
+      manualPossibleTypes = () ⇒ Nil,
+      astDirectives = Vector.empty))
 
   def buildInputField(
       typeDefinition: IntrospectionInputObjectType,
@@ -219,7 +224,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       name = inputFieldName(definition),
       description = inputFieldDescription(definition),
       fieldType = tpe,
-      defaultValue = defaultValue))
+      defaultValue = defaultValue,
+      astDirectives = Vector.empty))
 
   def buildArgument(
       fieldDefinition: Option[IntrospectionField],
@@ -232,7 +238,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       description = argumentDescription(definition),
       argumentType = tpe,
       defaultValue = defaultValue,
-      fromInput = argumentFromInput(fieldDefinition, definition)))
+      fromInput = argumentFromInput(fieldDefinition, definition),
+      astDirectives = Vector.empty))
 
   def buildDirective(
       definition: IntrospectionDirective,

--- a/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -395,6 +395,23 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
       nonBreakingChange[TypeAdded]("`Subs1` type was added"),
       breakingChange[SchemaMutationTypeChanged]("Schema mutation type changed from `Mut` to none type"),
       breakingChange[SchemaSubscriptionTypeChanged]("Schema subscription type changed from `Subs` to `Subs1` type"))
+
+
+    "detect breaking changes in field AST directives" in checkChangesWithoutQueryType(
+      gql"""
+        type Query {
+          foo: String @foo
+        }
+      """,
+
+      gql"""
+        type Query {
+          foo: String @bar(ids: [1, 2])
+        }
+      """,
+
+      nonBreakingChange[FieldAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a field `Query.foo`"),
+      nonBreakingChange[FieldAstDirectiveRemoved]("Directive `@foo` removed from a field `Query.foo`"))
   }
 
   def breakingChange[T : ClassTag](description: String) =

--- a/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -436,6 +436,72 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
 
       nonBreakingChange[SchemaAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a schema"),
       nonBreakingChange[SchemaAstDirectiveRemoved]("Directive `@foo` removed from a schema"))
+
+    "detect changes in type AST directives" in checkChangesWithoutQueryType(
+      gql"""
+        type Query {
+          foo: String
+        }
+
+        input Foo @bar(ids: [1, 2]) {
+          a: Int
+        }
+
+        type Foo1 @bar(ids: [1, 2]) {
+          a: Int
+        }
+
+        interface Foo2 @bar(ids: [1, 2]) {
+          a: Int
+        }
+
+        union Foo3 @bar(ids: [1, 2]) = Query | Foo1
+
+        enum Foo4 @bar(ids: [1, 2]) {
+          A B C
+        }
+
+        scalar Foo5 @bar(ids: [1, 2])
+      """,
+
+      gql"""
+        type Query {
+          foo: String
+        }
+
+        input Foo @bar(ids: [1]) {
+          a: Int
+        }
+
+        type Foo1 @baz {
+          a: Int
+        }
+
+        interface Foo2 @baz {
+          a: Int
+        }
+
+        union Foo3 @bar(id: 1) = Query | Foo1
+
+        enum Foo4 @bar(id: 1) {
+          A B C
+        }
+
+        scalar Foo5 @bar(ids: [1])
+      """,
+
+      nonBreakingChange[InputObjectTypeAstDirectiveAdded]("Directive `@bar(ids:[1])` added on an input type `Foo`"),
+      nonBreakingChange[InputObjectTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from an input type `Foo`"),
+      nonBreakingChange[ObjectTypeAstDirectiveAdded]("Directive `@baz` added on an object type `Foo1`"),
+      nonBreakingChange[ObjectTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from an object type `Foo1`"),
+      nonBreakingChange[InterfaceTypeAstDirectiveAdded]("Directive `@baz` added on an interface type `Foo2`"),
+      nonBreakingChange[InterfaceTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from an interface type `Foo2`"),
+      nonBreakingChange[UnionTypeAstDirectiveAdded]("Directive `@bar(id:1)` added on a union type `Foo3`"),
+      nonBreakingChange[UnionTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from a union type `Foo3`"),
+      nonBreakingChange[EnumTypeAstDirectiveAdded]("Directive `@bar(id:1)` added on an enum type `Foo4`"),
+      nonBreakingChange[EnumTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from an enum type `Foo4`"),
+      nonBreakingChange[ScalarTypeAstDirectiveAdded]("Directive `@bar(ids:[1])` added on a scalar type `Foo5`"),
+      nonBreakingChange[ScalarTypeAstDirectiveRemoved]("Directive `@bar(ids:[1,2])` removed from a scalar type `Foo5`"))
   }
 
   def breakingChange[T : ClassTag](description: String) =

--- a/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -414,6 +414,28 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
       nonBreakingChange[FieldAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a field `Query.foo`"),
       nonBreakingChange[FieldAstDirectiveRemoved]("Directive `@foo` removed from a field `Query.foo`"))
 
+    "detect changes in argument AST directives" in checkChangesWithoutQueryType(
+      gql"""
+        type Query {
+          foo(bar: String @foo): String
+        }
+
+        directive @test(bar: String @hello) on FIELD
+      """,
+
+      gql"""
+        type Query {
+          foo(bar: String @bar(ids: [1, 2])): String
+        }
+
+        directive @test(bar: String @world) on FIELD
+      """,
+
+      nonBreakingChange[FieldArgumentAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a field argument `Query.foo[bar]`"),
+      nonBreakingChange[FieldArgumentAstDirectiveRemoved]("Directive `@foo` removed from a field argument `Query.foo[bar]`"),
+      nonBreakingChange[DirectiveArgumentAstDirectiveRemoved]("Directive `@hello` removed from a directive argument `test.bar`"),
+      nonBreakingChange[DirectiveArgumentAstDirectiveAdded]("Directive `@world` added on a directive argument `test.bar`"))
+
     "detect changes in input field AST directives" in checkChangesWithoutQueryType(
       gql"""
         type Query {a: Int}

--- a/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -397,7 +397,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
       breakingChange[SchemaSubscriptionTypeChanged]("Schema subscription type changed from `Subs` to `Subs1` type"))
 
 
-    "detect breaking changes in field AST directives" in checkChangesWithoutQueryType(
+    "detect changes in field AST directives" in checkChangesWithoutQueryType(
       gql"""
         type Query {
           foo: String @foo
@@ -412,6 +412,30 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
 
       nonBreakingChange[FieldAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a field `Query.foo`"),
       nonBreakingChange[FieldAstDirectiveRemoved]("Directive `@foo` removed from a field `Query.foo`"))
+
+    "detect changes in schema AST directives" in checkChangesWithoutQueryType(
+      gql"""
+        type Query {
+          foo: String
+        }
+
+        schema @foo {
+          query: Query
+        }
+      """,
+
+      gql"""
+        type Query {
+          foo: String
+        }
+
+        schema @bar(ids: [1, 2]) {
+          query: Query
+        }
+      """,
+
+      nonBreakingChange[SchemaAstDirectiveAdded]("Directive `@bar(ids:[1,2])` added on a schema"),
+      nonBreakingChange[SchemaAstDirectiveRemoved]("Directive `@foo` removed from a schema"))
   }
 
   def breakingChange[T : ClassTag](description: String) =


### PR DESCRIPTION
This also adds `Vector[ast.Directive]` to all relevant schema definitions which may be extremely useful for future features and schema analysis