### PR TITLE
Improved input document validation and deserialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.2
+  - 2.12.3
   - 2.11.11
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.2"
-crossScalaVersions := Seq("2.11.11", "2.12.2")
+scalaVersion := "2.12.3"
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/scala/sangria/ast/QueryAst.scala
+++ b/src/main/scala/sangria/ast/QueryAst.scala
@@ -1,22 +1,22 @@
 package sangria.ast
 
 import org.parboiled2.Position
-import sangria.parser.SourceMapper
+import sangria.execution.InputDocumentMaterializer
+import sangria.marshalling.{FromInput, InputUnmarshaller}
+import sangria.parser.{DeliveryScheme, SourceMapper}
 import sangria.renderer.QueryRenderer
 import sangria.validation.DocumentAnalyzer
-
-import sangria.schema.Schema
+import sangria.schema.{InputType, Schema}
 import sangria.validation.{TypeInfo, Violation}
 import sangria.visitor._
 
 import scala.util.control.Breaks._
-
 import scala.collection.immutable.ListMap
 
 case class Document(definitions: Vector[Definition], trailingComments: Vector[Comment] = Vector.empty, position: Option[Position] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
   lazy val operations = Map(definitions collect {case op: OperationDefinition ⇒ op.name → op}: _*)
   lazy val fragments = Map(definitions collect {case fragment: FragmentDefinition ⇒ fragment.name → fragment}: _*)
-  lazy val source = sourceMapper map (_.source)
+  lazy val source: Option[String] = sourceMapper map (_.source)
 
   def operationType(operationName: Option[String] = None): Option[OperationType] =
     operation(operationName) map (_.operationType)
@@ -32,14 +32,6 @@ case class Document(definitions: Vector[Definition], trailingComments: Vector[Co
   def withoutSourceMapper = copy(sourceMapper = None)
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Document]
-
-  override def equals(other: Any): Boolean = other match {
-    case that: Document ⇒
-      (that canEqual this) &&
-        definitions == that.definitions &&
-        position == that.position
-    case _ ⇒ false
-  }
 
   /**
     * Merges two documents. The `sourceMapper` is lost along the way.
@@ -57,6 +49,14 @@ case class Document(definitions: Vector[Definition], trailingComments: Vector[Co
 
   def separateOperation(definition: OperationDefinition) = analyzer.separateOperation(definition)
   def separateOperation(operationName: Option[String]) = analyzer.separateOperation(operationName)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Document ⇒
+      (that canEqual this) &&
+          definitions == that.definitions &&
+          position == that.position
+    case _ ⇒ false
+  }
 
   override def hashCode(): Int =
     Seq(definitions, position).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
@@ -81,6 +81,59 @@ object Document {
     Document(Vector(
       ObjectTypeDefinition("Query", Vector.empty, Vector(
         FieldDefinition("stub", NamedType("String"), Vector.empty)))))
+}
+
+case class InputDocument(values: Vector[Value], trailingComments: Vector[Comment] = Vector.empty, position: Option[Position] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
+  lazy val source: Option[String] = sourceMapper map (_.source)
+
+  /**
+    * Merges two documents. The `sourceMapper` is lost along the way.
+    */
+  def merge(other: InputDocument) = InputDocument.merge(Vector(this, other))
+
+  /**
+    * An alias for `merge`
+    */
+  def +(other: InputDocument) = merge(other)
+
+
+  def to[T](
+    schema: Schema[_, _],
+    inputType: InputType[T]
+  )(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer.to(schema, this, inputType)
+
+  def to[T, Vars](
+    schema: Schema[_, _],
+    inputType: InputType[T],
+    variables: Vars
+  )(implicit iu: InputUnmarshaller[Vars], fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer.to(schema, this, inputType, variables)
+
+  def to[T](inputType: InputType[T])(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer.to(this, inputType)
+
+  def to[T, Vars](
+    inputType: InputType[T],
+    variables: Vars = InputUnmarshaller.emptyMapVars
+  )(implicit iu: InputUnmarshaller[Vars], fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer.to(this, inputType, variables)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: InputDocument ⇒
+      (that canEqual this) &&
+          values == that.values &&
+          position == that.position
+    case _ ⇒ false
+  }
+
+  override def hashCode(): Int =
+    Seq(values, position).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
+}
+
+object InputDocument {
+  def merge(documents: Traversable[InputDocument]): InputDocument =
+    InputDocument(documents.toVector.flatMap(_.values))
 }
 
 sealed trait ConditionalFragment extends AstNode {
@@ -444,6 +497,12 @@ object AstVisitor {
     def loop(node: AstNode): Unit =
       node match {
         case n @ Document(defs, trailingComments, _, _) ⇒
+          if (breakOrSkip(onEnter(n))) {
+            defs.foreach(d ⇒ loop(d))
+            trailingComments.foreach(s ⇒ loop(s))
+            breakOrSkip(onLeave(n))
+          }
+        case n @ InputDocument(defs, trailingComments, _, _) ⇒
           if (breakOrSkip(onEnter(n))) {
             defs.foreach(d ⇒ loop(d))
             trailingComments.foreach(s ⇒ loop(s))

--- a/src/main/scala/sangria/execution/ExecutionError.scala
+++ b/src/main/scala/sangria/execution/ExecutionError.scala
@@ -66,6 +66,9 @@ case class AttributeCoercionError(violations: Vector[Violation], eh: Executor.Ex
 case class ValidationError(violations: Vector[Violation], eh: Executor.ExceptionHandler) extends ExecutionError(
   s"Query does not pass validation. Violations:\n\n${violations map (_.errorMessage) mkString "\n\n"}", eh) with WithViolations with QueryAnalysisError
 
+case class InputDocumentMaterializationError(violations: Vector[Violation], eh: Executor.ExceptionHandler) extends ExecutionError(
+  s"Input document does not pass validation. Violations:\n\n${violations map (_.errorMessage) mkString "\n\n"}", eh) with WithViolations with QueryAnalysisError
+
 case class QueryReducingError(cause: Throwable, exceptionHandler: Executor.ExceptionHandler) extends Exception(s"Query reducing error: ${cause.getMessage}", cause) with QueryAnalysisError
 
 case class OperationSelectionError(message: String, eh: Executor.ExceptionHandler, sm: Option[SourceMapper] = None, pos: List[Position] = Nil)

--- a/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
+++ b/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
@@ -42,7 +42,7 @@ case class InputDocumentMaterializer[Vars](schema: Schema[_, _], variables: Vars
     }
   }
 
-  private def inferVariableDefinitions[T](document: InputDocument, inputType: InputType[T]) = {
+  def inferVariableDefinitions[T](document: InputDocument, inputType: InputType[T]) = {
     document.values.flatMap { v ⇒
       AstVisitor.visitAstWithState(schema, v, new mutable.HashMap[String, VariableDefinition]) { (typeInfo, state) ⇒
         typeInfo.withInputType(inputType)

--- a/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
+++ b/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
@@ -1,0 +1,102 @@
+package sangria.execution
+
+import sangria.ast.{AstVisitor, InputDocument, VariableDefinition}
+import sangria.ast
+import sangria.marshalling.{FromInput, InputUnmarshaller}
+import sangria.parser.DeliveryScheme
+import sangria.renderer.SchemaRenderer
+import sangria.schema._
+import sangria.visitor.VisitorCommand
+import sangria.marshalling.queryAst._
+import sangria.validation.QueryValidator
+
+import scala.collection.mutable
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+case class InputDocumentMaterializer[Vars](schema: Schema[_, _], variables: Vars = InputUnmarshaller.emptyMapVars)(implicit iu: InputUnmarshaller[Vars]) {
+  def to[T](document: InputDocument, inputType: InputType[T])(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result = {
+    val collector = new ValueCollector[Unit, Vars](schema, variables, document.sourceMapper, DeprecationTracker.empty, (), PartialFunction.empty, None)
+
+    val violations = QueryValidator.default.validateInputDocument(schema, document, inputType)
+
+    if (violations.nonEmpty)
+      scheme.failure(InputDocumentMaterializationError(violations, PartialFunction.empty))
+    else {
+      val variableDefinitions = inferVariableDefinitions(document, inputType)
+
+      collector.getVariableValues(variableDefinitions, None) match {
+        case Failure(e) ⇒ scheme.failure(e)
+        case Success(vars) ⇒
+          try {
+            scheme.success(document.values flatMap { value ⇒
+              collector.coercionHelper.coerceInputValue(inputType, Nil, value, Some(vars), fromInput.marshaller, fromInput.marshaller, isArgument = false) match {
+                case Left(vs) ⇒ throw InputDocumentMaterializationError(vs, PartialFunction.empty)
+                case Right(coerced) ⇒ coerced.toOption.map(res ⇒ fromInput.fromResult(res))
+              }
+            })
+          } catch {
+            case NonFatal(e) ⇒ scheme.failure(e)
+          }
+      }
+    }
+  }
+
+  private def inferVariableDefinitions[T](document: InputDocument, inputType: InputType[T]) = {
+    document.values.flatMap { v ⇒
+      AstVisitor.visitAstWithState(schema, v, new mutable.HashMap[String, VariableDefinition]) { (typeInfo, state) ⇒
+        typeInfo.withInputType(inputType)
+
+        AstVisitor {
+          case v: ast.VariableValue if typeInfo.inputType.isDefined ⇒
+            val parentType = typeInfo.inputType.get
+            val parentTypeAst = SchemaRenderer.renderTypeNameAst(parentType)
+
+            state.get(v.name) match {
+              case None ⇒
+                state(v.name) = ast.VariableDefinition(v.name, parentTypeAst, None)
+                VisitorCommand.Continue
+              case _ ⇒ VisitorCommand.Continue
+            }
+        }
+      }.values.toVector
+    }
+  }
+}
+
+object InputDocumentMaterializer {
+  def to[T](
+    schema: Schema[_, _],
+    document: InputDocument,
+    inputType: InputType[T]
+  )(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer(schema, InputUnmarshaller.emptyMapVars).to(document, inputType)
+
+  def to[T, Vars](
+    schema: Schema[_, _],
+    document: InputDocument,
+    inputType: InputType[T],
+    variables: Vars
+  )(implicit iu: InputUnmarshaller[Vars], fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    InputDocumentMaterializer(schema, variables).to(document, inputType)
+
+  def to[T](
+    document: InputDocument,
+    inputType: InputType[T]
+  )(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    to(emptyStubSchema(inputType), document, inputType, InputUnmarshaller.emptyMapVars)
+
+  def to[T, Vars](
+    document: InputDocument,
+    inputType: InputType[T],
+    variables: Vars = InputUnmarshaller.emptyMapVars
+  )(implicit iu: InputUnmarshaller[Vars], fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result =
+    to(emptyStubSchema(inputType), document, inputType, variables)
+
+  private def emptyStubSchema[T : FromInput](inputType: InputType[T]): Schema[_, _] =
+    Schema(ObjectType("Query", fields[Unit, Unit](
+      Field("stub", StringType,
+        arguments = Argument("stub", inputType) :: Nil,
+        resolve = _ ⇒ "stub"))))
+
+}

--- a/src/main/scala/sangria/execution/ValueCoercionHelper.scala
+++ b/src/main/scala/sangria/execution/ValueCoercionHelper.scala
@@ -379,11 +379,11 @@ class ValueCoercionHelper[Ctx](sourceMapper: Option[SourceMapper] = None, deprec
           UnknownInputObjectFieldViolation(SchemaRenderer.renderTypeName(objTpe, true), f, sourceMapper, Nil)
       }
 
-      if (unknownFields.nonEmpty) unknownFields
-      else {
+      val fieldViolations =
         objTpe.fields.toVector.flatMap(f ⇒
           isValidValue(f.fieldType, um.getMapValue(valueMap, f.name)) map (MapValueViolation(f.name, _, sourceMapper, Nil)))
-      }
+
+      fieldViolations ++ unknownFields
 
     case (objTpe: InputObjectType[_], _) ⇒
       Vector(InputObjectIsOfWrongTypeMissingViolation(SchemaRenderer.renderTypeName(objTpe, true), sourceMapper, Nil))

--- a/src/main/scala/sangria/macros/AstLiftable.scala
+++ b/src/main/scala/sangria/macros/AstLiftable.scala
@@ -134,6 +134,10 @@ trait AstLiftable {
   implicit def liftDocument: Liftable[Document] = Liftable {
     case doc @ Document(d, c, p, _) ⇒ q"_root_.sangria.ast.Document($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.Parboiled2SourceMapper(_root_.org.parboiled2.ParserInput(${doc.source.get}))))"
   }
+
+  implicit def liftInputDocument: Liftable[InputDocument] = Liftable {
+    case doc @ InputDocument(d, c, p, _) ⇒ q"_root_.sangria.ast.InputDocument($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.Parboiled2SourceMapper(_root_.org.parboiled2.ParserInput(${doc.source.get}))))"
+  }
 }
 
 trait MacroAstLiftable extends AstLiftable {

--- a/src/main/scala/sangria/macros/package.scala
+++ b/src/main/scala/sangria/macros/package.scala
@@ -1,19 +1,17 @@
 package sangria
 
 import scala.language.experimental.{macros ⇒ `scalac, please just let me do it!`}
-
-import sangria.schema._
-
-
-import sangria.ast.{Document, Value}
+import sangria.ast.{Document, InputDocument, Value}
 
 package object macros {
   implicit class LiteralGraphQLStringContext(val sc: StringContext) extends AnyVal {
     def gql(args: Any*): Document = macro ParseMacro.impl
     def gqlInp(args: Any*): Value = macro ParseMacro.implInput
+    def gqlInpDoc(args: Any*): InputDocument = macro ParseMacro.implInputDoc
 
     def graphql(args: Any*): Document = macro ParseMacro.impl
     def graphqlInput(args: Any*): Value = macro ParseMacro.implInput
+    def graphqlInputDoc(args: Any*): InputDocument = macro ParseMacro.implInputDoc
   }
 
 }

--- a/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -233,6 +233,10 @@ object QueryRenderer {
         (defs map (render(_, config, indentLevel)) mkString config.definitionSeparator) +
           renderTrailingComment(d, None, indent, config)
 
+      case d @ InputDocument(defs, _, _, _) ⇒
+        (defs map (render(_, config, indentLevel)) mkString config.definitionSeparator) +
+          renderTrailingComment(d, None, indent, config)
+
       case op @ OperationDefinition(OperationType.Query, None, vars, dirs, sels, _, _, _) if vars.isEmpty && dirs.isEmpty ⇒
         renderComment(op, prev, indent, config) + indent + renderSelections(sels, op, indent, indentLevel, config)
 

--- a/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -21,7 +21,7 @@ object SchemaRenderer {
     loop(tpe, if (topLevel) "" else "!")
   }
 
-  private def renderTypeNameAst(tpe: Type, topLevel: Boolean = false) = {
+  def renderTypeNameAst(tpe: Type, topLevel: Boolean = false): ast.Type = {
     def nn(tpe: ast.Type, notNull: Boolean) =
       if (notNull) ast.NotNullType(tpe)
       else tpe

--- a/src/main/scala/sangria/schema/Schema.scala
+++ b/src/main/scala/sangria/schema/Schema.scala
@@ -563,13 +563,13 @@ case class EnumType[T](
   lazy val byValue = values groupBy (_.value) mapValues (_.head)
 
   def coerceUserInput(value: Any): Either[Violation, (T, Boolean)] = value match {
-    case name: String ⇒ byName get name map (v ⇒ Right(v.value → v.deprecationReason.isDefined)) getOrElse Left(EnumValueCoercionViolation(name))
+    case valueName: String ⇒ byName get valueName map (v ⇒ Right(v.value → v.deprecationReason.isDefined)) getOrElse Left(EnumValueCoercionViolation(valueName, name, values.map(_.name)))
     case v if byValue exists (_._1 == v) ⇒ Right(v.asInstanceOf[T] → byValue(v.asInstanceOf[T]).deprecationReason.isDefined)
     case _ ⇒ Left(EnumCoercionViolation)
   }
 
   def coerceInput(value: ast.Value): Either[Violation, (T, Boolean)] = value match {
-    case ast.EnumValue(name, _, _) ⇒ byName get name map (v ⇒ Right(v.value → v.deprecationReason.isDefined)) getOrElse Left(EnumValueCoercionViolation(name))
+    case ast.EnumValue(valueName, _, _) ⇒ byName get valueName map (v ⇒ Right(v.value → v.deprecationReason.isDefined)) getOrElse Left(EnumValueCoercionViolation(valueName, name, values.map(_.name)))
     case _ ⇒ Left(EnumCoercionViolation)
   }
 

--- a/src/main/scala/sangria/validation/TypeInfo.scala
+++ b/src/main/scala/sangria/validation/TypeInfo.scala
@@ -24,6 +24,12 @@ class TypeInfo(schema: Schema[_, _]) {
   def fieldDef = fieldDefStack.headOption.flatten
   def ancestors: Seq[ast.AstNode] = ancestorStack.toSeq
 
+  def withInputType(inputType: InputType[_]) = {
+    inputTypeStack push Some(inputType)
+
+    this
+  }
+
   def enter(node: ast.AstNode) = {
     ancestorStack push node
 

--- a/src/main/scala/sangria/validation/Violation.scala
+++ b/src/main/scala/sangria/validation/Violation.scala
@@ -382,7 +382,7 @@ case class MapValueViolation(fieldName: String, violation: Violation, mapSourceM
 case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation with PathBasedViolation {
   lazy val pathString = "." + fieldName
 
-  lazy val errorMessageWithoutPath = s"Unknown field '$fieldName' is not defined in the input type '$typeName'."
+  lazy val errorMessageWithoutPath = s"Field '$fieldName' is not defined in the input type '$typeName'."
 
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }

--- a/src/main/scala/sangria/validation/Violation.scala
+++ b/src/main/scala/sangria/validation/Violation.scala
@@ -387,8 +387,12 @@ case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String,
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
-case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: String, fieldType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
-  lazy val simpleErrorMessage = s"The NotNull field '$fieldName' of type '$fieldType' defined in the '$typeName' input type  is missing."
+case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: String, fieldType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation with PathBasedViolation {
+  lazy val pathString = "." + fieldName
+
+  lazy val errorMessageWithoutPath = s"Not-null field '$fieldName' of type '$fieldType' defined in the '$typeName' input type is missing."
+
+  lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
 case class NotNullValueIsNullViolation(sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {

--- a/src/main/scala/sangria/validation/Violation.scala
+++ b/src/main/scala/sangria/validation/Violation.scala
@@ -379,16 +379,20 @@ case class MapValueViolation(fieldName: String, violation: Violation, mapSourceM
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
+case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation with PathBasedViolation {
+  lazy val pathString = "." + fieldName
+
+  lazy val errorMessageWithoutPath = s"Unknown field '$fieldName' is not defined in the input type '$typeName'."
+
+  lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
+}
+
 case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: String, fieldType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"The NotNull field '$fieldName' of type '$fieldType' defined in the '$typeName' input type  is missing."
 }
 
 case class NotNullValueIsNullViolation(sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Expected non-null value, found null."
-}
-
-case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
-  lazy val simpleErrorMessage = s"Unknown field '$fieldName' is not defined in the input type '$typeName'."
 }
 
 case class InputObjectIsOfWrongTypeMissingViolation(typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {

--- a/src/main/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInference.scala
+++ b/src/main/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInference.scala
@@ -1,0 +1,44 @@
+package sangria.validation.rules
+
+import org.parboiled2.Position
+import sangria.ast
+import sangria.ast.AstVisitorCommand
+import sangria.renderer.SchemaRenderer
+import sangria.validation.{ValidationContext, ValidationRule, VariableInferenceViolation}
+
+import scala.collection.mutable
+
+/**
+ * All inferred variables within input document should not conflict in it's inferred type
+ */
+class InputDocumentNonConflictingVariableInference extends ValidationRule {
+  override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
+    private var inInputDocument = false
+    private val usedVariables = new mutable.HashMap[String, (ast.Type, List[Position])]
+
+    override val onEnter: ValidationVisit = {
+      case _: ast.InputDocument ⇒
+        inInputDocument = true
+        AstVisitorCommand.RightContinue
+
+      case v: ast.VariableValue if inInputDocument && ctx.typeInfo.inputType.isDefined ⇒
+        val parentType = ctx.typeInfo.inputType.get
+        val parentTypeAst = SchemaRenderer.renderTypeNameAst(parentType)
+
+        usedVariables.get(v.name) match {
+          case Some((existing, otherPos)) if existing != parentTypeAst ⇒
+            Left(Vector(VariableInferenceViolation(v.name, existing.renderCompact, parentTypeAst.renderCompact, ctx.sourceMapper, v.position.toList ++ otherPos)))
+          case None ⇒
+            usedVariables(v.name) = (parentTypeAst, v.position.toList)
+            AstVisitorCommand.RightContinue
+          case _ ⇒ AstVisitorCommand.RightContinue
+        }
+    }
+
+    override def onLeave = {
+      case _: ast.InputDocument ⇒
+        inInputDocument = false
+        AstVisitorCommand.RightContinue
+    }
+  }
+}

--- a/src/main/scala/sangria/validation/rules/InputDocumentOfCorrectType.scala
+++ b/src/main/scala/sangria/validation/rules/InputDocumentOfCorrectType.scala
@@ -1,0 +1,34 @@
+package sangria.validation.rules
+
+import sangria.ast
+import sangria.ast.AstVisitorCommand
+import sangria.renderer.{QueryRenderer, SchemaRenderer}
+import sangria.validation.ValidationContext.isValidLiteralValue
+import sangria.validation.{BadValueViolation, InvalidInputDocumentViolation, ValidationContext, ValidationRule}
+
+/**
+ * Input document needs to confirm to the parent input type
+ */
+class InputDocumentOfCorrectType extends ValidationRule {
+  override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
+    override val onEnter: ValidationVisit = {
+      case ast.InputDocument(values, _, pos, sourceMapper) ⇒
+        ctx.typeInfo.inputType.map { inputType ⇒
+          val violations = values.flatMap { value ⇒
+            isValidLiteralValue(inputType, value, sourceMapper)
+              .map(violation ⇒ InvalidInputDocumentViolation(
+                SchemaRenderer.renderTypeName(inputType),
+                QueryRenderer.render(value),
+                violation,
+                sourceMapper,
+                Nil))
+          }
+
+          if (violations.nonEmpty)
+            Left(violations)
+          else
+            AstVisitorCommand.RightContinue
+        } getOrElse AstVisitorCommand.RightContinue
+    }
+  }
+}

--- a/src/test/resources/scenarios/validation/DefaultValuesOfCorrectType.yaml
+++ b/src/test/resources/scenarios/validation/DefaultValuesOfCorrectType.yaml
@@ -85,5 +85,5 @@ tests:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 1
-      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' defined in the input type 'Boolean' is missing."
+      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type  is missing."
         loc: {line: 1, column: 47}

--- a/src/test/resources/scenarios/validation/DefaultValuesOfCorrectType.yaml
+++ b/src/test/resources/scenarios/validation/DefaultValuesOfCorrectType.yaml
@@ -85,5 +85,5 @@ tests:
       validate: [DefaultValuesOfCorrectType]
     then:
       - error-count: 1
-      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type  is missing."
+      - error: "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: 'requiredField' Not-null field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type is missing."
         loc: {line: 1, column: 47}

--- a/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
+++ b/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
@@ -95,7 +95,7 @@ class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMa
 
       val errors = QueryValidator.default.validateInputDocument(schema, inp, "Config")
 
-      errors should have size 5
+      errors should have size 6
 
       errors(0).errorMessage should include (
         "At path 'bar' Int value expected")
@@ -104,13 +104,16 @@ class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMa
         "At path 'list[1].baz' Enum value 'FOO_BAR' is undefined in enum type 'Color'. Known values are: RED, GREEN, BLUE.")
 
       errors(2).errorMessage should include (
-        "At path 'list[2]' Unknown field 'test' is not defined in the input type 'Foo'.")
+        "At path 'list[2].test' Field 'test' is not defined in the input type 'Foo'.")
 
       errors(3).errorMessage should include (
-        "At path 'list[3]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
+        "At path 'list[2]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
 
       errors(4).errorMessage should include (
-        "At path Unknown field 'doo' is not defined in the input type 'Config'.")
+        "At path 'list[3]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
+
+      errors(5).errorMessage should include (
+        "At path 'doo' Field 'doo' is not defined in the input type 'Config'.")
     }
 
     "support `Any` value" in {

--- a/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
+++ b/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
@@ -1,0 +1,213 @@
+package sangria.execution
+
+import org.scalatest.{Matchers, WordSpec}
+import sangria.ast.ScalarTypeDefinition
+import sangria.macros._
+import sangria.marshalling.ScalaInput.scalaInput
+import sangria.marshalling.sprayJson._
+import sangria.parser.QueryParser
+import sangria.schema._
+import sangria.util.{DebugUtil, StringMatchers}
+import sangria.validation.QueryValidator
+import spray.json.{DefaultJsonProtocol, JsValue, pimpString}
+import sangria.parser.DeliveryScheme.Throw
+
+class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMatchers {
+  case class Comment(author: String, text: Option[String])
+  case class Article(title: String, text: Option[String], tags: Option[Vector[String]], comments: Vector[Option[Comment]])
+
+  object MyJsonProtocol extends DefaultJsonProtocol {
+    implicit val commentFormat = jsonFormat2(Comment.apply)
+    implicit val articleFormat = jsonFormat4(Article.apply)
+  }
+
+  import MyJsonProtocol._
+  
+  val CommentType = InputObjectType[Comment]("Comment", List(
+    InputField("author", OptionInputType(StringType), defaultValue = "anonymous"),
+    InputField("text", OptionInputType(StringType))
+  ))
+
+  val ArticleType = InputObjectType[Article]("Article", List(
+    InputField("title", StringType),
+    InputField("text", OptionInputType(StringType), defaultValue = "Hello World!"),
+    InputField("tags", OptionInputType(ListInputType(StringType))),
+    InputField("comments", ListInputType(OptionInputType(CommentType)))))
+
+  val ConfigType = InputObjectType[JsValue]("Article", List(
+    InputField("hosts", ListInputType(StringType)),
+    InputField("port", OptionInputType(IntType), 1234)))
+
+  val anyValueBuilder = new DefaultAstSchemaBuilder[Any] {
+    override def buildScalarType(definition: ScalarTypeDefinition, mat: AstSchemaMaterializer[Any]) =
+      if (definition.directives.exists(_.name == "anyValue"))
+        Some(ScalarType[Any](
+          name = typeName(definition),
+          description = typeDescription(definition),
+          coerceUserInput = v ⇒ Right(v),
+          coerceOutput = (v, _) ⇒ v,
+          coerceInput = v ⇒ Right(v),
+          complexity = scalarComplexity(definition),
+          scalarInfo = scalarValueInfo(definition),
+          astDirectives = definition.directives))
+      else
+        super.buildScalarType(definition, mat)
+  }
+
+  "InputDocument materializer and validator" should {
+    "validate input document" in {
+      val schema = Schema.buildStubFromAst(
+        gql"""
+          enum Color {
+            RED
+            GREEN
+            BLUE
+          }
+
+          input Foo {
+            baz: Color!
+          }
+
+          input Config {
+            foo: String
+            bar: Int
+            list: [Foo]
+          }
+        """)
+
+      val inp =
+        gqlInpDoc"""
+          {
+            foo: "bar"
+            bar: "foo"
+            list: [
+              {baz: RED}
+              {baz: FOO_BAR}
+              {test: 1}
+              {}
+            ]
+          }
+
+          {
+            doo: "hello"
+          }
+        """
+
+      val errors = QueryValidator.default.validateInputDocument(schema, inp, "Config")
+
+      errors should have size 5
+
+      errors(0).errorMessage should include (
+        "At path 'bar' Int value expected")
+
+      errors(1).errorMessage should include (
+        "At path 'list[1].baz' Enum value 'FOO_BAR' is undefined in enum type 'Color'. Known values are: RED, GREEN, BLUE.")
+
+      errors(2).errorMessage should include (
+        "At path 'list[2]' Unknown field 'test' is not defined in the input type 'Foo'.")
+
+      errors(3).errorMessage should include (
+        "At path 'list[3]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
+
+      errors(4).errorMessage should include (
+        "At path Unknown field 'doo' is not defined in the input type 'Config'.")
+    }
+
+    "support `Any` value" in {
+      val schema = Schema.buildStubFromAst(
+        gql"""
+          enum Color {
+            RED
+            GREEN
+            BLUE
+          }
+
+          input Foo {
+            baz: Color!
+          }
+
+          input Config {
+            foo: String
+            bar: Int
+            test: Any!
+          }
+
+          # Any valid GraphQL value
+          scalar Any @anyValue
+        """, anyValueBuilder)
+
+      val inp =
+        gqlInpDoc"""
+          {
+            foo: "bar"
+            bar: "foo"
+          }
+
+          {
+            test: [
+              {hello: "world"}
+            ]
+          }
+        """
+
+      val errors = QueryValidator.default.validateInputDocument(schema, inp, "Config")
+
+      errors should have size 2
+
+      errors(0).errorMessage should include (
+        "At path 'bar' Int value expected")
+
+      errors(1).errorMessage should include (
+        "At path The NotNull field 'test' of type 'Any!' defined in the 'Config' input type  is missing.")
+    }
+
+    "support `to` with `FromInput` type class" in {
+      val document = QueryParser.parseInputDocumentWithVariables(
+        """
+          {
+            title: "foo",
+            tags: null,
+            comments: []
+          }
+
+          {
+            title: "Article 2",
+            text: "contents 2",
+            tags: ["spring", "guitars"],
+            comments: [{
+              author: "Me"
+              text: $comm
+            }]
+          }
+        """)
+
+      val vars = scalaInput(Map(
+        "comm" → "from variable"
+      ))
+
+      document.to(ArticleType, vars) should be (
+        Vector(
+          Article("foo", Some("Hello World!"), None, Vector.empty),
+          Article("Article 2", Some("contents 2"),
+            Some(Vector("spring", "guitars")),
+            Vector(Some(Comment("Me", Some("from variable")))))))
+    }
+
+    "support `to` with `FromInput` type class (raw json value)" in {
+      val document = QueryParser.parseInputDocumentWithVariables(
+        """{hosts: ["localhost", "127.0.0.1"]}""")
+
+      val res = document to ConfigType
+
+      res should have size 1
+
+      res(0) should be (
+        """
+          {
+            "hosts": ["localhost", "127.0.0.1"],
+            "port": 1234
+          }
+        """.parseJson)
+    }
+  }
+}

--- a/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
+++ b/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
@@ -5,12 +5,12 @@ import sangria.ast.ScalarTypeDefinition
 import sangria.macros._
 import sangria.marshalling.ScalaInput.scalaInput
 import sangria.marshalling.sprayJson._
+import sangria.parser.DeliveryScheme.Throw
 import sangria.parser.QueryParser
 import sangria.schema._
-import sangria.util.{DebugUtil, StringMatchers}
+import sangria.util.StringMatchers
 import sangria.validation.QueryValidator
 import spray.json.{DefaultJsonProtocol, JsValue, pimpString}
-import sangria.parser.DeliveryScheme.Throw
 
 class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMatchers {
   case class Comment(author: String, text: Option[String])

--- a/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
+++ b/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
@@ -107,10 +107,10 @@ class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMa
         "At path 'list[2].test' Field 'test' is not defined in the input type 'Foo'.")
 
       errors(3).errorMessage should include (
-        "At path 'list[2]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
+        "At path 'list[2].baz' Not-null field 'baz' of type 'Color!' defined in the 'Foo' input type is missing.")
 
       errors(4).errorMessage should include (
-        "At path 'list[3]' The NotNull field 'baz' of type 'Color!' defined in the 'Foo' input type  is missing.")
+        "At path 'list[3].baz' Not-null field 'baz' of type 'Color!' defined in the 'Foo' input type is missing.")
 
       errors(5).errorMessage should include (
         "At path 'doo' Field 'doo' is not defined in the input type 'Config'.")
@@ -161,7 +161,7 @@ class InputDocumentMaterializerSpec extends WordSpec with Matchers with StringMa
         "At path 'bar' Int value expected")
 
       errors(1).errorMessage should include (
-        "At path The NotNull field 'test' of type 'Any!' defined in the 'Config' input type  is missing.")
+        "At path 'test' Not-null field 'test' of type 'Any!' defined in the 'Config' input type is missing.")
     }
 
     "support `to` with `FromInput` type class" in {

--- a/src/test/scala/sangria/execution/ScalarAliasSpec.scala
+++ b/src/test/scala/sangria/execution/ScalarAliasSpec.scala
@@ -241,8 +241,8 @@ class ScalarAliasSpec extends WordSpec with Matchers with FutureResultSupport {
       violations should (
         have(size(3)) and
         contain("Argument 'n' expected type 'Int!' but got: -123. Reason: Predicate failed: (-123 > 0).") and
-        contain("Argument 'c' expected type 'Complex!' but got: {userId: 1, userNum: -5}. Reason: [in field 'userId'] String value expected") and
-        contain("Argument 'c' expected type 'Complex!' but got: {userId: 1, userNum: -5}. Reason: [in field 'userNum'] Predicate failed: (-5 > 0).")
+        contain("Argument 'c' expected type 'Complex!' but got: {userId: 1, userNum: -5}. Reason: 'userId' String value expected") and
+        contain("Argument 'c' expected type 'Complex!' but got: {userId: 1, userNum: -5}. Reason: 'userNum' Predicate failed: (-5 > 0).")
       )
     }
   }

--- a/src/test/scala/sangria/execution/VariablesSpec.scala
+++ b/src/test/scala/sangria/execution/VariablesSpec.scala
@@ -123,7 +123,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """,
           null,
-          List("""Argument 'input' expected type '[String!]!' but got: ["a1", null, "b1"]. Reason: [at index #1] String value expected""" → List(Pos(3, 31)))
+          List("""Argument 'input' expected type '[String!]!' but got: ["a1", null, "b1"]. Reason: '[1]' String value expected""" → List(Pos(3, 31)))
         )
 
         "does not allow null literals in not-null fields in complex objects" in checkContainsErrors(
@@ -134,7 +134,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """,
           null,
-          List("""Argument 'input' expected type 'TestInputObject' but got: {a: "foo", c: null}. Reason: [in field 'c'] String value expected""" → List(Pos(3, 43), Pos(3, 54)))
+          List("""Argument 'input' expected type 'TestInputObject' but got: {a: "foo", c: null}. Reason: 'c' String value expected""" → List(Pos(3, 43), Pos(3, 54)))
         )
 
         "does not allow null literals in not-null arguments" in checkContainsErrors(
@@ -145,7 +145,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """,
           null,
-          List("""Argument 'input' expected type '[String!]!' but got: null. Reason: [at index #0] String value expected""" → List(Pos(3, 31)))
+          List("""Argument 'input' expected type '[String!]!' but got: null. Reason: '[0]' String value expected""" → List(Pos(3, 31)))
         )
 
         "does not allow null literals in not-null lists inside of complex objects" in checkContainsErrors(
@@ -156,7 +156,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
             }
           """,
           null,
-          List("""Argument 'input' expected type 'TestInputObject' but got: {a: "foo", c: "baz", d: ["aa", null]}. Reason: [in field 'd'] [at index #1] String value expected""" → List(Pos(3, 43), Pos(3, 67)))
+          List("""Argument 'input' expected type 'TestInputObject' but got: {a: "foo", c: "baz", d: ["aa", null]}. Reason: 'd[1]' String value expected""" → List(Pos(3, 43), Pos(3, 64), Pos(3, 67)))
         )
 
         "executes with complex input containing undefined object fields" in check(
@@ -292,7 +292,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
 
         "errors on omission of nested non-null" in  assertErrorResult(
           """{"input": {"a": "foo", "b": "bar"}}""".parseJson,
-          """Variable '$input' expected value of type 'TestInputObject' but got: {"a":"foo","b":"bar"}. Reason: [in field 'c'] Expected non-null value, found null""")
+          """Variable '$input' expected value of type 'TestInputObject' but got: {"a":"foo","b":"bar"}. Reason: 'c' Expected non-null value, found null""")
 
         "errors on addition of unknown input field" in  assertErrorResult(
           """{"input": {"a": "foo", "b": "bar", "c": "baz", "z": "dog"}}""".parseJson,

--- a/src/test/scala/sangria/execution/VariablesSpec.scala
+++ b/src/test/scala/sangria/execution/VariablesSpec.scala
@@ -296,7 +296,7 @@ class VariablesSpec extends WordSpec with Matchers with GraphQlSupport {
 
         "errors on addition of unknown input field" in  assertErrorResult(
           """{"input": {"a": "foo", "b": "bar", "c": "baz", "z": "dog"}}""".parseJson,
-          """Variable '$input' expected value of type 'TestInputObject' but got: {"a":"foo","b":"bar","c":"baz","z":"dog"}. Reason: Unknown field 'z' is not defined in the input type 'TestInputObject'.""")
+          """Variable '$input' expected value of type 'TestInputObject' but got: {"a":"foo","b":"bar","c":"baz","z":"dog"}. Reason: 'z' Field 'z' is not defined in the input type 'TestInputObject'.""")
       }
     }
 

--- a/src/test/scala/sangria/util/DebugUtil.scala
+++ b/src/test/scala/sangria/util/DebugUtil.scala
@@ -11,6 +11,7 @@ object DebugUtil {
   private val indentClasses: PartialFunction[Any, Boolean] = {
     case v if v.getClass.getSimpleName.startsWith("Introspection") ⇒ true
     case _: Document |
+         _: InputDocument |
          _: Definition |
          _: SelectionContainer |
          _: Directive |

--- a/src/test/scala/sangria/validation/rules/ArgumentsOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/ArgumentsOfCorrectTypeSpec.scala
@@ -694,7 +694,7 @@ class ArgumentsOfCorrectTypeSpec extends WordSpec with ValidationSupport {
           }
         """,
         List(
-          "Argument 'complexArg' expected type 'ComplexInput' but got: {requiredField: true, unknownField: \"value\"}. Reason: Unknown field 'unknownField' is not defined in the input type 'ComplexInput'" →
+          "Argument 'complexArg' expected type 'ComplexInput' but got: {requiredField: true, unknownField: \"value\"}. Reason: 'unknownField' Field 'unknownField' is not defined in the input type 'ComplexInput'" →
               List(Pos(4, 43), Pos(6, 17))))
     }
 

--- a/src/test/scala/sangria/validation/rules/ArgumentsOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/ArgumentsOfCorrectTypeSpec.scala
@@ -679,8 +679,8 @@ class ArgumentsOfCorrectTypeSpec extends WordSpec with ValidationSupport {
           }
         """,
         List(
-          "Argument 'complexArg' expected type 'ComplexInput' but got: {stringListField: [\"one\", 2], requiredField: true}. Reason: [in field 'stringListField'] [at index #1] String value expected" →
-              List(Pos(4, 43), Pos(5, 34))))
+          "Argument 'complexArg' expected type 'ComplexInput' but got: {stringListField: [\"one\", 2], requiredField: true}. Reason: 'stringListField[1]' String value expected" →
+              List(Pos(4, 43), Pos(5, 17), Pos(5, 34))))
 
       "Partial object, unknown field arg" in expectFailsPosList(
         """

--- a/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
@@ -96,7 +96,7 @@ class DefaultValuesOfCorrectTypeSpec extends WordSpec with ValidationSupport {
         }
       """,
       List(
-        "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' defined in the input type 'Boolean' is missing." → Some(Pos(2, 55))
+        "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type  is missing." → Some(Pos(2, 55))
       ))
 
     "list variables with invalid item" in expectFails(

--- a/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
@@ -106,7 +106,7 @@ class DefaultValuesOfCorrectTypeSpec extends WordSpec with ValidationSupport {
         }
       """,
       List(
-        "Variable '$a' of type '[String]' has invalid default value: [\"one\", 2]. Reason: [at index #1] String value expected" → Some(Pos(2, 42))
+        "Variable '$a' of type '[String]' has invalid default value: [\"one\", 2]. Reason: '[1]' String value expected" → Some(Pos(2, 42))
       ))
   }
 }

--- a/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/DefaultValuesOfCorrectTypeSpec.scala
@@ -96,7 +96,7 @@ class DefaultValuesOfCorrectTypeSpec extends WordSpec with ValidationSupport {
         }
       """,
       List(
-        "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: The NotNull field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type  is missing." → Some(Pos(2, 55))
+        "Variable '$a' of type 'ComplexInput' has invalid default value: {intField: 3}. Reason: 'requiredField' Not-null field 'requiredField' of type 'Boolean!' defined in the 'ComplexInput' input type is missing." → Some(Pos(2, 55))
       ))
 
     "list variables with invalid item" in expectFails(

--- a/src/test/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInferenceSpec.scala
+++ b/src/test/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInferenceSpec.scala
@@ -1,0 +1,47 @@
+package sangria.validation.rules
+
+import org.scalatest.WordSpec
+import sangria.util.{Pos, ValidationSupport}
+
+class InputDocumentNonConflictingVariableInferenceSpec extends WordSpec with ValidationSupport {
+
+  override val defaultRule = Some(new InputDocumentNonConflictingVariableInference)
+
+  "InputDocumentNonConflictingVariableInference" should {
+    "variable used multiple times in the right position" in expectInputPasses("ComplexInput",
+      """
+        {
+          requiredField: true
+          stringField: $foo
+          stringListField: [$foo]
+        }
+      """)
+
+    "variable used 2 times with incompatible types" in expectInputFails("ComplexInput",
+      """
+        {
+          requiredField: $foo
+          stringField: "hello world"
+          stringListField: [$foo]
+        }
+      """,
+      List(
+        "Inferred variable '$foo' is used with two conflicting types: 'Boolean!' and 'String'." → List(Pos(5, 29), Pos(3, 26))
+      ))
+
+    "variable used multiple times with incompatible types" in expectInputFails("ComplexInput",
+      """
+        {
+          requiredField: $foo
+          intField: $foo
+          stringField: $foo
+          stringListField: [$foo]
+        }
+      """,
+      List(
+        "Inferred variable '$foo' is used with two conflicting types: 'Boolean!' and 'Int'." → List(Pos(4, 21), Pos(3, 26)),
+        "Inferred variable '$foo' is used with two conflicting types: 'Boolean!' and 'String'." → List(Pos(5, 24), Pos(3, 26)),
+        "Inferred variable '$foo' is used with two conflicting types: 'Boolean!' and 'String'." → List(Pos(6, 29), Pos(3, 26))
+      ))
+  }
+}

--- a/src/test/scala/sangria/validation/rules/InputDocumentOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/InputDocumentOfCorrectTypeSpec.scala
@@ -30,7 +30,7 @@ class InputDocumentOfCorrectTypeSpec extends WordSpec with ValidationSupport {
         "At path 'requiredField' Boolean value expected" → List(Pos(3, 11)),
         "At path 'stringField' String value expected" → List(Pos(4, 11)),
         "At path 'stringListField[0]' String value expected" → List(Pos(5, 11), Pos(5, 28)),
-        "At path 'bestField' Unknown field 'bestField' is not defined in the input type 'ComplexInput'." → List(Pos(6, 11))
+        "At path 'bestField' Field 'bestField' is not defined in the input type 'ComplexInput'." → List(Pos(6, 11))
       ))
   }
 }

--- a/src/test/scala/sangria/validation/rules/InputDocumentOfCorrectTypeSpec.scala
+++ b/src/test/scala/sangria/validation/rules/InputDocumentOfCorrectTypeSpec.scala
@@ -1,0 +1,36 @@
+package sangria.validation.rules
+
+import org.scalatest.WordSpec
+import sangria.util.{Pos, ValidationSupport}
+
+class InputDocumentOfCorrectTypeSpec extends WordSpec with ValidationSupport {
+
+  override val defaultRule = Some(new InputDocumentOfCorrectType)
+
+  "InputDocumentOfCorrectType" should {
+    "successfully validates" in expectInputPasses("ComplexInput",
+      """
+        {
+          requiredField: true
+          stringField: "hello world"
+          stringListField: ["test"]
+        }
+      """)
+
+    "fails in presence of validation errors" in expectInputFails("ComplexInput",
+      """
+        {
+          requiredField: ["test"]
+          stringField: true
+          stringListField: [123]
+          bestField: true
+        }
+      """,
+      List(
+        "At path 'requiredField' Boolean value expected" → List(Pos(3, 11)),
+        "At path 'stringField' String value expected" → List(Pos(4, 11)),
+        "At path 'stringListField[0]' String value expected" → List(Pos(5, 11), Pos(5, 28)),
+        "At path 'bestField' Unknown field 'bestField' is not defined in the input type 'ComplexInput'." → List(Pos(6, 11))
+      ))
+  }
+}


### PR DESCRIPTION
This PR improves on ideas described in this post:

https://medium.com/@oleg.ilyenko/graphql-object-notation-8f56194556ea

It adds an easier way to validate and materialize/deserialize input document. You can find some example of usage in this test: https://github.com/sangria-graphql/sangria/pull/272/files#diff-b6eed12a7a0cf608e15570a6fc3f868fR57