### PR TITLE
Fixed directive definition rendering in query renderer

### DIFF
--- a/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -434,7 +434,7 @@ object QueryRenderer {
 
         renderComment(dd, prev, indent, config) +
           indent + "directive" + config.separator + "@" + name +
-          renderInputValueDefs(args, indentLevel, config) +
+          renderInputValueDefs(args, indentLevel, config) + (if (args.isEmpty) config.mandatorySeparator else "") +
           "on" + (if (shouldRenderComment(locations.head, None, config)) "" else config.mandatorySeparator) +
           locsRendered.mkString(config.separator + "|")
 

--- a/src/test/scala/sangria/renderer/QueryRendererSpec.scala
+++ b/src/test/scala/sangria/renderer/QueryRendererSpec.scala
@@ -564,7 +564,20 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
       "renders minimal ast" in {
         QueryRenderer.render(ast.ScalarTypeDefinition("DateTime")) should be ("scalar DateTime")
       }
+      "renders directive definitions" in {
+        val directive = ast.DirectiveDefinition("custom", arguments = Vector.empty, locations = Vector(
+          ast.DirectiveLocation("FIELD"), ast.DirectiveLocation("FRAGMENT_SPREAD"), ast.DirectiveLocation("INLINE_FRAGMENT")))
+        val prettyRendered = QueryRenderer.render(directive, QueryRenderer.Pretty)
+        val compactRendered = QueryRenderer.render(directive, QueryRenderer.Compact)
 
+        compactRendered should equal (
+          """directive@custom on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT""".stripMargin
+        ) (after being strippedOfCarriageReturns)
+        prettyRendered should equal (
+          """directive @custom on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT""".stripMargin
+        ) (after being strippedOfCarriageReturns)
+
+      }
       "render kitchen sink" in {
         val Success(ast) = QueryParser.parse(FileUtil loadQuery "schema-kitchen-sink.graphql")
 


### PR DESCRIPTION
Currently if a directive doesn't have any arguments which is possible [per spec](https://facebook.github.io/graphql/#sec-Language.Directives) both compact and pretty printing doesn't have a space between the directive name and `on ...`
So it renders it like so for a directive named "custom"
```graphql
directive @customon FIELD
```
This PR fixes the behaviour so it renders
```graphql
directive @custom on FIELD
```
I didn't updated the kitchen sink test as it's breaking the expectations of the query parser test and I'll be honest I have no idea how to update that one