### PR TITLE
RFC: Resolve type info for fragment spreads

### DIFF
--- a/src/main/scala/sangria/validation/rules/PossibleFragmentSpreads.scala
+++ b/src/main/scala/sangria/validation/rules/PossibleFragmentSpreads.scala
@@ -37,8 +37,8 @@ class PossibleFragmentSpreads extends ValidationRule {
         }
       case fs: ast.FragmentSpread ⇒
         val errors = for {
-          tpe ← getFragmentType(ctx, fs.name)
-          parent ← ctx.typeInfo.parentType
+          tpe ← ctx.typeInfo.tpe
+          parent ← ctx.typeInfo.previousParentType
         } yield
           if (!doTypesOverlap(ctx, tpe, parent))
             Vector(TypeIncompatibleSpreadViolation(
@@ -55,9 +55,6 @@ class PossibleFragmentSpreads extends ValidationRule {
           case _ ⇒ AstVisitorCommand.RightContinue
         }
     }
-
-    def getFragmentType(ctx: ValidationContext, name: String) =
-      ctx.doc.fragments.get(name) flatMap (fd ⇒ ctx.schema.getOutputType(fd.typeCondition, topLevel = true))
 
     def doTypesOverlap(ctx: ValidationContext, type1: Type, type2: Type) = (type1, type2) match {
       case (t1: Named, t2: Named) if t1.name == t2.name ⇒ true


### PR DESCRIPTION
Add document field to TypeInfo so it can resolve fragment definitions
and provide type information for fragment spreads.

---

Motivated by [this case in sangria-codegen](https://github.com/mediative/sangria-codegen/blob/1f36a8458329bbbb2e1b31099811316cbf48d052/sangria-codegen/src/main/scala/com.mediative.sangria.codegen/Importer.scala#L99-L105). This complicates downstreams users of `TypeInfo` by requiring the document AST instance up front. Another way to go would be for `TypeInfo` to keep a "document AST stack" and optionally resolve fragment spreads if a previous `TypeInfo.enter(ast.Document)` call was made.