### PR TITLE
Fix `MeasureQueryDepth` reducer not keeping the largest depth found

### DIFF
--- a/src/main/scala/sangria/execution/QueryReducer.scala
+++ b/src/main/scala/sangria/execution/QueryReducer.scala
@@ -122,7 +122,7 @@ class MeasureQueryDepth[Ctx](action: (Int, Ctx) ⇒ ReduceAction[Ctx, Ctx]) exte
       parentType: ObjectType[Ctx, Val],
       field: Field[Ctx, Val],
       argumentValuesFn: (ExecutionPath, List[Argument[_]], Vector[ast.Argument]) ⇒ Try[Args]): Acc =
-    childrenAcc
+    Math.max(fieldAcc, childrenAcc)
 
   def reduceScalar[T](
     path: ExecutionPath,

--- a/src/test/scala/sangria/execution/QueryReducerSpec.scala
+++ b/src/test/scala/sangria/execution/QueryReducerSpec.scala
@@ -610,6 +610,35 @@ class QueryReducerSpec extends WordSpec with Matchers with FutureResultSupport {
       calcDepth("""
        {
          nest {
+           a
+           b
+           ab
+
+           named(size: 1) {
+             name
+
+             ... on Cat {
+               meows
+             }
+
+             ... on Dog {
+               barks
+             }
+           }
+         }
+
+         nest {
+           a
+         }
+
+         info
+         a
+       }
+       """) should be (3)
+
+      calcDepth("""
+       {
+         nest {
            nest {
              nest {
                nest {


### PR DESCRIPTION
From issue #245 