### PR TITLE
Built in scalars will now only be added to the schema if they are used

### DIFF
--- a/src/main/scala/sangria/schema/Schema.scala
+++ b/src/main/scala/sangria/schema/Schema.scala
@@ -783,6 +783,7 @@ case class Schema[Ctx, Val](
         case ListType(ofType) ⇒ collectTypes(parentInfo, priority, ofType, result)
         case ListInputType(ofType) ⇒ collectTypes(parentInfo, priority, ofType, result)
 
+        case t @ ScalarType(name, _, _, _, _, _, _, _) if BuiltinScalars.contains(t) ⇒ updated(40, name, t, result, parentInfo)
         case t @ ScalarType(name, _, _, _, _, _, _, _) ⇒ updated(priority, name, t, result, parentInfo)
         case ScalarAlias(aliasFor, _, _) ⇒ updated(priority, aliasFor.name, aliasFor, result, parentInfo)
         case t @ EnumType(name, _, _, _) ⇒ updated(priority, name, t, result, parentInfo)
@@ -819,7 +820,7 @@ case class Schema[Ctx, Val](
       }
     }
 
-    val schemaTypes = collectTypes("a '__Schema' type", 30, introspection.__Schema, Map(BuiltinScalars map (s ⇒ s.name → (40 → s)): _*))
+    val schemaTypes = collectTypes("a '__Schema' type", 30, introspection.__Schema, Map.empty)
     val queryTypes = collectTypes("a query type", 20, query, schemaTypes)
     val queryTypesWithAdditions = additionalTypes.foldLeft(queryTypes){case (acc, tpe) ⇒ collectTypes("additional type", 10, tpe, acc)}
     val queryAndSubTypes = mutation map (collectTypes("a mutation type", 10, _, queryTypesWithAdditions)) getOrElse queryTypesWithAdditions

--- a/src/test/scala/sangria/introspection/IntrospectionSpec.scala
+++ b/src/test/scala/sangria/introspection/IntrospectionSpec.scala
@@ -740,53 +740,8 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
                 "possibleTypes" → null),
               Map(
                 "inputFields" → null,
-                "name" → "BigDecimal",
-                "description" → "The `BigDecimal` scalar type represents signed fractional values with arbitrary precision.",
-                "interfaces" → null,
-                "enumValues" → null,
-                "fields" → null,
-                "kind" → "SCALAR",
-                "possibleTypes" → null),
-              Map(
-                "inputFields" → null,
-                "name" → "BigInt",
-                "description" → (
-                  "The `BigInt` scalar type represents non-fractional signed whole numeric values. " +
-                  "BigInt can represent arbitrary big values."),
-                "interfaces" → null,
-                "enumValues" → null,
-                "fields" → null,
-                "kind" → "SCALAR",
-                "possibleTypes" → null),
-              Map(
-                "inputFields" → null,
                 "name" → "Boolean",
                 "description" → "The `Boolean` scalar type represents `true` or `false`.",
-                "interfaces" → null,
-                "enumValues" → null,
-                "fields" → null,
-                "kind" → "SCALAR",
-                "possibleTypes" → null),
-              Map(
-                "inputFields" → null,
-                "name" → "Float",
-                "description" → (
-                  "The `Float` scalar type represents signed double-precision fractional " +
-                  "values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."),
-                "interfaces" → null,
-                "enumValues" → null,
-                "fields" → null,
-                "kind" → "SCALAR",
-                "possibleTypes" → null),
-              Map(
-                "inputFields" → null,
-                "name" → "ID",
-                "description" → (
-                  "The `ID` scalar type represents a unique identifier, often used to " +
-                  "refetch an object or as key for a cache. The ID type appears in a JSON " +
-                  "response as a String; however, it is not intended to be human-readable. " +
-                  "When expected as an input type, any string (such as `\"4\"`) or integer " +
-                  "(such as `4`) input value will be accepted as an ID."),
                 "interfaces" → null,
                 "enumValues" → null,
                 "fields" → null,
@@ -798,17 +753,6 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
                 "description" → (
                   "The `Int` scalar type represents non-fractional signed whole numeric values. " +
                   "Int can represent values between -(2^31) and 2^31 - 1."),
-                "interfaces" → null,
-                "enumValues" → null,
-                "fields" → null,
-                "kind" → "SCALAR",
-                "possibleTypes" → null),
-              Map(
-                "inputFields" → null,
-                "name" → "Long",
-                "description" → (
-                  "The `Long` scalar type represents non-fractional signed whole numeric values. " +
-                  "Long can represent values between -(2^63) and 2^63 - 1."),
                 "interfaces" → null,
                 "enumValues" → null,
                 "fields" → null,
@@ -968,37 +912,7 @@ class IntrospectionSpec extends WordSpec with Matchers with FutureResultSupport 
         ),
         Map(
           "kind" → "SCALAR",
-          "name" → "BigDecimal",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
-          "name" → "BigInt",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
           "name" → "Boolean",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
-          "name" → "Float",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
-          "name" → "ID",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
-          "name" → "Int",
-          "inputFields" → null
-        ),
-        Map(
-          "kind" → "SCALAR",
-          "name" → "Long",
           "inputFields" → null
         ),
         Map(

--- a/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -183,6 +183,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
         }
       """,
 
+      nonBreakingChange[TypeAdded]("`Int` type was added"),
       breakingChange[InputFieldRemoved]("Input field `descr` was removed from `Filter` type"),
       nonBreakingChange[InputFieldAdded]("Input field `size` was added to `Filter` type"),
       nonBreakingChange[InputFieldDescriptionChanged]("`Filter.name` description is changed"),
@@ -223,6 +224,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
       """,
 
       breakingChange[TypeRemoved]("`I2` type was removed"),
