### PR TITLE
Create args builder

### DIFF
--- a/src/main/scala/sangria/schema/Context.scala
+++ b/src/main/scala/sangria/schema/Context.scala
@@ -360,7 +360,7 @@ object Args {
 
     ValueCoercionHelper.default.coerceInputValue(tpe, List("stub"), value, None, rm.marshaller, rm.marshaller) match {
       case Right(v) ⇒ v.toOption.asInstanceOf[Option[Out]]
-      case Left(violations) ⇒ throw new AttributeCoercionError(violations, PartialFunction.empty)
+      case Left(violations) ⇒ throw AttributeCoercionError(violations, PartialFunction.empty)
     }
   }
 }

--- a/src/test/scala/sangria/schema/ArgsSpec.scala
+++ b/src/test/scala/sangria/schema/ArgsSpec.scala
@@ -1,0 +1,114 @@
+package sangria.schema
+
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.concurrent.TrieMap
+
+class ArgsSpec extends WordSpec with Matchers {
+
+
+  val NON_DEFAULT_ARGUMENT_NAME = "nonDefaultArgument"
+  val DEFAULT_ARGUMENT_NAME = "defaultArgument"
+  val OPTIONAL_ARGUMENT_NAME = "optionalArg"
+
+  val nonDefaultArgument = Argument(
+    name = NON_DEFAULT_ARGUMENT_NAME,
+    argumentType = IntType,
+    description = "Argument without default value"
+  )
+
+  val defaultArgument = Argument(
+    name = DEFAULT_ARGUMENT_NAME,
+    argumentType = OptionInputType(IntType),
+    defaultValue = 10,
+    description = "Argument with default value"
+  )
+
+  val optionalArgument = Argument(
+    name = OPTIONAL_ARGUMENT_NAME,
+    argumentType = OptionInputType(IntType),
+    description = "Optional argument"
+  )
+
+  "Args: Companion object" when {
+    "buildArgs" should {
+      "build with no arguments" in {
+        val args = Args.buildArgs(List.empty, Map.empty)
+        args.raw should be (Map.empty)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set.empty)
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+      }
+
+      "build with defined arguments" in {
+        val expectedMap = Map(NON_DEFAULT_ARGUMENT_NAME -> 9001)
+        val args = Args.buildArgs(List(nonDefaultArgument), expectedMap)
+        args.raw should be (expectedMap)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set.empty)
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(nonDefaultArgument) should be (9001)
+      }
+
+      "build with undefined arguments" in {
+        val args = Args.buildArgs(List(nonDefaultArgument), Map.empty)
+        args.raw should be (Map.empty)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set.empty)
+        args.undefinedArgs should be (Set(NON_DEFAULT_ARGUMENT_NAME))
+        args.defaultInfo should be (TrieMap.empty)
+
+        an [NoSuchElementException] should be thrownBy args.arg(nonDefaultArgument)
+      }
+
+      "build with optional arguments and defined input" in {
+        val expectedMap = Map(OPTIONAL_ARGUMENT_NAME -> Some(9001))
+        val args = Args.buildArgs(List(optionalArgument), expectedMap)
+        args.raw should be (expectedMap)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(optionalArgument) should be (Some(9001))
+      }
+
+      "build with optional argument and undefined input" in {
+        val args = Args.buildArgs(List(optionalArgument), Map.empty)
+        args.raw should be (Map.empty)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(optionalArgument) should be (None)
+      }
+
+      "build with default values" in {
+        val args = Args.buildArgs(List(defaultArgument), Map.empty)
+        args.raw should be (Map.empty)
+        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+
+        args.arg(defaultArgument) should be (10)
+      }
+
+      "build with overriden default values" in {
+        val expectedMap = Map(DEFAULT_ARGUMENT_NAME -> Some(9001))
+        val args = Args.buildArgs(List(defaultArgument), expectedMap)
+        args.raw should be (expectedMap)
+        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+
+        args.arg(defaultArgument) should be (9001)
+      }
+    }
+  }
+}

--- a/src/test/scala/sangria/schema/ArgsSpec.scala
+++ b/src/test/scala/sangria/schema/ArgsSpec.scala
@@ -1,8 +1,11 @@
 package sangria.schema
 
 import org.scalatest.{Matchers, WordSpec}
+import sangria.execution.AttributeCoercionError
 
 import scala.collection.concurrent.TrieMap
