### PR TITLE
Prepared queries without variables

### DIFF
--- a/src/main/scala/sangria/execution/DeprecationTracker.scala
+++ b/src/main/scala/sangria/execution/DeprecationTracker.scala
@@ -9,7 +9,7 @@ trait DeprecationTracker {
 
 object DeprecationTracker {
   val empty = NilDeprecationTracker
-  val print = PrintingDeprecationTracker
+  val print = new PrintingDeprecationTracker(println)
 }
 
 object NilDeprecationTracker extends DeprecationTracker {
@@ -17,10 +17,10 @@ object NilDeprecationTracker extends DeprecationTracker {
   def deprecatedEnumValueUsed[T, Ctx](enum: EnumType[T], value: T, userContext: Ctx) = ()
 }
 
-object PrintingDeprecationTracker extends DeprecationTracker {
+class PrintingDeprecationTracker(printline: String => Unit) extends DeprecationTracker {
   def deprecatedFieldUsed[Ctx](ctx: Context[Ctx, _]) =
-    println(s"Deprecated field '${ctx.parentType.name}.${ctx.field.name}' used at path '${ctx.path}'.")
+    printline(s"Deprecated field '${ctx.parentType.name}.${ctx.field.name}' used at path '${ctx.path}'.")
 
   def deprecatedEnumValueUsed[T, Ctx](enum: EnumType[T], value: T, userContext: Ctx) =
-    println(s"Deprecated enum value '$value' used of enum '${enum.name}'.")
+    printline(s"Deprecated enum value '$value' used of enum '${enum.name}'.")
 }

--- a/src/main/scala/sangria/execution/DeprecationTracker.scala
+++ b/src/main/scala/sangria/execution/DeprecationTracker.scala
@@ -9,7 +9,7 @@ trait DeprecationTracker {
 
 object DeprecationTracker {
   val empty = NilDeprecationTracker
-  val print = new PrintingDeprecationTracker(println)
+  val print = new LoggingDeprecationTracker(println)
 }
 
 object NilDeprecationTracker extends DeprecationTracker {
@@ -17,10 +17,10 @@ object NilDeprecationTracker extends DeprecationTracker {
   def deprecatedEnumValueUsed[T, Ctx](enum: EnumType[T], value: T, userContext: Ctx) = ()
 }
 
-class PrintingDeprecationTracker(printline: String => Unit) extends DeprecationTracker {
+class LoggingDeprecationTracker(logFn: String => Unit) extends DeprecationTracker {
   def deprecatedFieldUsed[Ctx](ctx: Context[Ctx, _]) =
-    printline(s"Deprecated field '${ctx.parentType.name}.${ctx.field.name}' used at path '${ctx.path}'.")
+    logFn(s"Deprecated field '${ctx.parentType.name}.${ctx.field.name}' used at path '${ctx.path}'.")
 
   def deprecatedEnumValueUsed[T, Ctx](enum: EnumType[T], value: T, userContext: Ctx) =
-    printline(s"Deprecated enum value '$value' used of enum '${enum.name}'.")
+    logFn(s"Deprecated enum value '$value' used of enum '${enum.name}'.")
 }

--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -7,8 +7,8 @@ import sangria.schema._
 import sangria.validation.QueryValidator
 import InputUnmarshaller.emptyMapVars
 import sangria.execution.deferred.DeferredResolver
-
 import scala.concurrent.{ExecutionContext, Future}
+import scala.sangria.execution.QueryReducerExecutor
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -37,12 +37,15 @@ case class Executor[Ctx, Root](
       val valueCollector = new ValueCollector[Ctx, Input](schema, variables, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)(um)
 
       val executionResult = for {
-        operation ← getOperation(queryAst, operationName)
+        operation ← Executor.getOperation(exceptionHandler,queryAst, operationName)
         unmarshalledVariables ← valueCollector.getVariableValues(operation.variables, scalarMiddleware)
         fieldCollector = new FieldCollector[Ctx, Root](schema, queryAst, unmarshalledVariables, queryAst.sourceMapper, valueCollector, exceptionHandler)
-        tpe ← getOperationRootType(operation, queryAst.sourceMapper)
+        tpe ← Executor.getOperationRootType(schema, exceptionHandler, operation, queryAst.sourceMapper)
         fields ← fieldCollector.collectFields(ExecutionPath.empty, tpe, Vector(operation))
       } yield {
+        val argumentValuesFn: QueryReducer.ArgumentValuesFn =
+          (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
+            valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, unmarshalledVariables)
         val preparedFields = fields.fields.flatMap {
           case CollectedField(_, astField, Success(_)) ⇒
             val allFields = tpe.getField(schema, astField.name).asInstanceOf[Vector[Field[Ctx, Root]]]
@@ -53,18 +56,12 @@ case class Executor[Ctx, Root](
           case _ ⇒ None
         }
 
-        reduceQuerySafe(fieldCollector, valueCollector, unmarshalledVariables, tpe, fields, userContext) match {
-          case fut: Future[(Ctx, TimeMeasurement) @unchecked] ⇒
-            fut.map(newCtx ⇒
-              new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx._1, root, preparedFields,
-                (c: Ctx, r: Root, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
-                  executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
-                    fieldCollector, m, unmarshalledVariables, tpe, fields, c, r, scheme, validationTiming, newCtx._2)))
-          case (newCtx: Ctx @unchecked, timing: TimeMeasurement) ⇒
-            Future.successful(new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx, root, preparedFields,
+        QueryReducerExecutor.reduceQuery(schema, queryReducers, exceptionHandler, fieldCollector, argumentValuesFn, tpe, fields, userContext).map {
+          case (newCtx, timing) ⇒
+            new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx, root, preparedFields,
               (c: Ctx, r: Root, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
                 executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
-                  fieldCollector, m, unmarshalledVariables, tpe, fields, c, r, scheme, validationTiming, timing)))
+                  fieldCollector, m, unmarshalledVariables, tpe, fields, c, r, scheme, validationTiming, timing))
         }
       }
 
@@ -90,18 +87,20 @@ case class Executor[Ctx, Root](
       val valueCollector = new ValueCollector[Ctx, Input](schema, variables, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)(um)
 
       val executionResult = for {
-        operation ← getOperation(queryAst, operationName)
+        operation ← Executor.getOperation(exceptionHandler, queryAst, operationName)
         unmarshalledVariables ← valueCollector.getVariableValues(operation.variables, scalarMiddleware)
         fieldCollector = new FieldCollector[Ctx, Root](schema, queryAst, unmarshalledVariables, queryAst.sourceMapper, valueCollector, exceptionHandler)
-        tpe ← getOperationRootType(operation, queryAst.sourceMapper)
+        tpe ← Executor.getOperationRootType(schema, exceptionHandler, operation, queryAst.sourceMapper)
         fields ← fieldCollector.collectFields(ExecutionPath.empty, tpe, Vector(operation))
-      } yield reduceQuerySafe(fieldCollector, valueCollector, unmarshalledVariables, tpe, fields, userContext) match {
-        case fut: Future[(Ctx, TimeMeasurement) @unchecked] ⇒
-          scheme.flatMapFuture(fut)(c ⇒ executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
-            fieldCollector, marshaller, unmarshalledVariables, tpe, fields, c._1, root, scheme, validationTiming, c._2))
-        case (ctx: Ctx @unchecked, timing: TimeMeasurement) ⇒
+      } yield {
+        val argumentValuesFn: QueryReducer.ArgumentValuesFn =
+          (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
+            valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, unmarshalledVariables)
+        val reduced = QueryReducerExecutor.reduceQuery(schema, queryReducers, exceptionHandler, fieldCollector, argumentValuesFn, tpe, fields, userContext)
+        scheme.flatMapFuture(reduced){ case (newCtx, timing) ⇒
           executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
-            fieldCollector, marshaller, unmarshalledVariables, tpe, fields, ctx, root, scheme, validationTiming, timing)
+            fieldCollector, marshaller, unmarshalledVariables, tpe, fields, newCtx, root, scheme, validationTiming, timing)
+        }
       }
 
       executionResult match {
@@ -110,26 +109,6 @@ case class Executor[Ctx, Root](
       }
     }
   }
-
-  def getOperation(document: ast.Document, operationName: Option[String]): Try[ast.OperationDefinition] =
-    if (document.operations.size != 1 && operationName.isEmpty)
-      Failure(OperationSelectionError("Must provide operation name if query contains multiple operations", exceptionHandler))
-    else {
-      val unexpectedDefinition = document.definitions.find(d ⇒ !(d.isInstanceOf[ast.OperationDefinition] || d.isInstanceOf[ast.FragmentDefinition]))
-
-      unexpectedDefinition match {
-        case Some(unexpected) ⇒
-          Failure(new ExecutionError(s"GraphQL cannot execute a request containing a ${unexpected.getClass.getSimpleName}.", exceptionHandler))
-        case None ⇒
-          operationName match {
-            case Some(opName) ⇒
-              document.operations get Some(opName) map (Success(_)) getOrElse
-                Failure(OperationSelectionError(s"Unknown operation name '$opName'", exceptionHandler))
-            case None ⇒
-              Success(document.operations.values.head)
-          }
-      }
-    }
 
   def executeOperation[Input](
         queryAst: ast.Document,
@@ -200,153 +179,6 @@ case class Executor[Ctx, Root](
       }
     }
 
-  def getOperationRootType(operation: ast.OperationDefinition, sourceMapper: Option[SourceMapper]) = operation.operationType match {
-    case ast.OperationType.Query ⇒
-      Success(schema.query)
-    case ast.OperationType.Mutation ⇒
-      schema.mutation map (Success(_)) getOrElse
-        Failure(OperationSelectionError("Schema is not configured for mutations", exceptionHandler, sourceMapper, operation.position.toList))
-    case ast.OperationType.Subscription ⇒
-      schema.subscription map (Success(_)) getOrElse
-        Failure(OperationSelectionError("Schema is not configured for subscriptions", exceptionHandler, sourceMapper, operation.position.toList))
-  }
-
-  // returns either new Ctx or future of it (with time measurement)
-  private def reduceQuerySafe[Val](
-      fieldCollector: FieldCollector[Ctx, Root],
-      valueCollector: ValueCollector[Ctx, _],
-      variables: Map[String, VariableValue],
-      rootTpe: ObjectType[Ctx, Root],
-      fields: CollectedFields,
-      userContext: Ctx): Any =
-    if (queryReducers.nonEmpty) {
-      val startTime = System.currentTimeMillis()
-      val start = System.nanoTime()
-
-      def timeMeasurement[T](res: T) = {
-        val end = System.nanoTime()
-        val endTime = System.currentTimeMillis()
-
-        res → TimeMeasurement(startTime, endTime, end - start)
-      }
-
-      reduceQuery(fieldCollector, valueCollector, variables, rootTpe, fields, queryReducers.toVector, userContext) match {
-        case future: Future[Ctx] ⇒
-          future
-            .map(newCtx ⇒ timeMeasurement(newCtx))
-            .recover { case error: Throwable ⇒ throw QueryReducingError(error, exceptionHandler) }
-        case newCtx: Ctx@unchecked ⇒
-          timeMeasurement(newCtx)
-      }
-    } else userContext → TimeMeasurement.empty
-
-  private def reduceQuery[Val](
-      fieldCollector: FieldCollector[Ctx, Val],
-      valueCollector: ValueCollector[Ctx, _],
-      variables: Map[String, VariableValue],
-      rootTpe: ObjectType[_, _],
-      fields: CollectedFields,
-      reducers: Vector[QueryReducer[Ctx, _]],
-      userContext: Ctx): Any = {
-    // Using mutability here locally in order to reduce footprint
-    import scala.collection.mutable.ListBuffer
-
-    val argumentValuesFn = (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
-      valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, variables)
-
-    val initialValues: Vector[Any] = reducers map (_.initial)
-
-    def loop(path: ExecutionPath, tpe: OutputType[_], astFields: Vector[ast.Field]): Seq[Any] =
-      tpe match {
-        case OptionType(ofType) ⇒ loop(path, ofType, astFields)
-        case ListType(ofType) ⇒ loop(path, ofType, astFields)
-        case objTpe: ObjectType[Ctx, _] ⇒
-          fieldCollector.collectFields(path, objTpe, astFields) match {
-            case Success(ff) ⇒
-              ff.fields.foldLeft(ListBuffer(initialValues: _*)) {
-                case (acc, CollectedField(_, _, Success(fields))) if objTpe.getField(schema, fields.head.name).nonEmpty ⇒
-                  val astField = fields.head
-                  val field = objTpe.getField(schema, astField.name).head
-                  val newPath = path.add(astField, objTpe)
-                  val childReduced = loop(newPath, field.fieldType, fields)
-
-                  for (i ← reducers.indices) {
-                    val reducer = reducers(i)
-
-                    acc(i) = reducer.reduceField[Any](
-                      acc(i).asInstanceOf[reducer.Acc],
-                      childReduced(i).asInstanceOf[reducer.Acc],
-                      newPath, userContext, fields,
-                      objTpe.asInstanceOf[ObjectType[Any, Any]],
-                      field.asInstanceOf[Field[Ctx, Any]], argumentValuesFn)
-                  }
-
-                  acc
-                case (acc, _) ⇒ acc
-              }
-            case Failure(_) ⇒ initialValues
-          }
-        case abst: AbstractType ⇒
-          schema.possibleTypes
-            .get (abst.name)
-            .map (types ⇒
-              types.map(loop(path, _, astFields)).transpose.zipWithIndex.map{
-                case (values, idx) ⇒
-                  val reducer = reducers(idx)
-                  reducer.reduceAlternatives(values.asInstanceOf[Seq[reducer.Acc]])
-              })
-            .getOrElse (initialValues)
-        case s: ScalarType[_] ⇒ reducers map (_.reduceScalar(path, userContext, s))
-        case ScalarAlias(aliasFor, _, _) ⇒ reducers map (_.reduceScalar(path, userContext, aliasFor))
-        case e: EnumType[_] ⇒ reducers map (_.reduceEnum(path, userContext, e))
-        case _ ⇒ initialValues
-      }
-
-    val reduced = fields.fields.foldLeft(ListBuffer(initialValues: _*)) {
-      case (acc, CollectedField(_, _, Success(astFields))) if rootTpe.getField(schema, astFields.head.name).nonEmpty ⇒
-        val astField = astFields.head
-        val field = rootTpe.getField(schema, astField.name).head
-        val path = ExecutionPath.empty.add(astField, rootTpe)
-        val childReduced = loop(path, field.fieldType, astFields)
-
-        for (i ← reducers.indices) {
-          val reducer = reducers(i)
-
-          acc(i) = reducer.reduceField(
-            acc(i).asInstanceOf[reducer.Acc],
-            childReduced(i).asInstanceOf[reducer.Acc],
-            path, userContext, astFields,
-            rootTpe.asInstanceOf[ObjectType[Any, Any]],
-            field.asInstanceOf[Field[Ctx, Any]], argumentValuesFn)
-        }
-
-        acc
-      case (acc, _) ⇒ acc
-    }
-
-    try {
-      // Unsafe part to avoid addition boxing in order to reduce the footprint
-      reducers.zipWithIndex.foldLeft(userContext: Any) {
-        case (acc: Future[Ctx], (reducer, idx)) ⇒
-          acc.flatMap(a ⇒ reducer.reduceCtx(reduced(idx).asInstanceOf[reducer.Acc], a) match {
-            case FutureValue(future) ⇒ future
-            case Value(value) ⇒ Future.successful(value)
-            case TryValue(value) ⇒ Future.fromTry(value)
-          })
-
-        case (acc: Ctx @unchecked, (reducer, idx)) ⇒
-          reducer.reduceCtx(reduced(idx).asInstanceOf[reducer.Acc], acc) match {
-            case FutureValue(future) ⇒ future
-            case Value(value) ⇒ value
-            case TryValue(value) ⇒ value.get
-          }
-
-        case (acc, _) ⇒ Future.failed(new IllegalStateException(s"Invalid shape of the user context! $acc"))
-      }
-    } catch {
-      case NonFatal(error) ⇒ Future.failed(error)
-    }
-  }
 }
 
 object Executor {
@@ -387,6 +219,38 @@ object Executor {
   )(implicit executionContext: ExecutionContext, um: InputUnmarshaller[Input]): Future[PreparedQuery[Ctx, Root, Input]] =
     Executor(schema, queryValidator, deferredResolver, exceptionHandler, deprecationTracker, middleware, maxQueryDepth, queryReducers)
       .prepare(queryAst, userContext, root, operationName, variables)
+
+  def getOperationRootType[Ctx, Root](schema: Schema[Ctx, Root], exceptionHandler: ExceptionHandler, operation: ast.OperationDefinition, sourceMapper: Option[SourceMapper]) = operation.operationType match {
+    case ast.OperationType.Query ⇒
+      Success(schema.query)
+    case ast.OperationType.Mutation ⇒
+      schema.mutation map (Success(_)) getOrElse
+        Failure(OperationSelectionError("Schema is not configured for mutations", exceptionHandler, sourceMapper, operation.position.toList))
+    case ast.OperationType.Subscription ⇒
+      schema.subscription map (Success(_)) getOrElse
+        Failure(OperationSelectionError("Schema is not configured for subscriptions", exceptionHandler, sourceMapper, operation.position.toList))
+  }
+
+  def getOperation(exceptionHandler: ExceptionHandler, document: ast.Document, operationName: Option[String]): Try[ast.OperationDefinition] =
+    if (document.operations.size != 1 && operationName.isEmpty)
+      Failure(OperationSelectionError("Must provide operation name if query contains multiple operations", exceptionHandler))
+    else {
+      val unexpectedDefinition = document.definitions.find(d ⇒ !(d.isInstanceOf[ast.OperationDefinition] || d.isInstanceOf[ast.FragmentDefinition]))
+
+      unexpectedDefinition match {
+        case Some(unexpected) ⇒
+          Failure(new ExecutionError(s"GraphQL cannot execute a request containing a ${unexpected.getClass.getSimpleName}.", exceptionHandler))
+        case None ⇒
+          operationName match {
+            case Some(opName) ⇒
+              document.operations get Some(opName) map (Success(_)) getOrElse
+                Failure(OperationSelectionError(s"Unknown operation name '$opName'", exceptionHandler))
+            case None ⇒
+              Success(document.operations.values.head)
+          }
+      }
+    }
+
 }
 
 class PreparedQuery[Ctx, Root, Input] private[execution] (

--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -20,14 +20,65 @@ case class Executor[Ctx, Root](
     deprecationTracker: DeprecationTracker = DeprecationTracker.empty,
     middleware: List[Middleware[Ctx]] = Nil,
     maxQueryDepth: Option[Int] = None,
-    queryReducers: List[QueryReducer[Ctx, _]] = Nil)(implicit executionContext: ExecutionContext) {
+    queryReducers: List[QueryReducer[Ctx, _]] = Nil,
+    preparationQueryReducers: Option[List[QueryReducer[Ctx, _]]] = None
+)(implicit executionContext: ExecutionContext) {
+
+  def prepare[Input](
+    queryAst: ast.Document,
+    userContext: Ctx,
+    root: Root,
+    operationName: Option[String]
+  )(implicit um: InputUnmarshaller[Input]): Future[PreparedQuery[Ctx, Root, Input]] = {
+    val (violations, validationTiming) = TimeMeasurement.measure(queryValidator.validateQuery(schema, queryAst))
+
+    if (violations.nonEmpty)
+      Future.failed(ValidationError(violations, exceptionHandler))
+    else {
+      val scalarMiddleware = Middleware.composeFromScalarMiddleware(middleware, userContext)
+      val reducers = preparationQueryReducers.getOrElse(List.empty)
+
+      val executionResult = for {
+        operation ← getOperation(queryAst, operationName)
+        fieldCollector = new FieldCollector[Ctx, Root](schema, queryAst, Map.empty, queryAst.sourceMapper, null, exceptionHandler)
+        tpe ← getOperationRootType(operation, queryAst.sourceMapper)
+        fields ← fieldCollector.collectFields(ExecutionPath.empty, tpe, Vector(operation))
+      } yield {
+
+        reduceQuerySafe(reducers, fieldCollector, None, Map.empty, tpe, fields, userContext) match {
+          case fut: Future[(Ctx, TimeMeasurement) @unchecked] ⇒
+            fut.map(newCtx ⇒
+              new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx._1, root, Seq.empty,
+                (c: Ctx, r: Root, v: Input, m: ResultMarshaller, scheme: ExecutionScheme) ⇒ {
+                  val valueCollector = new ValueCollector[Ctx, Input](schema, v, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)(um)
+                  val variables = valueCollector.getVariableValues(operation.variables, scalarMiddleware).get
+                  executeOperation(queryAst, operationName, v, um, operation, queryAst.sourceMapper, valueCollector,
+                    fieldCollector, m, variables, tpe, fields, c, r, scheme, validationTiming, newCtx._2)
+                }))
+          case (newCtx: Ctx @unchecked, timing: TimeMeasurement) ⇒
+            Future(new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx, root, Seq.empty,
+              (c: Ctx, r: Root, v: Input, m: ResultMarshaller, scheme: ExecutionScheme) ⇒ {
+                val valueCollector = new ValueCollector[Ctx, Input](schema, v, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)(um)
+                val variables = valueCollector.getVariableValues(operation.variables, scalarMiddleware).get
+                executeOperation(queryAst, operationName, v, um, operation, queryAst.sourceMapper, valueCollector,
+                  fieldCollector, m, variables, tpe, fields, c, r, scheme, validationTiming, timing)
+              }))
+        }
+      }
+
+      executionResult match {
+        case Success(future) ⇒ future
+        case Failure(error) ⇒ Future.failed(error)
+      }
+    }
+  }
 
   def prepare[Input](
       queryAst: ast.Document,
       userContext: Ctx,
       root: Root,
       operationName: Option[String] = None,
-      variables: Input = emptyMapVars)(implicit um: InputUnmarshaller[Input]): Future[PreparedQuery[Ctx, Root, Input]] = {
+      variables: Input)(implicit um: InputUnmarshaller[Input]): Future[PreparedQuery[Ctx, Root, Input]] = {
     val (violations, validationTiming) = TimeMeasurement.measure(queryValidator.validateQuery(schema, queryAst))
 
     if (violations.nonEmpty)
@@ -35,6 +86,7 @@ case class Executor[Ctx, Root](
     else {
       val scalarMiddleware = Middleware.composeFromScalarMiddleware(middleware, userContext)
       val valueCollector = new ValueCollector[Ctx, Input](schema, variables, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)(um)
+      val reducers = preparationQueryReducers.getOrElse(List.empty) ++ queryReducers
 
       val executionResult = for {
         operation ← getOperation(queryAst, operationName)
@@ -53,17 +105,17 @@ case class Executor[Ctx, Root](
           case _ ⇒ None
         }
 
-        reduceQuerySafe(fieldCollector, valueCollector, unmarshalledVariables, tpe, fields, userContext) match {
+        reduceQuerySafe(reducers, fieldCollector, Some(valueCollector), unmarshalledVariables, tpe, fields, userContext) match {
           case fut: Future[(Ctx, TimeMeasurement) @unchecked] ⇒
             fut.map(newCtx ⇒
               new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx._1, root, preparedFields,
-                (c: Ctx, r: Root, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
-                  executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
+                (c: Ctx, r: Root, v: Input, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
+                  executeOperation(queryAst, operationName, v, um, operation, queryAst.sourceMapper, valueCollector,
                     fieldCollector, m, unmarshalledVariables, tpe, fields, c, r, scheme, validationTiming, newCtx._2)))
           case (newCtx: Ctx @unchecked, timing: TimeMeasurement) ⇒
             Future.successful(new PreparedQuery[Ctx, Root, Input](queryAst, operation, tpe, newCtx, root, preparedFields,
-              (c: Ctx, r: Root, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
-                executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
+              (c: Ctx, r: Root, v: Input, m: ResultMarshaller, scheme: ExecutionScheme) ⇒
+                executeOperation(queryAst, operationName, v, um, operation, queryAst.sourceMapper, valueCollector,
                   fieldCollector, m, unmarshalledVariables, tpe, fields, c, r, scheme, validationTiming, timing)))
         }
       }
@@ -95,7 +147,7 @@ case class Executor[Ctx, Root](
         fieldCollector = new FieldCollector[Ctx, Root](schema, queryAst, unmarshalledVariables, queryAst.sourceMapper, valueCollector, exceptionHandler)
         tpe ← getOperationRootType(operation, queryAst.sourceMapper)
         fields ← fieldCollector.collectFields(ExecutionPath.empty, tpe, Vector(operation))
-      } yield reduceQuerySafe(fieldCollector, valueCollector, unmarshalledVariables, tpe, fields, userContext) match {
+      } yield reduceQuerySafe(queryReducers, fieldCollector, Some(valueCollector), unmarshalledVariables, tpe, fields, userContext) match {
         case fut: Future[(Ctx, TimeMeasurement) @unchecked] ⇒
           scheme.flatMapFuture(fut)(c ⇒ executeOperation(queryAst, operationName, variables, um, operation, queryAst.sourceMapper, valueCollector,
             fieldCollector, marshaller, unmarshalledVariables, tpe, fields, c._1, root, scheme, validationTiming, c._2))
@@ -213,8 +265,9 @@ case class Executor[Ctx, Root](
 
   // returns either new Ctx or future of it (with time measurement)
   private def reduceQuerySafe[Val](
+      queryReducers: List[QueryReducer[Ctx, _]],
       fieldCollector: FieldCollector[Ctx, Root],
-      valueCollector: ValueCollector[Ctx, _],
+      valueCollector: Option[ValueCollector[Ctx, _]],
       variables: Map[String, VariableValue],
       rootTpe: ObjectType[Ctx, Root],
       fields: CollectedFields,
@@ -230,7 +283,17 @@ case class Executor[Ctx, Root](
         res → TimeMeasurement(startTime, endTime, end - start)
       }
 
-      reduceQuery(fieldCollector, valueCollector, variables, rootTpe, fields, queryReducers.toVector, userContext) match {
+      val argumentValuesFn =
+        valueCollector match {
+          case Some(valueCollector) =>
+            (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
+              valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, variables)
+          case None =>
+            (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
+              Success(Args.empty.copy(undefinedArgs = argumentDefs.map(_.name).toSet))
+        }
+
+      reduceQuery(queryReducers, fieldCollector, argumentValuesFn, variables, rootTpe, fields, queryReducers.toVector, userContext) match {
         case future: Future[Ctx] ⇒
           future
             .map(newCtx ⇒ timeMeasurement(newCtx))
@@ -241,8 +304,9 @@ case class Executor[Ctx, Root](
     } else userContext → TimeMeasurement.empty
 
   private def reduceQuery[Val](
+      queryReducers: List[QueryReducer[Ctx, _]],
       fieldCollector: FieldCollector[Ctx, Val],
-      valueCollector: ValueCollector[Ctx, _],
+      argumentValuesFn: (ExecutionPath, List[Argument[_]], Vector[ast.Argument]) ⇒ Try[Args],
       variables: Map[String, VariableValue],
       rootTpe: ObjectType[_, _],
       fields: CollectedFields,
@@ -251,8 +315,6 @@ case class Executor[Ctx, Root](
     // Using mutability here locally in order to reduce footprint
     import scala.collection.mutable.ListBuffer
 
-    val argumentValuesFn = (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
-      valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, variables)
 
     val initialValues: Vector[Any] = reducers map (_.initial)
 
@@ -376,17 +438,17 @@ object Executor {
     userContext: Ctx = (),
     root: Root = (),
     operationName: Option[String] = None,
-    variables: Input = emptyMapVars,
     queryValidator: QueryValidator = QueryValidator.default,
     deferredResolver: DeferredResolver[Ctx] = DeferredResolver.empty,
     exceptionHandler: ExceptionHandler = ExceptionHandler.empty,
     deprecationTracker: DeprecationTracker = DeprecationTracker.empty,
     middleware: List[Middleware[Ctx]] = Nil,
     maxQueryDepth: Option[Int] = None,
-    queryReducers: List[QueryReducer[Ctx, _]] = Nil
+    queryReducers: List[QueryReducer[Ctx, _]] = Nil,
+    preparationQueryReducers: Option[List[QueryReducer[Ctx, _]]] = None
   )(implicit executionContext: ExecutionContext, um: InputUnmarshaller[Input]): Future[PreparedQuery[Ctx, Root, Input]] =
     Executor(schema, queryValidator, deferredResolver, exceptionHandler, deprecationTracker, middleware, maxQueryDepth, queryReducers)
-      .prepare(queryAst, userContext, root, operationName, variables)
+      .prepare(queryAst, userContext, root, operationName)
 }
 
 class PreparedQuery[Ctx, Root, Input] private[execution] (
@@ -396,9 +458,9 @@ class PreparedQuery[Ctx, Root, Input] private[execution] (
     val userContext: Ctx,
     val root: Root,
     val fields: Seq[PreparedField[Ctx, Root]],
-    execFn: (Ctx, Root, ResultMarshaller, ExecutionScheme) ⇒ Any) {
-  def execute(userContext: Ctx = userContext, root: Root = root)(implicit marshaller: ResultMarshaller, scheme: ExecutionScheme): scheme.Result[Ctx, marshaller.Node] =
-    execFn(userContext, root, marshaller, scheme).asInstanceOf[scheme.Result[Ctx, marshaller.Node]]
+    execFn: (Ctx, Root, Input, ResultMarshaller, ExecutionScheme) ⇒ Any) {
+  def execute(userContext: Ctx = userContext, root: Root = root, variables: Input)(implicit marshaller: ResultMarshaller, scheme: ExecutionScheme): scheme.Result[Ctx, marshaller.Node] =
+    execFn(userContext, root, variables, marshaller, scheme).asInstanceOf[scheme.Result[Ctx, marshaller.Node]]
 }
 
 case class PreparedField[Ctx, Root](field: Field[Ctx, Root], args: Args)

--- a/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
+++ b/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success}
 
 case class InputDocumentMaterializer[Vars](schema: Schema[_, _], variables: Vars = InputUnmarshaller.emptyMapVars)(implicit iu: InputUnmarshaller[Vars]) {
   def to[T](document: InputDocument, inputType: InputType[T])(implicit fromInput: FromInput[T], scheme: DeliveryScheme[Vector[T]]): scheme.Result = {
-    val collector = new ValueCollector[Unit, Vars](schema, variables, document.sourceMapper, DeprecationTracker.empty, (), ExceptionHandler.empty, None)
+    val collector = new ValueCollector[Unit, Vars](schema, variables, document.sourceMapper, DeprecationTracker.empty, (), ExceptionHandler.empty, None, false)(iu)
 
     val violations = QueryValidator.default.validateInputDocument(schema, document, inputType)
 

--- a/src/main/scala/sangria/execution/QueryReducerExecutor.scala
+++ b/src/main/scala/sangria/execution/QueryReducerExecutor.scala
@@ -1,0 +1,183 @@
+package scala.sangria.execution
+
+import sangria.ast
+import sangria.execution._
+import sangria.marshalling.{InputUnmarshaller, ResultMarshaller, ScalaInput, queryAst}
+import sangria.schema._
+import sangria.util.tag.@@
+import sangria.validation.QueryValidator
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+object QueryReducerExecutor {
+
+  def reduceQueryWithoutVariables[Ctx, Root](
+    schema: Schema[Ctx, Root],
+    queryAst: ast.Document,
+    userContext: Ctx,
+    root: Root,
+    queryReducers: List[QueryReducer[Ctx, _]],
+    operationName: Option[String] = None,
+    queryValidator: QueryValidator = QueryValidator.default,
+    exceptionHandler: ExceptionHandler = ExceptionHandler.empty,
+    deprecationTracker: DeprecationTracker = DeprecationTracker.empty,
+    middleware: List[Middleware[Ctx]] = Nil
+    )(implicit executionContext: ExecutionContext): Future[(Ctx, TimeMeasurement)] = {
+    val violations = queryValidator.validateQuery(schema, queryAst)
+
+    if (violations.nonEmpty)
+      Future.failed(ValidationError(violations, exceptionHandler))
+    else {
+      val scalarMiddleware = Middleware.composeFromScalarMiddleware(middleware, userContext)
+      val valueCollector = new UnknownVariablesValueCollector[Ctx](schema, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)
+
+      val executionResult = for {
+        operation ← Executor.getOperation(exceptionHandler,queryAst, operationName)
+        fieldCollector = new FieldCollector[Ctx, Root](schema, queryAst, Map.empty, queryAst.sourceMapper, valueCollector, exceptionHandler)
+        tpe ← Executor.getOperationRootType(schema, exceptionHandler, operation, queryAst.sourceMapper)
+        fields ← fieldCollector.collectFields(ExecutionPath.empty, tpe, Vector(operation))
+      } yield {
+        val argumentValuesFn: QueryReducer.ArgumentValuesFn =
+          (path: ExecutionPath, argumentDefs: List[Argument[_]], argumentAsts: Vector[ast.Argument]) ⇒
+            valueCollector.getFieldArgumentValues(path, argumentDefs, argumentAsts, Map.empty)
+//            Failure(new IllegalStateException("argument values are not available when reducing without variables"))
+
+        QueryReducerExecutor.reduceQuery(schema, queryReducers, exceptionHandler, fieldCollector, argumentValuesFn, tpe, fields, userContext)
+      }
+
+      executionResult match {
+        case Success(future) ⇒ future
+        case Failure(error) ⇒ Future.failed(error)
+      }
+    }
+  }
+
+  /** Returns either new Ctx or future of it (with time measurement) */
+  def reduceQuery[Ctx, Root, Val](
+    schema: Schema[Ctx, Root],
+    queryReducers: List[QueryReducer[Ctx, _]],
+    exceptionHandler: ExceptionHandler,
+    fieldCollector: FieldCollector[Ctx, Root],
+    argumentValuesFn: QueryReducer.ArgumentValuesFn,
+    rootTpe: ObjectType[Ctx, Root],
+    fields: CollectedFields,
+    userContext: Ctx)(implicit executionContext: ExecutionContext): Future[(Ctx, TimeMeasurement)] =
+    if (queryReducers.nonEmpty) {
+      val sw = StopWatch.start()
+      reduceQueryUnsafe(schema, fieldCollector, argumentValuesFn, rootTpe, fields, queryReducers.toVector, userContext)
+        .map(_ → sw.stop)
+        .recover { case error: Throwable ⇒ throw QueryReducingError(error, exceptionHandler) }
+    } else Future.successful(userContext → TimeMeasurement.empty)
+
+  private def reduceQueryUnsafe[Ctx, Val](
+    schema: Schema[Ctx, _],
+    fieldCollector: FieldCollector[Ctx, Val],
+    argumentValuesFn: QueryReducer.ArgumentValuesFn,
+    rootTpe: ObjectType[Ctx, _],
+    fields: CollectedFields,
+    reducers: Vector[QueryReducer[Ctx, _]],
+    userContext: Ctx)(implicit executionContext: ExecutionContext): Future[Ctx] = {
+    // Using mutability here locally in order to reduce footprint
+
+    val initialValues: Vector[Any] = reducers map (_.initial)
+
+    def loop(path: ExecutionPath, tpe: OutputType[_], astFields: Vector[ast.Field]): Seq[Any] =
+      tpe match {
+        case OptionType(ofType) ⇒ loop(path, ofType, astFields)
+        case ListType(ofType) ⇒ loop(path, ofType, astFields)
+        case objTpe: ObjectType[Ctx @unchecked, _] ⇒
+          fieldCollector.collectFields(path, objTpe, astFields) match {
+            case Success(ff) ⇒
+              ff.fields.foldLeft(Array(initialValues: _*)) {
+                case (acc, CollectedField(_, _, Success(fields))) if objTpe.getField(schema, fields.head.name).nonEmpty ⇒
+                  val astField = fields.head
+                  val field = objTpe.getField(schema, astField.name).head
+                  val newPath = path.add(astField, objTpe)
+                  val childReduced = loop(newPath, field.fieldType, fields)
+
+                  for (i ← reducers.indices) {
+                    val reducer = reducers(i)
+
+                    acc(i) = reducer.reduceField[Any](
+                      acc(i).asInstanceOf[reducer.Acc],
+                      childReduced(i).asInstanceOf[reducer.Acc],
+                      newPath, userContext, fields,
+                      objTpe.asInstanceOf[ObjectType[Any, Any]],
+                      field.asInstanceOf[Field[Ctx, Any]], argumentValuesFn)
+                  }
+
+                  acc
+                case (acc, _) ⇒ acc
+              }
+            case Failure(_) ⇒ initialValues
+          }
+        case abst: AbstractType ⇒
+          schema.possibleTypes
+            .get (abst.name)
+            .map (types ⇒
+              types.map(loop(path, _, astFields)).transpose.zipWithIndex.map{
+                case (values, idx) ⇒
+                  val reducer = reducers(idx)
+                  reducer.reduceAlternatives(values.asInstanceOf[Seq[reducer.Acc]])
+              })
+            .getOrElse (initialValues)
+        case s: ScalarType[_] ⇒ reducers map (_.reduceScalar(path, userContext, s))
+        case ScalarAlias(aliasFor, _, _) ⇒ reducers map (_.reduceScalar(path, userContext, aliasFor))
+        case e: EnumType[_] ⇒ reducers map (_.reduceEnum(path, userContext, e))
+        case _ ⇒ initialValues
+      }
+
+    val reduced = fields.fields.foldLeft(Array(initialValues: _*)) {
+      case (acc, CollectedField(_, _, Success(astFields))) if rootTpe.getField(schema, astFields.head.name).nonEmpty ⇒
+        val astField = astFields.head
+        val field = rootTpe.getField(schema, astField.name).head
+        val path = ExecutionPath.empty.add(astField, rootTpe)
+        val childReduced = loop(path, field.fieldType, astFields)
+
+        for (i ← reducers.indices) {
+          val reducer = reducers(i)
+
+          acc(i) = reducer.reduceField(
+            acc(i).asInstanceOf[reducer.Acc],
+            childReduced(i).asInstanceOf[reducer.Acc],
+            path, userContext, astFields,
+            rootTpe.asInstanceOf[ObjectType[Any, Any]],
+            field.asInstanceOf[Field[Ctx, Any]], argumentValuesFn)
+        }
+
+        acc
+      case (acc, _) ⇒ acc
+    }
+
+    val newContext =
+      try {
+        // Unsafe part to avoid additional boxing in order to reduce the footprint
+        reducers.zipWithIndex.foldLeft(userContext: Any) {
+          case (acc: Future[Ctx @unchecked], (reducer, idx)) ⇒
+            acc.flatMap(a ⇒ reducer.reduceCtx(reduced(idx).asInstanceOf[reducer.Acc], a) match {
+              case FutureValue(future) ⇒ future
+              case Value(value) ⇒ Future.successful(value)
+              case TryValue(value) ⇒ Future.fromTry(value)
+            })
+
+          case (acc: Ctx @unchecked, (reducer, idx)) ⇒
+            reducer.reduceCtx(reduced(idx).asInstanceOf[reducer.Acc], acc) match {
+              case FutureValue(future) ⇒ future
+              case Value(value) ⇒ value
+              case TryValue(value) ⇒ value.get
+            }
+
+          case (acc, _) ⇒ Future.failed(new IllegalStateException(s"Invalid shape of the user context! $acc"))
+        }
+      } catch {
+        case NonFatal(error) ⇒ Future.failed(error)
+      }
+
+    newContext match {
+      case fut: Future[Ctx @unchecked] => fut
+      case ctx => Future.successful(ctx.asInstanceOf[Ctx])
+    }
+  }
+
+}

--- a/src/main/scala/sangria/execution/QueryReducerExecutor.scala
+++ b/src/main/scala/sangria/execution/QueryReducerExecutor.scala
@@ -1,4 +1,4 @@
-package scala.sangria.execution
+package sangria.execution
 
 import sangria.ast
 import sangria.execution._
@@ -16,7 +16,6 @@ object QueryReducerExecutor {
     schema: Schema[Ctx, Root],
     queryAst: ast.Document,
     userContext: Ctx,
-    root: Root,
     queryReducers: List[QueryReducer[Ctx, _]],
     operationName: Option[String] = None,
     queryValidator: QueryValidator = QueryValidator.default,
@@ -30,7 +29,7 @@ object QueryReducerExecutor {
       Future.failed(ValidationError(violations, exceptionHandler))
     else {
       val scalarMiddleware = Middleware.composeFromScalarMiddleware(middleware, userContext)
-      val valueCollector = new UnknownVariablesValueCollector[Ctx](schema, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware)
+      val valueCollector = new ValueCollector[Ctx, _ @@ ScalaInput](schema, InputUnmarshaller.emptyMapVars, queryAst.sourceMapper, deprecationTracker, userContext, exceptionHandler, scalarMiddleware, true)(InputUnmarshaller.scalaInputUnmarshaller[_ @@ ScalaInput])
 
       val executionResult = for {
         operation ← Executor.getOperation(exceptionHandler,queryAst, operationName)

--- a/src/main/scala/sangria/execution/TimeMeasurement.scala
+++ b/src/main/scala/sangria/execution/TimeMeasurement.scala
@@ -4,15 +4,9 @@ case class TimeMeasurement(startMs: Long, endMs: Long, durationNanos: Long)
 
 object TimeMeasurement {
   def measure[T](fn: ⇒ T): (T, TimeMeasurement) = {
-    val startTime = System.currentTimeMillis()
-    val start = System.nanoTime()
-
+    val sw = StopWatch.start()
     val res = fn
-
-    val end = System.nanoTime()
-    val endTime = System.currentTimeMillis()
-
-    res → TimeMeasurement(startTime, endTime, end - start)
+    res → sw.stop
   }
 
   def empty = {
@@ -20,4 +14,17 @@ object TimeMeasurement {
 
     TimeMeasurement(time, time, 0L)
   }
+}
+
+case class StopWatch(startTime: Long, startNanos: Long) {
+  def stop: TimeMeasurement = {
+    val endTime = System.currentTimeMillis()
+    val endNanos = System.nanoTime()
+
+    TimeMeasurement(startTime, endTime, endNanos - startNanos)
+  }
+}
+
+object StopWatch {
+  def start(): StopWatch = StopWatch(System.currentTimeMillis(), System.nanoTime())
 }

--- a/src/main/scala/sangria/execution/ValueCollector.scala
+++ b/src/main/scala/sangria/execution/ValueCollector.scala
@@ -5,13 +5,12 @@ import sangria.marshalling._
 import sangria.parser.SourceMapper
 import sangria.renderer.QueryRenderer
 import sangria.schema._
-import sangria.util.tag.@@
 import sangria.validation._
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.VectorBuilder
 import scala.util.{Failure, Success, Try}
 
-class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceMapper: Option[SourceMapper], deprecationTracker: DeprecationTracker, userContext: Ctx, exceptionHandler: ExceptionHandler, fromScalarMiddleware: Option[(Any, InputType[_]) ⇒ Option[Either[Violation, Any]]])(implicit um: InputUnmarshaller[Input]) {
+class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceMapper: Option[SourceMapper], deprecationTracker: DeprecationTracker, userContext: Ctx, exceptionHandler: ExceptionHandler, fromScalarMiddleware: Option[(Any, InputType[_]) => Option[Either[Violation, Any]]], ignoreErrors: Boolean)(implicit um: InputUnmarshaller[Input]) {
   val coercionHelper = new ValueCoercionHelper[Ctx](sourceMapper, deprecationTracker, Some(userContext))
 
   private val argumentCache = TrieMap[(ExecutionPath.PathCacheKey, Vector[ast.Argument]), Try[Args]]()
@@ -48,8 +47,7 @@ class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceM
   def getArgumentValues[Ctx](
     argumentDefs: List[Argument[_]],
     argumentAsts: Vector[ast.Argument],
-    variables: Map[String, VariableValue],
-    ignoreErrors: Boolean = false
+    variables: Map[String, VariableValue]
   ): Try[Args] = ValueCollector.getArgumentValues(coercionHelper, argumentDefs, argumentAsts, variables, exceptionHandler, ignoreErrors, sourceMapper, fromScalarMiddleware)
 }
 
@@ -114,27 +112,4 @@ case class VariableValue(fn: (ResultMarshaller, ResultMarshaller, InputType[_]) 
   def resolve(marshaller: ResultMarshaller, firstKindMarshaller: ResultMarshaller, actualType: InputType[_]): Either[Vector[Violation], Trinary[firstKindMarshaller.Node]] =
     cache.getOrElseUpdate(System.identityHashCode(firstKindMarshaller) → System.identityHashCode(actualType.namedType),
       fn(marshaller, firstKindMarshaller, actualType)).asInstanceOf[Either[Vector[Violation], Trinary[firstKindMarshaller.Node]]]
-}
-
-class UnknownVariablesValueCollector[Ctx](
-  schema: Schema[_, _],
-  sourceMapper: Option[SourceMapper],
-  deprecationTracker: DeprecationTracker,
-  userContext: Ctx,
-  exceptionHandler: ExceptionHandler,
-  fromScalarMiddleware: Option[(Any, InputType[_]) ⇒ Option[Either[Violation, Any]]]
-) extends ValueCollector[Ctx, _ @@ ScalaInput](
-  schema,
-  InputUnmarshaller.emptyMapVars,
-  sourceMapper,
-  deprecationTracker,
-  userContext,
-  exceptionHandler,
-  fromScalarMiddleware
-)(InputUnmarshaller.scalaInputUnmarshaller[_ @@ ScalaInput]) {
-  override def getArgumentValues[_](
-    argumentDefs: List[Argument[_]],
-    argumentAsts: Vector[ast.Argument],
-    variables: Map[String, VariableValue],
-    ignoreErrors: Boolean) = super.getArgumentValues(argumentDefs, argumentAsts, variables, ignoreErrors = true)
 }

--- a/src/main/scala/sangria/execution/ValueCollector.scala
+++ b/src/main/scala/sangria/execution/ValueCollector.scala
@@ -136,6 +136,5 @@ class UnknownVariablesValueCollector[Ctx](
     argumentDefs: List[Argument[_]],
     argumentAsts: Vector[ast.Argument],
     variables: Map[String, VariableValue],
-    ignoreErrors: Boolean
-  ): Try[Args] = ValueCollector.emptyArgs
+    ignoreErrors: Boolean) = super.getArgumentValues(argumentDefs, argumentAsts, variables, ignoreErrors = true)
 }

--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -190,12 +190,18 @@ package object schema {
     description = Some("Directs the executor to include this field or fragment only when the `if` argument is true."),
     arguments = IfArg :: Nil,
     locations = Set(DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment),
+    // if we don't know if we should include it, then we should include it:
+    // ValueCollector will fail before we get here if values must be known, such as when preparing or executing a query,
+    // but for e.g. running a QueryReducer without known variables, we must be conservative
     shouldInclude = ctx ⇒ ctx.args.argOpt(IfArg).getOrElse(true))
 
   val SkipDirective = Directive("skip",
     description = Some("Directs the executor to skip this field or fragment when the `if` argument is true."),
     arguments = IfArg :: Nil,
     locations = Set(DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment),
+    // if we don't know if we should include it, then we should include it:
+    // ValueCollector will fail before we get here if values must be known, such as when preparing or executing a query,
+    // but for e.g. running a QueryReducer without known variables, we must be conservative
     shouldInclude = ctx ⇒ !ctx.args.argOpt(IfArg).getOrElse(false))
 
   val DefaultDeprecationReason = "No longer supported"

--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -190,13 +190,13 @@ package object schema {
     description = Some("Directs the executor to include this field or fragment only when the `if` argument is true."),
     arguments = IfArg :: Nil,
     locations = Set(DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment),
-    shouldInclude = ctx ⇒ ctx.arg(IfArg))
+    shouldInclude = ctx ⇒ ctx.args.argOpt(IfArg).getOrElse(true))
 
   val SkipDirective = Directive("skip",
     description = Some("Directs the executor to skip this field or fragment when the `if` argument is true."),
     arguments = IfArg :: Nil,
     locations = Set(DirectiveLocation.Field, DirectiveLocation.FragmentSpread, DirectiveLocation.InlineFragment),
-    shouldInclude = ctx ⇒ !ctx.arg(IfArg))
+    shouldInclude = ctx ⇒ !ctx.args.argOpt(IfArg).getOrElse(false))
 
   val DefaultDeprecationReason = "No longer supported"
 

--- a/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -1,14 +1,12 @@
 package sangria.execution
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.scalatest.{Matchers, WordSpec}
 import sangria.parser.QueryParser
 import sangria.schema._
-import sangria.util.{OutputMatchers, FutureResultSupport}
-
-import scala.util.Success
+import sangria.util.{FutureResultSupport, OutputMatchers}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
 
 class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSupport with OutputMatchers {
   class RecordingDeprecationTracker extends DeprecationTracker {
@@ -182,7 +180,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
     }
   }
 
-  "PrintingDeprecationTracker" should {
+  "LoggingDeprecationTracker" should {
     "track deprecated enum values" in  {
       val testEnum = EnumType[Int]("TestEnum", values = List(
         EnumValue("NONDEPRECATED", value = 1),
@@ -206,7 +204,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
         """)
 
       val sb = StringBuilder.newBuilder
-      val tracker = new PrintingDeprecationTracker(sb.append(_))
+      val tracker = new LoggingDeprecationTracker(sb.append(_))
 
       Executor.execute(schema, query, deprecationTracker = tracker).await
 
@@ -223,7 +221,7 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val Success(query) = QueryParser.parse("{ nonDeprecated deprecated}")
 
       val sb = StringBuilder.newBuilder
-      val tracker = new PrintingDeprecationTracker(sb.append(_))
+      val tracker = new LoggingDeprecationTracker(sb.append(_))
 
       Executor.execute(schema, query, deprecationTracker = tracker).await
 

--- a/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -205,11 +205,12 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
           }
         """)
 
-      val out = captureConsoleOut {
-        Executor.execute(schema, query, deprecationTracker = DeprecationTracker.print).await
-      }
+      val sb = StringBuilder.newBuilder
+      val tracker = new PrintingDeprecationTracker(sb.append(_))
 
-      out should include ("Deprecated enum value '2' used of enum 'TestEnum'.")
+      Executor.execute(schema, query, deprecationTracker = tracker).await
+
+      sb.toString() should include ("Deprecated enum value '2' used of enum 'TestEnum'.")
     }
 
     "track deprecated fields" in  {
@@ -221,11 +222,12 @@ class DeprecationTrackerSpec extends WordSpec with Matchers with FutureResultSup
       val schema = Schema(testType)
       val Success(query) = QueryParser.parse("{ nonDeprecated deprecated}")
 
-      val out = captureConsoleOut {
-        Executor.execute(schema, query, deprecationTracker = DeprecationTracker.print).await
-      }
+      val sb = StringBuilder.newBuilder
+      val tracker = new PrintingDeprecationTracker(sb.append(_))
 
-      out should include ("Deprecated field 'TestType.deprecated' used at path 'deprecated'.")
+      Executor.execute(schema, query, deprecationTracker = tracker).await
+
+      sb.toString() should include ("Deprecated field 'TestType.deprecated' used at path 'deprecated'.")
     }
   }
 }

--- a/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
+++ b/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
@@ -172,11 +172,11 @@ class ValueCoercionHelperSpec extends WordSpec with Matchers {
     import spray.json._
     import sangria.marshalling.sprayJson._
 
-    val valueCollector = new ValueCollector(testSchema, (if (vars._2.nonEmpty) vars._2 else "{}").parseJson, None, DeprecationTracker.empty, (), ExceptionHandler.empty, None)
+    val valueCollector = new ValueCollector(testSchema, (if (vars._2.nonEmpty) vars._2 else "{}").parseJson, None, DeprecationTracker.empty, (), ExceptionHandler.empty, None, true)
     val variables = valueCollector.getVariableValues(QueryParser.parse(s"query Foo${if (vars._1.nonEmpty) "(" + vars._1 + ")" else ""} {foo}").operations(Some("Foo")).variables, None).get
 
     val parsed = QueryParser.parseInputWithVariables(value)
-    val args = valueCollector.getArgumentValues(Argument("a", tpe) :: Nil, Vector(ast.Argument("a", parsed)), variables, ignoreErrors = true).get
+    val args = valueCollector.getArgumentValues(Argument("a", tpe) :: Nil, Vector(ast.Argument("a", parsed)), variables).get
 
     args.raw.get("a")
   }


### PR DESCRIPTION
This is a quick-and-dirty sketch for what #277 might look like. 

The basic approach is to add a new `Executor.prepare` method that doesn't accept variables, and add `preparedQueryReducers` to `Executor`.

Query reducers are run depending on the scenario:

* If we are preparing a query *without* known variables
  + Run `preparedQueryReducers` now and defer `queryReducers` to runtime
* If we are preparing a query *with* known variables
  + Run `preparedQueryReducers` and `queryReducers` now
* If we are executing an unprepared query:
  + Run `queryReducers`

The implementation is complete enough for my use case, but is not merge-ready.

What do you think about separating preparation-time from run-time like this?