### PR TITLE
Fixed scalar aliases when they are used with variables or schema is extended

### DIFF
--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -949,7 +949,7 @@ class Resolver[Ctx](
 
               val beforeAction = mBefore.flatMap{case ((_, action), _, _) ⇒ action}.lastOption
 
-              val mAfter = mBefore.filter(_._3.isInstanceOf[MiddlewareAfterField[Ctx]])
+              val mAfter = mBefore.filter(_._3.isInstanceOf[MiddlewareAfterField[Ctx]]).reverse
               val mError = mBefore.filter(_._3.isInstanceOf[MiddlewareErrorField[Ctx]])
 
               def doAfterMiddleware[Val](v: Val): Val =

--- a/src/main/scala/sangria/execution/ValueCoercionHelper.scala
+++ b/src/main/scala/sangria/execution/ValueCoercionHelper.scala
@@ -166,7 +166,7 @@ class ValueCoercionHelper[Ctx](sourceMapper: Option[SourceMapper] = None, deprec
         })
 
     (tpe, input) match {
-      case (_, node) if iu.isVariableNode(node) ⇒
+      case (tpe, node) if iu.isVariableNode(node) ⇒
         val varName = iu.getVariableName(node)
 
         variables match {
@@ -178,6 +178,19 @@ class ValueCoercionHelper[Ctx](sourceMapper: Option[SourceMapper] = None, deprec
                   case errors @ Left(_) ⇒ errors.asInstanceOf[Either[Vector[Violation], Trinary[marshaller.Node]]]
                 }
 
+                // we need to habe addition transformation comming from a scalar alias
+//                firstKindMarshaller match {
+//                  case raw: RawResultMarshaller ⇒
+//                    tpe match {
+//                      case ScalarAlias(_, _, fromScalar) ⇒
+//                        res.right.map(_.toOption)
+//                      case _ ⇒
+//                        res
+//                    }
+//                  case standard ⇒ res
+//                }
+//
+//                res.rig
                 res
               case None ⇒
                 Right(Trinary.Undefined)
@@ -442,6 +455,8 @@ sealed trait Trinary[+T] {
     case Trinary.Null | Trinary.Undefined | Trinary.NullWithDefault(_) ⇒ None
     case Trinary.Defined(v) ⇒ Some(v)
   }
+
+//  def map[R](fn: T ⇒ R): Trinary[R]
 }
 
 object Trinary {

--- a/src/main/scala/sangria/execution/ValueCollector.scala
+++ b/src/main/scala/sangria/execution/ValueCollector.scala
@@ -89,10 +89,10 @@ class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceM
     }
 }
 
-case class VariableValue(fn: (ResultMarshaller, ResultMarshaller) ⇒ Either[Vector[Violation], Trinary[ResultMarshaller#Node]]) {
-  private val cache = TrieMap[Int, Either[Vector[Violation], Trinary[ResultMarshaller#Node]]]()
+case class VariableValue(fn: (ResultMarshaller, ResultMarshaller, InputType[_]) ⇒ Either[Vector[Violation], Trinary[ResultMarshaller#Node]]) {
+  private val cache = TrieMap[(Int, Int), Either[Vector[Violation], Trinary[ResultMarshaller#Node]]]()
 
-  def resolve(marshaller: ResultMarshaller, firstKindMarshaller: ResultMarshaller): Either[Vector[Violation], Trinary[firstKindMarshaller.Node]] =
-    cache.getOrElseUpdate(System.identityHashCode(firstKindMarshaller),
-      fn(marshaller, firstKindMarshaller)).asInstanceOf[Either[Vector[Violation], Trinary[firstKindMarshaller.Node]]]
+  def resolve(marshaller: ResultMarshaller, firstKindMarshaller: ResultMarshaller, actualType: InputType[_]): Either[Vector[Violation], Trinary[firstKindMarshaller.Node]] =
+    cache.getOrElseUpdate(System.identityHashCode(firstKindMarshaller) → System.identityHashCode(actualType.namedType),
+      fn(marshaller, firstKindMarshaller, actualType)).asInstanceOf[Either[Vector[Violation], Trinary[firstKindMarshaller.Node]]]
 }

--- a/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -75,6 +75,11 @@ trait AstSchemaBuilder[Ctx] {
     types: List[ObjectType[Ctx, _]],
     mat: AstSchemaMaterializer[Ctx]): UnionType[Ctx]
 
+  def extendScalarAlias[T, ST](
+    existing: ScalarAlias[T, ST],
+    aliasFor: ScalarType[ST],
+    mat: AstSchemaMaterializer[Ctx]): ScalarAlias[T, ST]
+
   def buildScalarType(
     definition: ast.ScalarTypeDefinition,
     mat: AstSchemaMaterializer[Ctx]): Option[ScalarType[Any]]
@@ -286,6 +291,12 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
       types: List[ObjectType[Ctx, _]],
       mat: AstSchemaMaterializer[Ctx]) =
     existing.copy(types = types)
+
+  def extendScalarAlias[T, ST](
+      existing: ScalarAlias[T, ST],
+      aliasFor: ScalarType[ST],
+      mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(aliasFor = aliasFor)
 
   def buildScalarType(
       definition: ast.ScalarTypeDefinition,

--- a/src/test/scala/sangria/execution/MiddlewareSpec.scala
+++ b/src/test/scala/sangria/execution/MiddlewareSpec.scala
@@ -338,8 +338,8 @@ class MiddlewareSpec extends WordSpec with Matchers with FutureResultSupport {
 
       res should be (Map(
         "data" → Map(
-          "someString" → "nothing special s1 s2",
-          "someStringMapped" → "mapped s1 s2")))
+          "someString" → "nothing special s2 s1",
+          "someStringMapped" → "mapped s2 s1")))
     }
 
     behave like properFieldLevelMiddleware(


### PR DESCRIPTION
When schema is extended, scala aliases were partially erased from the schema. Verifiable resolution logic have not considered scala aliases either.