### PR TITLE
Add missing space in the description of the deprecation reason argument

### DIFF
--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -203,7 +203,7 @@ package object schema {
   val ReasonArg = Argument("reason", OptionInputType(StringType),
     description =
       "Explains why this element was deprecated, usually also including a " +
-      "suggestion for how to access supported similar data. Formatted" +
+      "suggestion for how to access supported similar data. Formatted " +
       "in [Markdown](https://daringfireball.net/projects/markdown/).",
     defaultValue = DefaultDeprecationReason)
 

--- a/src/test/scala/sangria/introspection/IntrospectionSpec.scala
+++ b/src/test/scala/sangria/introspection/IntrospectionSpec.scala
@@ -866,7 +866,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
                 "args" → Vector(
                   Map(
                     "name" → "reason",
-                    "description" → "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formattedin [Markdown](https://daringfireball.net/projects/markdown/).",
+                    "description" → "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
                     "type" → Map("kind" → "SCALAR", "name" → "String", "ofType" → null),
                     "defaultValue" → "\"No longer supported\""))))))))
     }

--- a/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -739,7 +739,7 @@ class SchemaRenderSpec extends WordSpec with Matchers with FutureResultSupport w
         |
         |# Marks an element of a GraphQL schema as no longer supported.
         |directive @deprecated(
-        |  # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formattedin [Markdown](https://daringfireball.net/projects/markdown/).
+        |  # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).
         |  reason: String = "No longer supported") on ENUM_VALUE | FIELD_DEFINITION
         |
         |# Directs the executor to include this field or fragment only when the `if` argument is true.


### PR DESCRIPTION
For reference, the space is not missing in the JS version: https://github.com/graphql/graphql-js/blob/831598ba76f015078ecb6c5c1fbaf133302f3f8e/src/type/directives.js#L169-L171