### PR TITLE
Batch Executor

### DIFF
--- a/src/main/scala/sangria/ast/QueryAst.scala
+++ b/src/main/scala/sangria/ast/QueryAst.scala
@@ -220,6 +220,10 @@ case class ObjectValue(fields: Vector[ObjectField], comments: Vector[Comment] = 
     }
 }
 
+object ObjectValue {
+  def apply(fields: (String, Value)*): ObjectValue = ObjectValue(fields.toVector map (f ⇒ ObjectField(f._1, f._2)))
+}
+
 case class ObjectField(name: String, value: Value, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends NameValue
 
 case class Comment(text: String, position: Option[Position] = None) extends AstNode

--- a/src/main/scala/sangria/execution/SimpleExtensionMiddleware.scala
+++ b/src/main/scala/sangria/execution/SimpleExtensionMiddleware.scala
@@ -1,0 +1,16 @@
+package sangria.execution
+
+import sangria.ast
+
+class SimpleAstBasedExtensionMiddleware[Ctx](extensionFn: MiddlewareQueryContext[Ctx, _, _] ⇒ ast.Value) extends Middleware[Ctx] with MiddlewareExtension[Ctx] {
+  override type QueryVal = Unit
+
+  override def beforeQuery(context: MiddlewareQueryContext[Ctx, _, _]) = ()
+  override def afterQuery(queryVal: QueryVal, context: MiddlewareQueryContext[Ctx, _, _]) = ()
+
+  def afterQueryExtensions(queryVal: QueryVal, context: MiddlewareQueryContext[Ctx, _, _]) = {
+    import sangria.marshalling.queryAst._
+
+    Vector(Extension(extensionFn(context)))
+  }
+}

--- a/src/main/scala/sangria/execution/batch/BatchExecutionPlan.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutionPlan.scala
@@ -1,0 +1,26 @@
+package sangria.execution.batch
+
+import sangria.ast
+import sangria.schema.OutputType
+import sangria.validation.SchemaBasedDocumentAnalyzer.VariableUsage
+
+case class BatchExecutionPlan(exportOperations: Map[String, BatchExecutionPlan.ExportOperation], dependencies: Map[String, Vector[(String, Set[String])]])
+
+object BatchExecutionPlan {
+  case class Export(exportedName: String, path: Vector[String], astDirective: ast.Directive, resultType: OutputType[_])
+
+  case class SpreadInfo(fragmentName: String, path: Vector[String])
+
+  case class ExportOperation(
+    operationName: String,
+    variableDefs: Vector[ast.VariableDefinition],
+    variableUsages: Vector[VariableUsage],
+    exports: Vector[Export],
+    fragmentSpreads: Set[SpreadInfo])
+
+  case class ExportFragment(
+    fragmentName: String,
+    variableUsages: Vector[VariableUsage],
+    exports: Vector[Export],
+    fragmentSpreads: Set[SpreadInfo])
+}

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -363,7 +363,7 @@ object BatchExecutor {
             val violations = new mutable.ListBuffer[Violation]
 
             tail.foreach { curr ⇒
-              val currType = first.tpe.getOrElse(throw new IllegalStateException("Variable usage type is not detected, but expected at this point!"))
+              val currType = curr.tpe.getOrElse(throw new IllegalStateException("Variable usage type is not detected, but expected at this point!"))
               val currAstType = SchemaRenderer.renderTypeNameAst(currType)
 
               if (firstAstType != currAstType)

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -1,0 +1,529 @@
+package sangria.execution.batch
+
+import sangria.ast
+import sangria.ast.AstVisitor
+import sangria.execution._
+import sangria.execution.deferred.DeferredResolver
+import sangria.marshalling.InputUnmarshaller.emptyMapVars
+import sangria.marshalling.{InputUnmarshaller, ResultMarshaller, SimpleResultMarshallerForType, SymmetricMarshaller}
+import sangria.renderer.SchemaRenderer
+import sangria.schema.{Argument, Directive, DirectiveLocation, ListInputType, OptionInputType, Schema, StringType, Type}
+import sangria.validation.SchemaBasedDocumentAnalyzer.VariableUsage
+import sangria.validation.{QueryValidator, TypeInfo, Violation}
+import sangria.visitor.VisitorCommand
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+import scala.util.control.Breaks.{break, breakable}
+import BatchExecutionPlan._
+
+object BatchExecutor {
+  val AsArg = Argument("as", StringType, "The variable name.")
+
+  val ExportDirective = Directive("export",
+    description = Some("Make the field value available for other operations via variable."),
+    arguments = AsArg :: Nil,
+    locations = Set(DirectiveLocation.Field),
+    shouldInclude = _ ⇒ true)
+
+  def executeBatch[Ctx, Root, Input, T](
+    schema: Schema[Ctx, Root],
+    queryAst: ast.Document,
+    operationNames: Seq[String],
+    userContext: Ctx = (),
+    root: Root = (),
+    variables: Input = emptyMapVars,
+    queryValidator: QueryValidator = QueryValidator.default,
+    deferredResolver: DeferredResolver[Ctx] = DeferredResolver.empty,
+    exceptionHandler: Executor.ExceptionHandler = PartialFunction.empty,
+    deprecationTracker: DeprecationTracker = DeprecationTracker.empty,
+    middleware: List[Middleware[Ctx]] = Nil,
+    maxQueryDepth: Option[Int] = None,
+    queryReducers: List[QueryReducer[Ctx, _]] = Nil,
+    inferVariableDefinitions: Boolean = true
+  )(implicit executionContext: ExecutionContext, marshaller: SymmetricMarshaller[T], um: InputUnmarshaller[Input], scheme: ExecutionScheme): scheme.Result[Ctx, T] = {
+    val executor = Executor(schema, QueryValidator.empty, deferredResolver, exceptionHandler, deprecationTracker, middleware, maxQueryDepth, queryReducers)
+    val validations =
+      validateOperationNames(queryAst, operationNames, exceptionHandler)
+        .flatMap(_ ⇒ calcExecutionPlan(schema, queryAst, operationNames, inferVariableDefinitions, exceptionHandler))
+        .flatMap { res ⇒
+          val violations = queryValidator.validateQuery(schema, res._1)
+
+          if (violations.nonEmpty) Failure(ValidationError(violations, exceptionHandler))
+          else Success(res)
+        }
+
+    implicit val m = marshaller.marshaller
+
+    val convertedVariables = convertVariables(variables, marshaller)
+
+    validations match {
+      case Failure(e) ⇒ scheme.failed(e)
+      case Success((updatedDocument, executionPlan)) ⇒
+        scheme match {
+          case ss: ExecutionScheme.StreamBasedExecutionScheme[_] ⇒
+            val childScheme = if (scheme.extended) ExecutionScheme.Extended else ExecutionScheme.Default
+
+            val futures =
+              doExecuteBatchPlan(executionPlan, marshaller, variables, convertedVariables, childScheme.extended, single = false) { (opName, vars, iu) ⇒
+                implicit val iiu = iu
+
+                executeIndividual(executor, updatedDocument, opName, userContext, root, vars, childScheme).asInstanceOf[Future[AnyRef]]
+              }
+
+            ss.subscriptionStream.merge(futures.map(ss.subscriptionStream.singleFuture)).asInstanceOf[scheme.Result[Ctx, T]]
+          case es ⇒
+            val futures =
+              doExecuteBatchPlan(executionPlan, marshaller, variables, convertedVariables, es.extended, single = true) { (opName, vars, iu) ⇒
+                implicit val iiu = iu
+
+                executeIndividual(executor, updatedDocument, opName, userContext, root, variables, es).asInstanceOf[Future[AnyRef]]
+              }
+
+
+            futures.head.asInstanceOf[scheme.Result[Ctx, T]]
+        }
+    }
+  }
+
+  private def convertVariables[In, M](variables: In, marshaller: SymmetricMarshaller[M])(implicit iu: InputUnmarshaller[In]): Map[String, M] = {
+    import sangria.marshalling.ImprovedMarshallingUtil._
+
+    implicit val m = SimpleResultMarshallerForType[M](marshaller.marshaller)
+
+    if (iu.isMapNode(variables)) {
+      val keys = iu.getMapKeys(variables)
+
+      keys.flatMap(k ⇒ iu.getRootMapValue(variables, k).map(v ⇒ k → v.convertMarshaled[M])).toMap
+    } else Map.empty
+  }
+
+
+  private def doExecuteBatchPlan[In, T, M](
+    plan: BatchExecutionPlan,
+    marshaller: SymmetricMarshaller[M],
+    origVariables: In,
+    convertedVariables: Map[String, M],
+    extendedScheme: Boolean,
+    single: Boolean
+  )(
+    executeFn: (String, Any, InputUnmarshaller[Any]) ⇒ Future[T]
+  )(implicit executionContext: ExecutionContext, inputUnmarshaller: InputUnmarshaller[In]): Vector[Future[T]] = {
+    val inProgress = new mutable.HashMap[String, Future[T]]
+
+    def loop(opName: String, deps: Vector[(String, Set[String])]): Future[T] = {
+      inProgress.getOrElseUpdate(opName, {
+        if (deps.nonEmpty) {
+          val depFutures = deps.map {case d @ (dep, _) ⇒ loop(dep, plan.dependencies(dep)).map(d → _)}
+
+          Future.sequence(depFutures).flatMap { resolved ⇒
+            collectVariables(opName, plan, resolved, marshaller, convertedVariables, extendedScheme) match {
+              case Some(newVars) ⇒ executeFn(opName, newVars, marshaller.inputUnmarshaller.asInstanceOf[InputUnmarshaller[Any]])
+              case None ⇒ executeFn(opName, origVariables, inputUnmarshaller.asInstanceOf[InputUnmarshaller[Any]])
+            }
+
+          }
+        } else {
+          if (single && inProgress.nonEmpty)
+            break()
+          else
+            executeFn(opName, origVariables, inputUnmarshaller.asInstanceOf[InputUnmarshaller[Any]])
+        }
+      })
+    }
+
+    breakable {
+      plan.dependencies.foreach { case (opName, deps) ⇒
+        loop(opName, deps)
+      }
+    }
+
+    inProgress.values.toVector
+  }
+
+  private def collectVariables[M](opName: String, plan: BatchExecutionPlan, depValues: Vector[((String, Set[String]), Any)], marshaller: SymmetricMarshaller[M], origVariables: Map[String, M], extendedScheme: Boolean): Option[M] = {
+    val collectedValues = new mutable.HashMap[String, mutable.ListBuffer[M]]
+    val iu = marshaller.inputUnmarshaller
+    val m = marshaller.marshaller
+
+    depValues.foreach { depVal ⇒
+      val ((operationName, neededExports), executionResult) = depVal
+      val exports = plan.exportOperations(operationName).exports.filter(e ⇒ neededExports contains e.exportedName)
+      val result = if (extendedScheme) executionResult.asInstanceOf[ExecutionResult[Any, M]].result else executionResult.asInstanceOf[M]
+
+      def visitPath(name: String, result: M, path: Vector[String]): Unit = {
+        if (path.isEmpty) {
+          val c = collectedValues.getOrElseUpdate(name, new mutable.ListBuffer[M])
+
+          if (iu.isListNode(result))
+            c ++= iu.getListValue(result)
+          else
+            c += result
+        } else if (iu.isMapNode(result)) {
+          val key = path.head
+          val childPath = path.tail
+
+          iu.getMapValue(result, key).foreach { value ⇒
+            if (iu.isListNode(value)) iu.getListValue(value).foreach(visitPath(name, _, childPath))
+            else visitPath(name, value, childPath)
+          }
+        }
+      }
+
+      exports.foreach { export ⇒
+        visitPath(export.exportedName, result, "data" +: export.path)
+      }
+    }
+
+    // merge in original variables with overlapping keys
+    origVariables.foreach { case (key, value) ⇒
+      collectedValues.get(key) match {
+        case Some(list) if iu.isListNode(value) ⇒
+          list ++= iu.getListValue(value)
+        case Some(list) ⇒
+          list += value
+        case _ ⇒ // do nothing
+      }
+    }
+
+
+    if (collectedValues.isEmpty) None
+    else {
+      val collectedKeys = collectedValues.keySet
+      val builder = m.emptyMapNode(origVariables.keys.filterNot(collectedKeys.contains).toSeq ++ collectedKeys)
+
+      collectedValues.foreach { case (key, values) ⇒
+        if (isListVariable(opName, plan, key))
+          m.addMapNodeElem(builder, key, m.arrayNode(values.toVector.asInstanceOf[Vector[m.Node]]), false)
+        else if (values.nonEmpty)
+          m.addMapNodeElem(builder, key, values.head.asInstanceOf[m.Node], false)
+      }
+
+      // add original vars
+      origVariables.foreach { case (key, value) ⇒
+        if (!collectedValues.contains(key))
+          m.addMapNodeElem(builder, key, value.asInstanceOf[m.Node], false)
+      }
+
+      Some(m.mapNode(builder).asInstanceOf[M])
+    }
+  }
+
+  private def isListVariable(opName: String, plan: BatchExecutionPlan, variableName: String): Boolean = {
+    val op = plan.exportOperations(opName)
+
+    op.variableDefs.find(_.name == variableName) match {
+      case Some(definition) ⇒ isInputList(definition.tpe)
+      case None ⇒ op.variableUsages.find(_.node.name == variableName) match {
+        case Some(usage) if usage.tpe.isDefined ⇒ isInputList(usage.tpe.get)
+        case _ ⇒ true
+      }
+    }
+  }
+
+  private def isInputList(tpe: Type): Boolean = tpe match {
+    case _: ListInputType[_] ⇒ true
+    case OptionInputType(ofType) ⇒ isInputList(ofType)
+    case _ ⇒ false
+  }
+
+  private def isInputList(tpe: ast.Type): Boolean = tpe match {
+    case _: ast.ListType ⇒ true
+    case ast.NotNullType(ofType, _) ⇒ isInputList(ofType)
+    case _ ⇒ false
+  }
+
+  private def executeIndividual[Ctx, Root, Input](
+    executor: Executor[Ctx, Root],
+    queryAst: ast.Document,
+    operationName: String,
+    userContext: Ctx = (),
+    root: Root = (),
+    variables: Input,
+    scheme: ExecutionScheme
+  )(implicit executionContext: ExecutionContext, marshaller: ResultMarshaller, um: InputUnmarshaller[Input]): scheme.Result[Ctx, marshaller.Node] = {
+    implicit val s = scheme
+
+    executor.execute(queryAst, userContext, root, Some(operationName), variables).asInstanceOf[scheme.Result[Ctx, marshaller.Node]]
+  }
+
+  private def validateOperationNames(document: ast.Document, operationNames: Seq[String], exceptionHandler: Executor.ExceptionHandler): Try[Unit] =
+    if (operationNames.isEmpty)
+      Failure(OperationSelectionError(s"List of operations to execute in batch is empty.", exceptionHandler))
+    else
+      operationNames.find(op ⇒ !document.operations.contains(Some(op))) match {
+        case Some(opName) ⇒ Failure(OperationSelectionError(s"Unknown operation name '$opName'.", exceptionHandler))
+        case None ⇒ Success(())
+      }
+
+  private def calcExecutionPlan(schema: Schema[_, _], queryAst: ast.Document, operationNames: Seq[String], allowedToInferVariableDefinitions: Boolean, exceptionHandler: Executor.ExceptionHandler): Try[(ast.Document, BatchExecutionPlan)] = {
+    val (exportOperations, exportFragments) = findUsages(schema, queryAst, operationNames)
+
+    val collectResult =
+      exportOperations.foldLeft(Success(exportOperations): Try[mutable.HashMap[String, ExportOperation]]) {
+        case (s @ Success(ops), (opName, op)) ⇒
+          collectFragmentInfo(op, exportFragments, exceptionHandler) match {
+            case Success(o) ⇒
+              ops(opName) = o
+              s
+
+            case Failure(e) ⇒ Failure(e)
+          }
+        case (f @ Failure(_), _) ⇒ f
+      }
+
+    collectResult
+      .flatMap { _ ⇒
+        if (allowedToInferVariableDefinitions)
+          inferVariableDefinitions(exportOperations, queryAst, exceptionHandler)
+        else {
+          val violations =
+            exportOperations.values.flatMap { op ⇒
+              findUndefinedVariableUsages(op).map(UndefinedVariableDefinitionViolation(op.operationName, _, queryAst.sourceMapper, op.variableUsages.flatMap(_.node.position).toList))
+            }
+
+          if (violations.nonEmpty)
+            Failure(BatchExecutionViolationError(violations.toVector, exceptionHandler))
+          else
+            Success(queryAst)
+        }
+      }
+      .flatMap { updatedQueryAst ⇒
+        val exportedVars = findExportedVariableNames(exportOperations)
+        val dependencies = findOperationDependencies(exportOperations, exportedVars)
+
+        validateCircularOperationDependencies(updatedQueryAst, dependencies, exceptionHandler)
+      }
+      .map { case (updatedQueryAst, dependencies) ⇒
+        updatedQueryAst → BatchExecutionPlan(exportOperations.toMap, dependencies)
+      }
+  }
+
+  private def validateCircularOperationDependencies(queryAst: ast.Document, dependencies: Map[String, Vector[(String, Set[String])]], exceptionHandler: Executor.ExceptionHandler): Try[(ast.Document, Map[String, Vector[(String, Set[String])]])] = {
+    val violations = new mutable.ListBuffer[Violation]
+
+    def loop(src: String, deps: Vector[(String, Set[String])], path: Vector[(String, String)]): Unit =
+      if (path.exists(_._1 == src))
+        violations += CircularOperationDependencyViolation(src, path.map(_._2), queryAst.sourceMapper, queryAst.operations(Some(src)).position.toList)
+      else {
+        deps.foreach { d ⇒
+          loop(d._1, dependencies(d._1), path :+ (src, s"$src(${d._2.map("$" + _).mkString(", ")})"))
+        }
+      }
+
+    dependencies.foreach { case (op, deps) ⇒
+      loop(op, deps, Vector.empty)
+    }
+
+    if (violations.nonEmpty)
+      Failure(BatchExecutionViolationError(violations.toVector, exceptionHandler))
+    else
+      Success(queryAst → dependencies)
+  }
+
+  private def findOperationDependencies(exportOperations: mutable.HashMap[String, ExportOperation], exportedVars: Set[String]): Map[String, Vector[(String, Set[String])]] =
+    exportOperations.values.map { src ⇒
+      val requires = (src.variableDefs.map(_.name).filter(exportedVars.contains) ++ src.variableUsages.map(_.node.name).filter(exportedVars.contains)).toSet
+
+      val providers = exportOperations.values.map(dst ⇒ dst.operationName → dst.exports.map(_.exportedName).toSet.intersect(requires)).filter(_._2.nonEmpty)
+
+      src.operationName → providers.toVector
+    }.toMap
+
+  private def findExportedVariableNames(exportOperations: mutable.HashMap[String, ExportOperation]): Set[String] =
+    exportOperations.values.flatMap(_.exports.map(_.exportedName)).toSet
+
+  private def inferVariableDefinitions(exportOperations: mutable.HashMap[String, ExportOperation], queryAst: ast.Document, exceptionHandler: Executor.ExceptionHandler): Try[ast.Document] = {
+    val inferenceViolations = new mutable.ListBuffer[Violation]
+
+    val updatedDocument =
+      AstVisitor.visit(queryAst, AstVisitor {
+        case od: ast.OperationDefinition if od.name.isDefined && exportOperations.contains(od.name.get) ⇒
+          val exportOperation = exportOperations(od.name.get)
+          val undefined = findUndefinedVariableUsages(exportOperation)
+
+          val usagesByName = exportOperation.variableUsages.groupBy(_.node.name)
+
+          val newVariableDefs = new mutable.ListBuffer[ast.VariableDefinition]
+
+          undefined.foreach { ud ⇒
+            val allUsages = usagesByName(ud)
+            val first = allUsages.head
+            val firstType = first.tpe.getOrElse(throw new IllegalStateException("Variable usage type is not detected, but expected at this point!"))
+            val firstAstType = SchemaRenderer.renderTypeNameAst(firstType)
+            val tail = allUsages.tail
+
+            val violations = new mutable.ListBuffer[Violation]
+
+            tail.foreach { curr ⇒
+              val currType = first.tpe.getOrElse(throw new IllegalStateException("Variable usage type is not detected, but expected at this point!"))
+              val currAstType = SchemaRenderer.renderTypeNameAst(currType)
+
+              if (firstAstType != currAstType)
+                violations += VariableDefinitionInferenceViolation(
+                  exportOperation.operationName,
+                  ud,
+                  firstAstType.renderPretty,
+                  currAstType.renderPretty,
+                  queryAst.sourceMapper,
+                  first.node.position.toList ++ curr.node.position.toList)
+            }
+
+            if (violations.nonEmpty)
+              inferenceViolations ++= violations
+            else
+              newVariableDefs += ast.VariableDefinition(ud, firstAstType, None, Vector(ast.Comment("Inferred variable")))
+          }
+
+          if (newVariableDefs.nonEmpty && inferenceViolations.isEmpty)
+            VisitorCommand.Transform(od.copy(variables = od.variables ++ newVariableDefs))
+          else
+            VisitorCommand.Continue
+      })
+
+    if (inferenceViolations.nonEmpty)
+      Failure(BatchExecutionViolationError(inferenceViolations.toVector, exceptionHandler))
+    else
+      Success(updatedDocument)
+  }
+
+  private def findUndefinedVariableUsages(exportOperation: ExportOperation) = {
+    val defs = exportOperation.variableDefs.map(_.name).toSet
+    val usages = exportOperation.variableUsages.map(_.node.name).toSet
+
+    usages diff defs
+  }
+
+  private def collectFragmentInfo(exportOperation: ExportOperation, exportFragments: mutable.HashMap[String, ExportFragment], exceptionHandler: Executor.ExceptionHandler): Try[ExportOperation] = {
+    val currentExports = new mutable.ListBuffer[Export]
+    val currentVariables = new mutable.ListBuffer[VariableUsage]
+
+    val recursive = new mutable.HashSet[String]
+    val unknown = new mutable.HashSet[String]
+
+
+    def loop(spreads: Set[SpreadInfo], seenFragmentNames: Set[String], path: Vector[String]): Unit = {
+      spreads.foreach { s ⇒
+        if (seenFragmentNames.contains(s.fragmentName))
+          recursive += s.fragmentName
+        else
+          exportFragments.get(s.fragmentName) match {
+            case Some(f) ⇒
+              val spreadPath = path ++ s.path
+
+              currentExports ++= f.exports.map(e ⇒ e.copy(path = spreadPath ++ e.path))
+              currentVariables ++= f.variableUsages
+
+              loop(f.fragmentSpreads, seenFragmentNames + s.fragmentName, spreadPath)
+            case None ⇒
+              unknown += s.fragmentName
+          }
+      }
+    }
+
+    loop(exportOperation.fragmentSpreads, Set.empty, Vector.empty)
+
+    if (recursive.nonEmpty)
+      Failure(BatchExecutionError(s"Query contains recursive fragments: ${recursive.mkString(", ")}.", exceptionHandler))
+    else if (unknown.nonEmpty)
+      Failure(BatchExecutionError(s"Query contains undefined fragments: ${unknown.mkString(", ")}.", exceptionHandler))
+    else if (currentExports.nonEmpty || currentVariables.nonEmpty)
+      Success(exportOperation.copy(
+        exports = exportOperation.exports ++ currentExports.toVector,
+        variableUsages = exportOperation.variableUsages ++ currentVariables.toVector))
+    else
+      Success(exportOperation)
+  }
+
+  private def findUsages(schema: Schema[_, _], queryAst: ast.Document, operationNames: Seq[String]): (mutable.HashMap[String, ExportOperation], mutable.HashMap[String, ExportFragment]) = {
+    var currentOperation: Option[String] = None
+    var currentFragment: Option[String] = None
+
+    val currentSpreads = new mutable.HashSet[SpreadInfo]
+    val currentDirectives = new mutable.ListBuffer[Export]
+    val currentVariableDefs = new mutable.ListBuffer[ast.VariableDefinition]
+    val currentVariables = new mutable.ListBuffer[VariableUsage]
+
+    val exportOperations = new mutable.HashMap[String, ExportOperation]
+    val exportFragments = new mutable.HashMap[String, ExportFragment]
+
+    AstVisitor.visitAstWithTypeInfo(schema, queryAst)(typeInfo ⇒ AstVisitor(
+      onEnter = {
+        case op: ast.OperationDefinition if op.name.isDefined && !operationNames.contains(op.name.get) ⇒
+          VisitorCommand.Skip
+
+        case op: ast.OperationDefinition if op.name.isDefined ⇒
+          currentOperation = op.name
+          VisitorCommand.Continue
+
+        case fd: ast.FragmentDefinition ⇒
+          currentFragment = Some(fd.name)
+          VisitorCommand.Continue
+
+        case fs: ast.FragmentSpread if currentOperation.isDefined || currentFragment.isDefined ⇒
+          currentSpreads += SpreadInfo(fs.name, calcPath(typeInfo))
+          VisitorCommand.Continue
+
+        case vd: ast.VariableDefinition if currentOperation.isDefined || currentFragment.isDefined ⇒
+          currentVariableDefs += vd
+          VisitorCommand.Continue
+
+        case vv: ast.VariableValue if currentOperation.isDefined || currentFragment.isDefined ⇒
+          currentVariables += VariableUsage(vv, typeInfo.inputType)
+          VisitorCommand.Continue
+
+        case field: ast.Field if currentOperation.isDefined || currentFragment.isDefined ⇒
+          field.directives.find(_.name == ExportDirective.name) match {
+            case Some(d) ⇒ d.arguments.find(_.name == AsArg.name) match {
+              case Some(ast.Argument(_, ast.StringValue(as, _, _), _, _)) if typeInfo.fieldDef.isDefined ⇒
+                currentDirectives += Export(as, calcPath(typeInfo), d, typeInfo.fieldDef.get.fieldType)
+                VisitorCommand.Continue
+              case _ ⇒ VisitorCommand.Continue
+            }
+            case None ⇒ VisitorCommand.Continue
+          }
+      },
+
+      onLeave = {
+        case od: ast.OperationDefinition if od.name.isDefined ⇒
+          val name = od.name.get
+
+          currentOperation = None
+
+          exportOperations(name) = ExportOperation(name,
+            currentVariableDefs.toVector,
+            currentVariables.toVector,
+            currentDirectives.toVector,
+            currentSpreads.toSet)
+
+          currentSpreads.clear()
+          currentDirectives.clear()
+          currentVariableDefs.clear()
+          currentVariables.clear()
+
+          VisitorCommand.Continue
+
+        case fd: ast.FragmentDefinition ⇒
+          currentFragment = None
+
+          exportFragments(fd.name) = ExportFragment(fd.name,
+            currentVariables.toVector,
+            currentDirectives.toVector,
+            currentSpreads.toSet)
+
+          currentSpreads.clear()
+          currentDirectives.clear()
+          currentVariableDefs.clear()
+          currentVariables.clear()
+
+          VisitorCommand.Continue
+      }
+    ))
+
+    exportOperations → exportFragments
+  }
+
+  private def calcPath(typeInfo: TypeInfo) =
+    typeInfo.ancestors.collect{case f: ast.Field ⇒ f.outputName}.toVector
+}

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -36,7 +36,7 @@ object BatchExecutor {
     variables: Input = emptyMapVars,
     queryValidator: QueryValidator = QueryValidator.default,
     deferredResolver: DeferredResolver[Ctx] = DeferredResolver.empty,
-    exceptionHandler: Executor.ExceptionHandler = PartialFunction.empty,
+    exceptionHandler: ExceptionHandler = ExceptionHandler.empty,
     deprecationTracker: DeprecationTracker = DeprecationTracker.empty,
     middleware: List[Middleware[Ctx]] = Nil,
     maxQueryDepth: Option[Int] = None,
@@ -248,7 +248,7 @@ object BatchExecutor {
     executor.execute(queryAst, userContext, root, Some(operationName), variables).asInstanceOf[scheme.Result[Ctx, marshaller.Node]]
   }
 
-  private def validateOperationNames(document: ast.Document, operationNames: Seq[String], exceptionHandler: Executor.ExceptionHandler): Try[Unit] =
+  private def validateOperationNames(document: ast.Document, operationNames: Seq[String], exceptionHandler: ExceptionHandler): Try[Unit] =
     if (operationNames.isEmpty)
       Failure(OperationSelectionError(s"List of operations to execute in batch is empty.", exceptionHandler))
     else
@@ -257,7 +257,7 @@ object BatchExecutor {
         case None ⇒ Success(())
       }
 
-  private def calcExecutionPlan(schema: Schema[_, _], queryAst: ast.Document, operationNames: Seq[String], allowedToInferVariableDefinitions: Boolean, exceptionHandler: Executor.ExceptionHandler): Try[(ast.Document, BatchExecutionPlan)] = {
+  private def calcExecutionPlan(schema: Schema[_, _], queryAst: ast.Document, operationNames: Seq[String], allowedToInferVariableDefinitions: Boolean, exceptionHandler: ExceptionHandler): Try[(ast.Document, BatchExecutionPlan)] = {
     val (exportOperations, exportFragments) = findUsages(schema, queryAst, operationNames)
 
     val collectResult =
@@ -300,7 +300,7 @@ object BatchExecutor {
       }
   }
 
-  private def validateCircularOperationDependencies(queryAst: ast.Document, dependencies: Map[String, Vector[(String, Set[String])]], exceptionHandler: Executor.ExceptionHandler): Try[(ast.Document, Map[String, Vector[(String, Set[String])]])] = {
+  private def validateCircularOperationDependencies(queryAst: ast.Document, dependencies: Map[String, Vector[(String, Set[String])]], exceptionHandler: ExceptionHandler): Try[(ast.Document, Map[String, Vector[(String, Set[String])]])] = {
     val violations = new mutable.ListBuffer[Violation]
 
     def loop(src: String, deps: Vector[(String, Set[String])], path: Vector[(String, String)]): Unit =
@@ -334,7 +334,7 @@ object BatchExecutor {
   private def findExportedVariableNames(exportOperations: mutable.HashMap[String, ExportOperation]): Set[String] =
     exportOperations.values.flatMap(_.exports.map(_.exportedName)).toSet
 
-  private def inferVariableDefinitions(exportOperations: mutable.HashMap[String, ExportOperation], queryAst: ast.Document, exceptionHandler: Executor.ExceptionHandler): Try[ast.Document] = {
+  private def inferVariableDefinitions(exportOperations: mutable.HashMap[String, ExportOperation], queryAst: ast.Document, exceptionHandler: ExceptionHandler): Try[ast.Document] = {
     val inferenceViolations = new mutable.ListBuffer[Violation]
 
     val updatedDocument =
@@ -395,7 +395,7 @@ object BatchExecutor {
     usages diff defs
   }
 
-  private def collectFragmentInfo(exportOperation: ExportOperation, exportFragments: mutable.HashMap[String, ExportFragment], exceptionHandler: Executor.ExceptionHandler): Try[ExportOperation] = {
+  private def collectFragmentInfo(exportOperation: ExportOperation, exportFragments: mutable.HashMap[String, ExportFragment], exceptionHandler: ExceptionHandler): Try[ExportOperation] = {
     val currentExports = new mutable.ListBuffer[Export]
     val currentVariables = new mutable.ListBuffer[VariableUsage]
 

--- a/src/main/scala/sangria/execution/batch/batchViolations.scala
+++ b/src/main/scala/sangria/execution/batch/batchViolations.scala
@@ -1,0 +1,23 @@
+package sangria.execution.batch
+
+import org.parboiled2.Position
+import sangria.execution.{ExecutionError, Executor, QueryAnalysisError, WithViolations}
+import sangria.parser.SourceMapper
+import sangria.validation.{AstNodeViolation, Violation}
+
+case class BatchExecutionError(message: String, eh: Executor.ExceptionHandler) extends ExecutionError(message, eh) with QueryAnalysisError
+
+case class VariableDefinitionInferenceViolation(operationName: String, variableName: String, type1: String, type2: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+  lazy val simpleErrorMessage = s"Inferred variable '$$$variableName' in operation '$operationName' is used with two conflicting types: '$type1' and '$type2'."
+}
+
+case class UndefinedVariableDefinitionViolation(operationName: String, variableName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+  lazy val simpleErrorMessage = s"Variable '$$$variableName' is not defined in the operation '$operationName'."
+}
+
+case class CircularOperationDependencyViolation(operationName: String, path: Vector[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+  lazy val simpleErrorMessage = s"Operation '$operationName' has a circular dependency at path '${path.mkString(" -> ")} -> $operationName'."
+}
+
+case class BatchExecutionViolationError(violations: Vector [Violation], eh: Executor.ExceptionHandler) extends ExecutionError(
+  s"Invalid batch query. Violations:\n\n${violations map (_.errorMessage) mkString "\n\n"}", eh) with QueryAnalysisError with WithViolations

--- a/src/main/scala/sangria/execution/middleware.scala
+++ b/src/main/scala/sangria/execution/middleware.scala
@@ -77,7 +77,7 @@ object Middleware {
     else None
   }
 
-  def simpleExtension[Ctx](extensionFn: MiddlewareQueryContext[Ctx, _, _] ⇒ ast.Value) =
+  def simpleExtension[Ctx](extensionFn: MiddlewareQueryContext[Ctx, _, _] ⇒ ast.Value): Middleware[Ctx] =
     new SimpleAstBasedExtensionMiddleware[Ctx](extensionFn)
 }
 

--- a/src/main/scala/sangria/execution/middleware.scala
+++ b/src/main/scala/sangria/execution/middleware.scala
@@ -76,6 +76,9 @@ object Middleware {
       })
     else None
   }
+
+  def simpleExtension[Ctx](extensionFn: MiddlewareQueryContext[Ctx, _, _] ⇒ ast.Value) =
+    new SimpleAstBasedExtensionMiddleware[Ctx](extensionFn)
 }
 
 trait MiddlewareBeforeField[Ctx] extends Middleware[Ctx] {

--- a/src/main/scala/sangria/marshalling/ImprovedMarshallingUtil.scala
+++ b/src/main/scala/sangria/marshalling/ImprovedMarshallingUtil.scala
@@ -1,0 +1,40 @@
+package sangria.marshalling
+
+// copy/pasted upd-to-date version from sangria-marshalling-api (TODO: remove as soon as it is released)
+object ImprovedMarshallingUtil {
+  def convert[In: InputUnmarshaller, Out: ResultMarshallerForType](value: In): Out = {
+    val iu = implicitly[InputUnmarshaller[In]]
+    val rm = implicitly[ResultMarshallerForType[Out]].marshaller
+
+    val converted = value match {
+      case nil if !iu.isDefined(nil) ⇒ rm.nullNode
+      case map if iu.isMapNode(map) ⇒
+        val keys = iu.getMapKeys(map)
+        val builder = keys.foldLeft(rm.emptyMapNode(keys.toSeq)) {
+          case (acc, key) ⇒
+            iu.getMapValue(map, key) match {
+              case Some(v) ⇒ rm.addMapNodeElem(acc, key, convert(v).asInstanceOf[rm.Node], optional = false)
+              case None ⇒ acc
+            }
+        }
+
+        rm.mapNode(builder)
+      case list if iu.isListNode(list) ⇒
+        rm.mapAndMarshal(iu.getListValue(list), (elem: In) ⇒ convert(elem).asInstanceOf[rm.Node])
+      case enum if iu.isEnumNode(enum) && iu.getScalaScalarValue(enum).isInstanceOf[String] ⇒
+        rm.enumNode(iu.getScalaScalarValue(enum).asInstanceOf[String], "Conversion")
+      case scalar if iu.isScalarNode(scalar) ⇒
+        rm.scalarNode(iu.getScalaScalarValue(scalar), "Conversion", Set.empty)
+      case variable if iu.isVariableNode(variable) ⇒
+        throw new IllegalArgumentException(s"Variable '${iu.getVariableName(value)}' found in the input, but variables are not supported in conversion!")
+      case node ⇒
+        throw new IllegalStateException(s"Unexpected node '$node'!")
+    }
+
+    converted.asInstanceOf[Out]
+  }              
+
+  implicit class MarshaledConverter[In : InputUnmarshaller](in: In) {
+    def convertMarshaled[Out : ResultMarshallerForType] = convert(in)
+  }
+}

--- a/src/main/scala/sangria/marshalling/SymmetricMarshaller.scala
+++ b/src/main/scala/sangria/marshalling/SymmetricMarshaller.scala
@@ -1,0 +1,23 @@
+package sangria.marshalling
+
+trait SymmetricMarshaller[T] {
+  def marshaller: ResultMarshaller
+  def inputUnmarshaller: InputUnmarshaller[T]
+}
+
+object SymmetricMarshaller extends SymmetricMarshallerLowProImplicits {
+  case class DefaultSymmetricMarshaller[T](marshaller: ResultMarshaller, inputUnmarshaller: InputUnmarshaller[T]) extends SymmetricMarshaller[T]
+
+  implicit def symmetric[T : ResultMarshallerForType : InputUnmarshaller]: SymmetricMarshaller[T] =
+    DefaultSymmetricMarshaller(implicitly[ResultMarshallerForType[T]].marshaller, implicitly[InputUnmarshaller[T]])
+}
+
+abstract class SymmetricMarshallerLowProImplicits {
+  val defaultInput =
+    SymmetricMarshaller.DefaultSymmetricMarshaller[Any](
+      scalaMarshalling.scalaResultMarshaller,
+      scalaMarshalling.scalaInputUnmarshaller[Any].asInstanceOf[InputUnmarshaller[Any]])
+
+  // `T =:= Any` is the only constraint that makes type inference work
+  implicit def default[T](implicit ev: T =:= Any): SymmetricMarshaller[T] = defaultInput.asInstanceOf[SymmetricMarshaller[T]]
+}

--- a/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -21,7 +21,7 @@ object SchemaRenderer {
     loop(tpe, if (topLevel) "" else "!")
   }
 
-  private def renderTypeNameAst(tpe: Type, topLevel: Boolean = false) = {
+  def renderTypeNameAst(tpe: Type, topLevel: Boolean = false) = {
     def nn(tpe: ast.Type, notNull: Boolean) =
       if (notNull) ast.NotNullType(tpe)
       else tpe

--- a/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
+++ b/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
@@ -12,6 +12,7 @@ class BatchExecutorSpec extends WordSpec with Matchers with FutureResultSupport 
   val IdsArg = Argument("ids", ListInputType(IntType))
   val IdArg = Argument("id", IntType)
   val NameArg = Argument("name", StringType)
+  val NamesArg = Argument("names", ListInputType(StringType))
 
   val DataType = ObjectType("Data", fields[Unit, Int](
     Field("id", IntType, resolve = _.value)))
@@ -20,9 +21,14 @@ class BatchExecutorSpec extends WordSpec with Matchers with FutureResultSupport 
     Field("ids", ListType(IntType), resolve = _ ⇒ List(1, 2)),
     Field("ids1", ListType(IntType), resolve = _ ⇒ List(4, 5)),
     Field("ids2", ListType(IntType), resolve = _ ⇒ Nil),
+    Field("name1", StringType, resolve = _ ⇒ "some name 1"),
+    Field("name2", OptionType(StringType), resolve = _ ⇒ "some name 2"),
     Field("greet", StringType,
       arguments = NameArg :: Nil,
       resolve = c ⇒ s"Hello, ${c arg NameArg}!"),
+    Field("greetAll", StringType,
+      arguments = NamesArg :: Nil,
+      resolve = c ⇒ s"Hello, ${c arg NamesArg mkString " and "}!"),
     Field("nested", QueryType, resolve = _ ⇒ ()),
     Field("stuff", ListType(DataType),
       arguments = IdsArg :: Nil,
@@ -128,6 +134,90 @@ class BatchExecutorSpec extends WordSpec with Matchers with FutureResultSupport 
             "stuff1": "1, 2, 4, 5, 4, 5, 111, 222, 444",
             "single": { "id": 1 },
             "greet": "Hello, Bob!"
+          }
+        }
+        """).map(_.parseJson)
+
+      res.toListL.runAsync.await.toSet should be (expectedResults)
+    }
+
+    "take the first element of the list" in {
+      val query =
+        gql"""
+          query q1 {
+            name2 @export(as: "name")
+            nested {
+              ...Foo
+            }
+          }
+
+          fragment Foo on Query {
+            name1 @export(as: "name")
+          }
+
+          query q2 {
+            greet(name: $$name)
+          }
+
+          query q3 {
+            ...Bar
+          }
+
+          fragment Bar on Query {
+            greetAll(names: $$name)
+          }
+
+          query q4 {
+            greet(name: $$name)
+          }
+        """
+
+      import monix.execution.Scheduler.Implicits.global
+      import sangria.execution.ExecutionScheme.Stream
+      import sangria.marshalling.sprayJson._
+      import sangria.streaming.monix._
+
+      val res = BatchExecutor.executeBatch(schema, query,
+        operationNames = List("q3", "q1", "q2"),
+        middleware = BatchExecutor.OperationNameExtension :: Nil)
+
+      val expectedResults = Set(
+        """
+        {
+          "data": {
+            "name2": "some name 2",
+            "nested": {
+              "name1": "some name 1"
+            }
+          },
+          "extensions": {
+            "batch": {
+              "operationName": "q1"
+            }
+          }
+        }
+        """,
+        """
+        {
+          "data": {
+            "greet": "Hello, some name 2!"
+          },
+          "extensions": {
+            "batch": {
+              "operationName": "q2"
+            }
+          }
+        }
+        """,
+        """
+        {
+          "data": {
+            "greetAll": "Hello, some name 2 and some name 1!"
+          },
+          "extensions": {
+            "batch": {
+              "operationName": "q3"
+            }
           }
         }
         """).map(_.parseJson)

--- a/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
+++ b/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
@@ -1,0 +1,138 @@
+package sangria.execution.batch
+
+import scala.language.higherKinds
+import org.scalatest.{Matchers, WordSpec}
+import sangria.macros._
+import sangria.marshalling._
+import sangria.schema._
+import sangria.util.FutureResultSupport
+import spray.json._
+
+class BatchExecutorSpec extends WordSpec with Matchers with FutureResultSupport {
+  val IdsArg = Argument("ids", ListInputType(IntType))
+  val IdArg = Argument("id", IntType)
+  val NameArg = Argument("name", StringType)
+
+  val DataType = ObjectType("Data", fields[Unit, Int](
+    Field("id", IntType, resolve = _.value)))
+
+  lazy val QueryType: ObjectType[Unit, Unit] = ObjectType("Query", () ⇒ fields[Unit, Unit](
+    Field("ids", ListType(IntType), resolve = _ ⇒ List(1, 2)),
+    Field("ids1", ListType(IntType), resolve = _ ⇒ List(4, 5)),
+    Field("ids2", ListType(IntType), resolve = _ ⇒ Nil),
+    Field("greet", StringType,
+      arguments = NameArg :: Nil,
+      resolve = c ⇒ s"Hello, ${c arg NameArg}!"),
+    Field("nested", QueryType, resolve = _ ⇒ ()),
+    Field("stuff", ListType(DataType),
+      arguments = IdsArg :: Nil,
+      resolve = _.arg(IdsArg)),
+    Field("single", DataType,
+      arguments = IdArg :: Nil,
+      resolve = _.arg(IdArg)),
+    Field("stuff1", StringType,
+      arguments = IdsArg :: Nil,
+      resolve = _.arg(IdsArg).mkString(", "))
+  ))
+
+  val schema = Schema(QueryType, directives = BuiltinDirectives :+ BatchExecutor.ExportDirective)
+
+  "BatchExecutor" should {
+    "Batch multiple queries and ensure correct execution order" in {
+      val query =
+        gql"""
+          query q1 {
+            ids @export(as: "ids")
+            foo: ids @export(as: "foo")
+            nested {
+              ...Foo
+            }
+          }
+
+          fragment Foo on Query {
+            ids1 @export(as: "ids")
+            aaa: ids1 @export(as: "ids")
+          }
+
+          query q2($$name: String!) {
+            stuff(ids: $$ids) {id}
+
+            ...Bar
+
+            single(id: $$foo) {id}
+
+            greet(name: $$name)
+          }
+
+          fragment Bar on Query {
+            stuff1(ids: $$ids)
+          }
+
+          query q3 {
+            ids2 @export(as: "ids")
+            stuff(ids: 2) {id}
+          }
+        """
+
+      val vars = ScalaInput.scalaInput(Map(
+        "ids" → Vector(111, 222, 444),
+        "bar" → Map("a" → "hello", "b" → "world"),
+        "name" → "Bob"))
+
+      import monix.execution.Scheduler.Implicits.global
+      import sangria.execution.ExecutionScheme.Stream
+      import sangria.marshalling.sprayJson._
+      import sangria.streaming.monix._
+
+      val res = BatchExecutor.executeBatch(schema, query,
+        operationNames = List("q1", "q2", "q3"),
+        variables = vars)
+
+      val expectedResults = Set(
+        """
+        {
+          "data": {
+            "ids": [1, 2],
+            "foo": [1, 2],
+            "nested": {
+              "ids1": [4, 5],
+              "aaa": [4, 5]
+            }
+          }
+        }
+        """,
+        """
+        {
+          "data": {
+            "ids2": [],
+            "stuff": [
+              {"id": 2}
+            ]
+          }
+        }
+        """,
+        """
+        {
+          "data": {
+            "stuff": [
+              {"id": 1},
+              {"id": 2},
+              {"id": 4},
+              {"id": 5},
+              {"id": 4},
+              {"id": 5},
+              {"id": 111},
+              {"id": 222},
+              {"id": 444}
+            ],
+            "stuff1": "1, 2, 4, 5, 4, 5, 111, 222, 444",
+            "single": { "id": 1 },
+            "greet": "Hello, Bob!"
+          }
+        }
+        """).map(_.parseJson)
+
+      res.toListL.runAsync.await.toSet should be (expectedResults)
+    }
+  }
+}

--- a/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
+++ b/src/test/scala/sangria/execution/batch/BatchExecutorSpec.scala
@@ -8,7 +8,6 @@ import sangria.schema._
 import sangria.util.{FutureResultSupport, Pos}
 import spray.json._
 import monix.execution.Scheduler.Implicits.global
-import sangria.execution.{ValidationError, WithViolations}
 import sangria.marshalling.sprayJson._
 import sangria.streaming.monix._
 import sangria.util.SimpleGraphQlSupport.checkContainsViolations


### PR DESCRIPTION
This batch executor implementation is inspired by this talk:

[![batch](https://user-images.githubusercontent.com/156569/28756687-928d7598-7573-11e7-8902-77745768b5e7.png)](https://youtu.be/ViXL0YQnioU?t=10m26s)

It provides following features:

* Allows specifying multiple `operationNames` when executing a GraphQL query document. All operations would be executed in order inferred from the dependencies between queries.
* Support for `@export(as: "foo")` directive. This directive allows you to save the results of the query execution and then use it as a variable in a different query within the same document. This provides a way to define data dependencies between queries.
* When used with `@export` directive, the variables would be automatically inferred by the execution engine, so you don't need to declare them explicitly (though you can)

Here is an example usage (using monix for a streaming and spray-json for data serialization):

```scala
import monix.execution.Scheduler.Implicits.global

import sangria.execution.ExecutionScheme.Stream
import sangria.marshalling.sprayJson._
import sangria.streaming.monix._

val schema = Schema(..., directives = BuiltinDirectives :+ BatchExecutor.ExportDirective)

val result: Observable[JsValue] =
  BatchExecutor.executeBatch(schema, query,
    operationNames = List("q1", "q2", "q3"))
```

You can also check this test for a more detailed example:

https://github.com/sangria-graphql/sangria/pull/273/files#diff-fbc9049ee6fc512d08c46eac6956f066