+      nonBreakingChange[TypeAdded]("`ID` type was added"),
       nonBreakingChange[TypeAdded]("`I3` type was added"),
       breakingChange[ObjectTypeInterfaceRemoved]("`Filter` object type no longer implements `I2` interface"),
       nonBreakingChange[ObjectTypeInterfaceAdded]("`Filter` object type now implements `I3` interface"),
@@ -259,6 +261,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
         }
       """,
 
+      nonBreakingChange[TypeAdded]("`Int` type was added"),
       breakingChange[ObjectTypeArgumentTypeChanged]("`Filter.foo(b)` type changed from `String` to `[String]`"),
       nonBreakingChange[ObjectTypeArgumentAdded]("Argument `d` was added to `Filter.foo` field"),
       breakingChange[ObjectTypeArgumentTypeChanged]("`Filter.foo(b1)` type changed from `String` to `String!`"),
@@ -314,6 +317,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
         }
       """,
 
+      nonBreakingChange[TypeAdded]("`Int` type was added"),
       breakingChange[InputFieldAdded]("Input field `e` was added to `Filter` type"),
       nonBreakingChange[InputFieldAdded]("Input field `d` was added to `Filter` type"),
       breakingChange[InputFieldTypeChanged]("`Filter.b` input field type changed from `String` to `[String]`"),
@@ -350,6 +354,7 @@ class SchemaComparatorSpec extends WordSpec with Matchers {
 
       breakingChange[TypeRemoved]("`Query` type was removed"),
       nonBreakingChange[TypeAdded]("`Mut` type was added"),
+      nonBreakingChange[TypeAdded]("`Int` type was added"),
       nonBreakingChange[TypeAdded]("`Subs` type was added"),
       nonBreakingChange[TypeAdded]("`Foo` type was added"),
       breakingChange[SchemaQueryTypeChanged]("Schema query type changed from `Query` to `Foo` type"),

--- a/src/test/scala/sangria/starWars/StarWarsIntrospectionSpec.scala
+++ b/src/test/scala/sangria/starWars/StarWarsIntrospectionSpec.scala
@@ -41,13 +41,7 @@ class StarWarsIntrospectionSpec extends WordSpec with Matchers with FutureResult
                 Map("name" → "__Schema"),
                 Map("name" → "__Type"),
                 Map("name" → "__TypeKind"),
-                Map("name" → "BigDecimal"),
-                Map("name" → "BigInt"),
                 Map("name" → "Boolean"),
-                Map("name" → "Float"),
-                Map("name" → "ID"),
-                Map("name" → "Int"),
-                Map("name" → "Long"),
                 Map("name" → "String")
               )
             )


### PR DESCRIPTION
This resolves #270 