+import sangria.marshalling.sprayJson._
+import spray.json._
 
 class ArgsSpec extends WordSpec with Matchers {
 
@@ -31,9 +34,9 @@ class ArgsSpec extends WordSpec with Matchers {
   )
 
   "Args: Companion object" when {
-    "buildArgs" should {
+    "buildArgs with map input" should {
       "build with no arguments" in {
-        val args = Args.buildArgs(List.empty, Map.empty)
+        val args = Args(List.empty)
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set.empty)
@@ -43,7 +46,7 @@ class ArgsSpec extends WordSpec with Matchers {
 
       "build with defined arguments" in {
         val expectedMap = Map(NON_DEFAULT_ARGUMENT_NAME -> 9001)
-        val args = Args.buildArgs(List(nonDefaultArgument), expectedMap)
+        val args = Args(List(nonDefaultArgument), expectedMap)
         args.raw should be (expectedMap)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set.empty)
@@ -53,20 +56,13 @@ class ArgsSpec extends WordSpec with Matchers {
         args.arg(nonDefaultArgument) should be (9001)
       }
 
-      "build with undefined arguments" in {
-        val args = Args.buildArgs(List(nonDefaultArgument), Map.empty)
-        args.raw should be (Map.empty)
-        args.argsWithDefault should be (Set.empty)
-        args.optionalArgs should be (Set.empty)
-        args.undefinedArgs should be (Set(NON_DEFAULT_ARGUMENT_NAME))
-        args.defaultInfo should be (TrieMap.empty)
-
-        an [NoSuchElementException] should be thrownBy args.arg(nonDefaultArgument)
+      "not build with undefined arguments" in {
+        an [AttributeCoercionError] should be thrownBy Args(List(nonDefaultArgument))
       }
 
-      "build with optional arguments and defined input" in {
-        val expectedMap = Map(OPTIONAL_ARGUMENT_NAME -> Some(9001))
-        val args = Args.buildArgs(List(optionalArgument), expectedMap)
+      "build with optional argument and defined input" in {
+        val expectedMap = Map(OPTIONAL_ARGUMENT_NAME -> 9001)
+        val args = Args(List(optionalArgument), expectedMap)
         args.raw should be (expectedMap)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
@@ -77,7 +73,7 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with optional argument and undefined input" in {
-        val args = Args.buildArgs(List(optionalArgument), Map.empty)
+        val args = Args(List(optionalArgument))
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
@@ -88,7 +84,7 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with default values" in {
-        val args = Args.buildArgs(List(defaultArgument), Map.empty)
+        val args = Args(List(defaultArgument))
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
         args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
@@ -99,9 +95,59 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with overriden default values" in {
-        val expectedMap = Map(DEFAULT_ARGUMENT_NAME -> Some(9001))
-        val args = Args.buildArgs(List(defaultArgument), expectedMap)
+        val expectedMap = Map(DEFAULT_ARGUMENT_NAME -> 9001)
+        val args = Args(List(defaultArgument), expectedMap)
         args.raw should be (expectedMap)
+        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+
+        args.arg(defaultArgument) should be (9001)
+      }
+    }
+
+    "buildArgs with spray-json" should {
+      "build with defined argument" in {
+        val args = Args(List(nonDefaultArgument), s"""{"$NON_DEFAULT_ARGUMENT_NAME": 10}""".parseJson)
+        args.raw should be (Map(NON_DEFAULT_ARGUMENT_NAME -> 10))
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set.empty)
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(nonDefaultArgument) should be (10)
+      }
+
+      "not build with undefined arguments" in {
+        an [AttributeCoercionError] should be thrownBy Args(List(nonDefaultArgument), s"""{}""".parseJson)
+      }
+
+      "build with optional argument and defined input" in {
+        val args = Args(List(optionalArgument), s"""{"$OPTIONAL_ARGUMENT_NAME": 9001}""".parseJson)
+        args.raw should be (Map(OPTIONAL_ARGUMENT_NAME -> Some(9001)))
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(optionalArgument) should be (Some(9001))
+      }
+
+      "build with optional argument and undefined input" in {
+        val args = Args(List(optionalArgument))
+        args.raw should be (Map.empty)
+        args.argsWithDefault should be (Set.empty)
+        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.undefinedArgs should be (Set.empty)
+        args.defaultInfo should be (TrieMap.empty)
+
+        args.arg(optionalArgument) should be (None)
+      }
+
+      "build with overriden default values" in {
+        val args = Args(List(defaultArgument), s"""{"$DEFAULT_ARGUMENT_NAME": 9001}""".parseJson)
+        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(9001)))
         args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
         args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
         args.undefinedArgs should be (Set.empty)

--- a/src/test/scala/sangria/schema/ArgsSpec.scala
+++ b/src/test/scala/sangria/schema/ArgsSpec.scala
@@ -1,37 +1,54 @@
 package sangria.schema
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
 import sangria.execution.AttributeCoercionError
-
-import scala.collection.concurrent.TrieMap
 import sangria.marshalling.sprayJson._
 import spray.json._
+
+import scala.collection.concurrent.TrieMap
 
 class ArgsSpec extends WordSpec with Matchers {
 
 
-  val NON_DEFAULT_ARGUMENT_NAME = "nonDefaultArgument"
-  val DEFAULT_ARGUMENT_NAME = "defaultArgument"
-  val OPTIONAL_ARGUMENT_NAME = "optionalArg"
+  val NonDefaultArgumentName = "nonDefaultArgument"
+  val DefaultArgumentName = "defaultArgument"
+  val OptionalArgumentName = "optionalArg"
+  val NestedParentArgumentName = "nestedParentArgument"
 
   val nonDefaultArgument = Argument(
-    name = NON_DEFAULT_ARGUMENT_NAME,
+    name = NonDefaultArgumentName,
     argumentType = IntType,
     description = "Argument without default value"
   )
 
   val defaultArgument = Argument(
-    name = DEFAULT_ARGUMENT_NAME,
+    name = DefaultArgumentName,
     argumentType = OptionInputType(IntType),
     defaultValue = 10,
     description = "Argument with default value"
   )
 
   val optionalArgument = Argument(
-    name = OPTIONAL_ARGUMENT_NAME,
+    name = OptionalArgumentName,
     argumentType = OptionInputType(IntType),
     description = "Optional argument"
   )
+
+  val nestedObj  = InputObjectType[JsValue]("Body", List(
+      InputField(NonDefaultArgumentName, nonDefaultArgument.argumentType),
+      InputField(DefaultArgumentName, defaultArgument.argumentType, 10),
+      InputField(OptionalArgumentName, optionalArgument.argumentType)
+    )
+  )
+
+  val nestedParentArgument = Argument(
+    name = NestedParentArgumentName,
+    argumentType = nestedObj,
+    description = "Nested parent argument"
+  )
+
+
 
   "Args: Companion object" when {
     "buildArgs with map input" should {
@@ -45,7 +62,7 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with defined arguments" in {
-        val expectedMap = Map(NON_DEFAULT_ARGUMENT_NAME -> 9001)
+        val expectedMap = Map(NonDefaultArgumentName -> 9001)
         val args = Args(List(nonDefaultArgument), expectedMap)
         args.raw should be (expectedMap)
         args.argsWithDefault should be (Set.empty)
@@ -61,10 +78,10 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with optional argument and defined input" in {
-        val args = Args(List(optionalArgument), Map(OPTIONAL_ARGUMENT_NAME -> 9001))
-        args.raw should be (Map(OPTIONAL_ARGUMENT_NAME -> Some(9001)))
+        val args = Args(List(optionalArgument), Map(OptionalArgumentName -> 9001))
+        args.raw should be (Map(OptionalArgumentName -> Some(9001)))
         args.argsWithDefault should be (Set.empty)
-        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(OptionalArgumentName))
         args.undefinedArgs should be (Set.empty)
         args.defaultInfo should be (TrieMap.empty)
 
@@ -75,8 +92,8 @@ class ArgsSpec extends WordSpec with Matchers {
         val args = Args(List(optionalArgument))
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
-        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(OptionalArgumentName))
+        args.undefinedArgs should be (Set(OptionalArgumentName))
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(optionalArgument) should be (None)
@@ -84,20 +101,20 @@ class ArgsSpec extends WordSpec with Matchers {
 
       "build with default values" in {
         val args = Args(List(defaultArgument))
-        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(10)))
-        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
-        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.raw should be (Map(DefaultArgumentName -> Some(10)))
+        args.argsWithDefault should be (Set(DefaultArgumentName))
+        args.optionalArgs should be (Set(DefaultArgumentName))
+        args.undefinedArgs should be (Set(DefaultArgumentName))
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(defaultArgument) should be (10)
       }
 
       "build with overriden default values" in {
-        val args = Args(List(defaultArgument), Map(DEFAULT_ARGUMENT_NAME -> 9001))
-        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(9001)))
-        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
-        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        val args = Args(List(defaultArgument), Map(DefaultArgumentName -> 9001))
+        args.raw should be (Map(DefaultArgumentName -> Some(9001)))
+        args.argsWithDefault should be (Set(DefaultArgumentName))
+        args.optionalArgs should be (Set(DefaultArgumentName))
         args.undefinedArgs should be (Set.empty)
         args.defaultInfo should be (TrieMap.empty)
 
@@ -107,8 +124,8 @@ class ArgsSpec extends WordSpec with Matchers {
 
     "buildArgs with spray-json" should {
       "build with defined argument" in {
-        val args = Args(List(nonDefaultArgument), s"""{"$NON_DEFAULT_ARGUMENT_NAME": 10}""".parseJson)
-        args.raw should be (Map(NON_DEFAULT_ARGUMENT_NAME -> 10))
+        val args = Args(List(nonDefaultArgument), s"""{"$NonDefaultArgumentName": 10}""".parseJson)
+        args.raw should be (Map(NonDefaultArgumentName -> 10))
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set.empty)
         args.undefinedArgs should be (Set.empty)
@@ -122,10 +139,10 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with optional argument and defined input" in {
-        val args = Args(List(optionalArgument), s"""{"$OPTIONAL_ARGUMENT_NAME": 9001}""".parseJson)
-        args.raw should be (Map(OPTIONAL_ARGUMENT_NAME -> Some(9001)))
+        val args = Args(List(optionalArgument), s"""{"$OptionalArgumentName": 9001}""".parseJson)
+        args.raw should be (Map(OptionalArgumentName -> Some(9001)))
         args.argsWithDefault should be (Set.empty)
-        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(OptionalArgumentName))
         args.undefinedArgs should be (Set.empty)
         args.defaultInfo should be (TrieMap.empty)
 
@@ -136,22 +153,95 @@ class ArgsSpec extends WordSpec with Matchers {
         val args = Args(List(optionalArgument))
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
-        args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
+        args.optionalArgs should be (Set(OptionalArgumentName))
+        args.undefinedArgs should be (Set(OptionalArgumentName))
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(optionalArgument) should be (None)
       }
 
       "build with overriden default values" in {
-        val args = Args(List(defaultArgument), s"""{"$DEFAULT_ARGUMENT_NAME": 9001}""".parseJson)
-        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(9001)))
-        args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
-        args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        val args = Args(List(defaultArgument), s"""{"$DefaultArgumentName": 9001}""".parseJson)
+        args.raw should be (Map(DefaultArgumentName -> Some(9001)))
+        args.argsWithDefault should be (Set(DefaultArgumentName))
+        args.optionalArgs should be (Set(DefaultArgumentName))
         args.undefinedArgs should be (Set.empty)
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(defaultArgument) should be (9001)
+      }
+    }
+
+    "buildArgs with nested objects" should {
+      "build with nested arguments" in {
+        val json =
+          s"""
+             |{
+             |  "$NestedParentArgumentName": {
+             |    "$NonDefaultArgumentName": 1,
+             |    "$DefaultArgumentName": 2,
+             |    "$OptionalArgumentName": 3
+             |  }
+             |}
+           """.stripMargin.parseJson
+        val args = Args(List(nestedParentArgument), json)
+        val fields = args.arg(nestedParentArgument).asJsObject.fields
+
+        fields(NonDefaultArgumentName) should be (JsNumber(1))
+        fields(DefaultArgumentName) should be (JsNumber(2))
+        fields(OptionalArgumentName) should be (JsNumber(3))
+      }
+
+      "not build without required arguments" in {
+        val json =
+          s"""
+             |{
+             |  "$NestedParentArgumentName": {
+             |    "$DefaultArgumentName": 2,
+             |    "$OptionalArgumentName": 3
+             |  }
+             |}
+           """.stripMargin.parseJson
+
+        an [AttributeCoercionError] should be thrownBy Args(List(nestedParentArgument), json)
+      }
+
+      "build without default arguments" in {
+        val json =
+          s"""
+             |{
+             |  "$NestedParentArgumentName": {
+             |    "$NonDefaultArgumentName": 1,
+             |    "$OptionalArgumentName": 3
+             |  }
+             |}
+           """.stripMargin.parseJson
+
+        val args = Args(List(nestedParentArgument), json)
+        val fields = args.arg(nestedParentArgument).asJsObject.fields
+
+        fields(NonDefaultArgumentName) should be (JsNumber(1))
+        fields(DefaultArgumentName) should be (JsNumber(10))
+        fields(OptionalArgumentName) should be (JsNumber(3))
+      }
+
+      "build without optional arguments" in {
+        val json =
+          s"""
+             |{
+             |  "$NestedParentArgumentName": {
+             |    "$NonDefaultArgumentName": 1,
+             |    "$DefaultArgumentName": 2
+             |  }
+             |}
+           """.stripMargin.parseJson
+
+        val args = Args(List(nestedParentArgument), json)
+        val fields = args.arg(nestedParentArgument).asJsObject.fields
+
+        fields(NonDefaultArgumentName) should be (JsNumber(1))
+        fields(DefaultArgumentName) should be (JsNumber(2))
+        an [NoSuchElementException] should be thrownBy fields(OptionalArgumentName)
       }
     }
   }

--- a/src/test/scala/sangria/schema/ArgsSpec.scala
+++ b/src/test/scala/sangria/schema/ArgsSpec.scala
@@ -61,9 +61,8 @@ class ArgsSpec extends WordSpec with Matchers {
       }
 
       "build with optional argument and defined input" in {
-        val expectedMap = Map(OPTIONAL_ARGUMENT_NAME -> 9001)
-        val args = Args(List(optionalArgument), expectedMap)
-        args.raw should be (expectedMap)
+        val args = Args(List(optionalArgument), Map(OPTIONAL_ARGUMENT_NAME -> 9001))
+        args.raw should be (Map(OPTIONAL_ARGUMENT_NAME -> Some(9001)))
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
         args.undefinedArgs should be (Set.empty)
@@ -77,7 +76,7 @@ class ArgsSpec extends WordSpec with Matchers {
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set.empty)
+        args.undefinedArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(optionalArgument) should be (None)
@@ -85,23 +84,22 @@ class ArgsSpec extends WordSpec with Matchers {
 
       "build with default values" in {
         val args = Args(List(defaultArgument))
-        args.raw should be (Map.empty)
+        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(10)))
         args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
         args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set.empty)
-        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+        args.undefinedArgs should be (Set(DEFAULT_ARGUMENT_NAME))
+        args.defaultInfo should be (TrieMap.empty)
 
         args.arg(defaultArgument) should be (10)
       }
 
       "build with overriden default values" in {
-        val expectedMap = Map(DEFAULT_ARGUMENT_NAME -> 9001)
-        val args = Args(List(defaultArgument), expectedMap)
-        args.raw should be (expectedMap)
+        val args = Args(List(defaultArgument), Map(DEFAULT_ARGUMENT_NAME -> 9001))
+        args.raw should be (Map(DEFAULT_ARGUMENT_NAME -> Some(9001)))
         args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
         args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
         args.undefinedArgs should be (Set.empty)
-        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+        args.defaultInfo should be (TrieMap.empty)
 
         args.arg(defaultArgument) should be (9001)
       }
@@ -139,7 +137,7 @@ class ArgsSpec extends WordSpec with Matchers {
         args.raw should be (Map.empty)
         args.argsWithDefault should be (Set.empty)
         args.optionalArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
-        args.undefinedArgs should be (Set.empty)
+        args.undefinedArgs should be (Set(OPTIONAL_ARGUMENT_NAME))
         args.defaultInfo should be (TrieMap.empty)
 
         args.arg(optionalArgument) should be (None)
@@ -151,7 +149,7 @@ class ArgsSpec extends WordSpec with Matchers {
         args.argsWithDefault should be (Set(DEFAULT_ARGUMENT_NAME))
         args.optionalArgs should be (Set(DEFAULT_ARGUMENT_NAME))
         args.undefinedArgs should be (Set.empty)
-        args.defaultInfo should be (TrieMap(DEFAULT_ARGUMENT_NAME -> 10))
+        args.defaultInfo should be (TrieMap.empty)
 
         args.arg(defaultArgument) should be (9001)
       }


### PR DESCRIPTION
I'd like a helper be able to generate `Args` based on argument definitions and provided inputs. Generating Args manually can be rather tedious and a lot of the work seems like it can be abstracted away. 