### PR TITLE
Block String Support

### DIFF
--- a/src/main/scala/sangria/ast/QueryAst.scala
+++ b/src/main/scala/sangria/ast/QueryAst.scala
@@ -265,7 +265,7 @@ case class IntValue(value: Int, comments: Vector[Comment] = Vector.empty, positi
 case class BigIntValue(value: BigInt, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class FloatValue(value: Double, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class BigDecimalValue(value: BigDecimal, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class StringValue(value: String, block: Boolean = false, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
+case class StringValue(value: String, block: Boolean = false, blockRawValue: Option[String] = None, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class BooleanValue(value: Boolean, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class EnumValue(value: String, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
 case class ListValue(values: Vector[Value], comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
@@ -652,7 +652,7 @@ object AstVisitor {
           if (breakOrSkip(onEnter(n))) {
             breakOrSkip(onLeave(n))
           }
-        case n @ StringValue(_, _, comment, _) ⇒
+        case n @ StringValue(_, _, _, comment, _) ⇒
           if (breakOrSkip(onEnter(n))) {
             comment.foreach(s ⇒ loop(s))
             breakOrSkip(onLeave(n))

--- a/src/main/scala/sangria/ast/QueryAst.scala
+++ b/src/main/scala/sangria/ast/QueryAst.scala
@@ -265,7 +265,7 @@ case class IntValue(value: Int, comments: Vector[Comment] = Vector.empty, positi
 case class BigIntValue(value: BigInt, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class FloatValue(value: Double, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class BigDecimalValue(value: BigDecimal, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class StringValue(value: String, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
+case class StringValue(value: String, block: Boolean = false, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class BooleanValue(value: Boolean, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
 case class EnumValue(value: String, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
 case class ListValue(values: Vector[Value], comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
@@ -652,7 +652,7 @@ object AstVisitor {
           if (breakOrSkip(onEnter(n))) {
             breakOrSkip(onLeave(n))
           }
-        case n @ StringValue(_, comment, _) ⇒
+        case n @ StringValue(_, _, comment, _) ⇒
           if (breakOrSkip(onEnter(n))) {
             comment.foreach(s ⇒ loop(s))
             breakOrSkip(onLeave(n))

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -1283,7 +1283,7 @@ object Resolver {
     }
 
   def marshalAstValue(value: ast.Value, marshaller: ResultMarshaller, typeName: String, scalarInfo: Set[ScalarValueInfo]): marshaller.Node = value match {
-    case ast.StringValue(str, _, _) ⇒ marshaller.scalarNode(str, typeName, scalarInfo)
+    case ast.StringValue(str, _, _, _) ⇒ marshaller.scalarNode(str, typeName, scalarInfo)
     case ast.IntValue(i, _, _) ⇒ marshaller.scalarNode(i, typeName, scalarInfo)
     case ast.BigIntValue(i, _, _) ⇒ marshaller.scalarNode(i, typeName, scalarInfo)
     case ast.FloatValue(f, _, _) ⇒ marshaller.scalarNode(f, typeName, scalarInfo)

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -1283,7 +1283,7 @@ object Resolver {
     }
 
   def marshalAstValue(value: ast.Value, marshaller: ResultMarshaller, typeName: String, scalarInfo: Set[ScalarValueInfo]): marshaller.Node = value match {
-    case ast.StringValue(str, _, _, _) ⇒ marshaller.scalarNode(str, typeName, scalarInfo)
+    case ast.StringValue(str, _, _, _, _) ⇒ marshaller.scalarNode(str, typeName, scalarInfo)
     case ast.IntValue(i, _, _) ⇒ marshaller.scalarNode(i, typeName, scalarInfo)
     case ast.BigIntValue(i, _, _) ⇒ marshaller.scalarNode(i, typeName, scalarInfo)
     case ast.FloatValue(f, _, _) ⇒ marshaller.scalarNode(f, typeName, scalarInfo)

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -492,7 +492,7 @@ object BatchExecutor {
         case field: ast.Field if currentOperation.isDefined || currentFragment.isDefined ⇒
           field.directives.find(_.name == ExportDirective.name) match {
             case Some(d) ⇒ d.arguments.find(_.name == AsArg.name) match {
-              case Some(ast.Argument(_, ast.StringValue(as, _, _), _, _)) if typeInfo.fieldDef.isDefined ⇒
+              case Some(ast.Argument(_, ast.StringValue(as, _, _, _), _, _)) if typeInfo.fieldDef.isDefined ⇒
                 currentDirectives += Export(as, calcPath(typeInfo), d, typeInfo.fieldDef.get.fieldType)
                 VisitorCommand.Continue
               case _ ⇒ VisitorCommand.Continue

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -492,7 +492,7 @@ object BatchExecutor {
         case field: ast.Field if currentOperation.isDefined || currentFragment.isDefined ⇒
           field.directives.find(_.name == ExportDirective.name) match {
             case Some(d) ⇒ d.arguments.find(_.name == AsArg.name) match {
-              case Some(ast.Argument(_, ast.StringValue(as, _, _, _), _, _)) if typeInfo.fieldDef.isDefined ⇒
+              case Some(ast.Argument(_, ast.StringValue(as, _, _, _, _), _, _)) if typeInfo.fieldDef.isDefined ⇒
                 currentDirectives += Export(as, calcPath(typeInfo), d, typeInfo.fieldDef.get.fieldType)
                 VisitorCommand.Continue
               case _ ⇒ VisitorCommand.Continue

--- a/src/main/scala/sangria/macros/AstLiftable.scala
+++ b/src/main/scala/sangria/macros/AstLiftable.scala
@@ -105,7 +105,7 @@ trait AstLiftable {
   implicit def liftValue[T <: sangria.ast.Value]: Liftable[T] = Liftable {
     case IntValue(v, c, p) ⇒ q"_root_.sangria.ast.IntValue($v, $c, $p)"
     case FloatValue(v, c, p) ⇒ q"_root_.sangria.ast.FloatValue($v, $c, $p)"
-    case StringValue(v, b, c, p) ⇒ q"_root_.sangria.ast.StringValue($v, $b, $c, $p)"
+    case StringValue(v, b, r, c, p) ⇒ q"_root_.sangria.ast.StringValue($v, $b, $r, $c, $p)"
     case BooleanValue(v, c, p) ⇒ q"_root_.sangria.ast.BooleanValue($v, $c, $p)"
     case NullValue(c, p) ⇒ q"_root_.sangria.ast.NullValue($c, $p)"
     case EnumValue(v, c, p) ⇒ q"_root_.sangria.ast.EnumValue($v, $c, $p)"

--- a/src/main/scala/sangria/macros/AstLiftable.scala
+++ b/src/main/scala/sangria/macros/AstLiftable.scala
@@ -105,7 +105,7 @@ trait AstLiftable {
   implicit def liftValue[T <: sangria.ast.Value]: Liftable[T] = Liftable {
     case IntValue(v, c, p) ⇒ q"_root_.sangria.ast.IntValue($v, $c, $p)"
     case FloatValue(v, c, p) ⇒ q"_root_.sangria.ast.FloatValue($v, $c, $p)"
-    case StringValue(v, c, p) ⇒ q"_root_.sangria.ast.StringValue($v, $c, $p)"
+    case StringValue(v, b, c, p) ⇒ q"_root_.sangria.ast.StringValue($v, $b, $c, $p)"
     case BooleanValue(v, c, p) ⇒ q"_root_.sangria.ast.BooleanValue($v, $c, $p)"
     case NullValue(c, p) ⇒ q"_root_.sangria.ast.NullValue($c, $p)"
     case EnumValue(v, c, p) ⇒ q"_root_.sangria.ast.EnumValue($v, $c, $p)"

--- a/src/main/scala/sangria/marshalling/queryAst.scala
+++ b/src/main/scala/sangria/marshalling/queryAst.scala
@@ -55,7 +55,7 @@ class QueryAstInputUnmarshaller extends InputUnmarshaller[ast.Value] {
     case ast.BigDecimalValue(d, _, _) ⇒ d
     case ast.FloatValue(f, _, _) ⇒ f
     case ast.IntValue(i, _, _) ⇒ i
-    case ast.StringValue(s, _, _) ⇒ s
+    case ast.StringValue(s, _, _, _) ⇒ s
     case ast.EnumValue(s, _, _) ⇒ s
     case node ⇒ throw new IllegalStateException("Unsupported scalar node: " + node)
   }

--- a/src/main/scala/sangria/marshalling/queryAst.scala
+++ b/src/main/scala/sangria/marshalling/queryAst.scala
@@ -55,7 +55,7 @@ class QueryAstInputUnmarshaller extends InputUnmarshaller[ast.Value] {
     case ast.BigDecimalValue(d, _, _) ⇒ d
     case ast.FloatValue(f, _, _) ⇒ f
     case ast.IntValue(i, _, _) ⇒ i
-    case ast.StringValue(s, _, _, _) ⇒ s
+    case ast.StringValue(s, _, _, _, _) ⇒ s
     case ast.EnumValue(s, _, _) ⇒ s
     case node ⇒ throw new IllegalStateException("Unsupported scalar node: " + node)
   }

--- a/src/main/scala/sangria/parser/QueryParser.scala
+++ b/src/main/scala/sangria/parser/QueryParser.scala
@@ -1,11 +1,11 @@
 package sangria.parser
 
 import org.parboiled2._
-import CharPredicate.{HexDigit, Digit19}
-
+import CharPredicate.{Digit19, HexDigit}
 import sangria.ast
+import sangria.util.StringUtil
 
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 trait Tokens extends StringBuilding with PositionTracking { this: Parser with Ignored ⇒
 
@@ -54,7 +54,7 @@ trait Tokens extends StringBuilding with PositionTracking { this: Parser with Ig
 
   def BlockStringValue = rule {
     Comments ~ trackPos ~ BlockString ~ clearSB() ~ BlockStringCharacters ~ BlockString ~ push(sb.toString) ~ IgnoredNoComment.* ~>
-      ((comment, pos, s) ⇒ ast.StringValue(s, true, comment, Some(pos)))
+      ((comment, pos, s) ⇒ ast.StringValue(StringUtil.blockStringValue(s), true, Some(s), comment, Some(pos)))
   }
 
   def BlockStringCharacters = rule { (BlockStringCharacter | BlockStringEscapedChar).* }
@@ -73,7 +73,7 @@ trait Tokens extends StringBuilding with PositionTracking { this: Parser with Ig
 
   def NonBlockStringValue = rule {
     Comments ~ trackPos ~ '"' ~ clearSB() ~ Characters ~ '"' ~ push(sb.toString) ~ IgnoredNoComment.* ~>
-        ((comment, pos, s) ⇒ ast.StringValue(s, false, comment, Some(pos)))
+        ((comment, pos, s) ⇒ ast.StringValue(s, false, None, comment, Some(pos)))
   }
 
   def Characters = rule { (NormalCharacter | '\\' ~ EscapedChar).* }

--- a/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -300,7 +300,7 @@ object QueryRenderer {
       case v @ BigIntValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ FloatValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ BigDecimalValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
-      case v @ StringValue(value, _, _) ⇒ renderInputComment(v, indent, config) + '"' + escapeString(value) + '"'
+      case v @ StringValue(value, _, _, _) ⇒ renderInputComment(v, indent, config) + '"' + escapeString(value) + '"'
       case v @ BooleanValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ NullValue(_, _) ⇒ renderInputComment(v, indent, config) + "null"
       case v @ EnumValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value

--- a/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -300,7 +300,7 @@ object QueryRenderer {
       case v @ BigIntValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ FloatValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ BigDecimalValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
-      case v @ StringValue(value, _, _, _) ⇒ renderInputComment(v, indent, config) + '"' + escapeString(value) + '"'
+      case v @ StringValue(value, _, _, _, _) ⇒ renderInputComment(v, indent, config) + '"' + escapeString(value) + '"'
       case v @ BooleanValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ NullValue(_, _) ⇒ renderInputComment(v, indent, config) + "null"
       case v @ EnumValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value

--- a/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -36,7 +36,7 @@ object QueryRenderer {
     renderComments = false,
     formatBlockStrings = false)
 
-  def renderSelections(sels: Vector[Selection], tc: WithTrailingComments, indent: String, indentLevel: Int, config: QueryRendererConfig) =
+  def renderSelections(sels: Vector[Selection], tc: WithTrailingComments, indent: Indent, config: QueryRendererConfig) =
     if (sels.nonEmpty) {
       val rendered = sels.zipWithIndex map {
         case (sel, idx) ⇒
@@ -49,20 +49,20 @@ object QueryRenderer {
           val trailing =
             trailingNext orElse (for (c ← tc.trailingComments.headOption; cp ← c.position; sp ← sel.position; if cp.line == sp.line) yield c)
 
-          (if (idx != 0 && shouldRenderComment(sel, prev, config)) config.lineBreak else "") + render(sel, config, indentLevel + 1, prev = prev) +
+          (if (idx != 0 && shouldRenderComment(sel, prev, config)) config.lineBreak else "") + renderNode(sel, config, indent.inc, prev = prev) +
             trailing.fold("")(c ⇒ renderIndividualComment(c, " ", config))
       } mkString config.mandatoryLineBreak
 
       "{" +
         config.lineBreak +
         rendered +
-        renderTrailingComment(tc, sels.lastOption, config.indentLevel * (indentLevel + 1), config) +
+        renderTrailingComment(tc, sels.lastOption, indent.inc, config) +
         trailingLineBreak(tc, config) +
-        indent +
+        indent.str +
         "}"
     } else ""
 
-  def renderFieldDefinitions(fields: Vector[FieldDefinition], tc: WithTrailingComments, indent: String, indentLevel: Int, config: QueryRendererConfig) =
+  def renderFieldDefinitions(fields: Vector[FieldDefinition], tc: WithTrailingComments, indent: Indent, config: QueryRendererConfig) =
     if (fields.nonEmpty) {
       val rendered = fields.zipWithIndex map {
         case (field, idx) ⇒
@@ -76,58 +76,58 @@ object QueryRenderer {
             trailingNext orElse (for (c ← tc.trailingComments.headOption; cp ← c.position; sp ← field.position; if cp.line == sp.line) yield c)
 
           (if (idx != 0 && shouldRenderComment(field, prev, config)) config.lineBreak else "") +
-            render(field, config, indentLevel + 1, prev = prev) +
+            renderNode(field, config, indent.inc, prev = prev) +
             trailing.fold("")(c ⇒ renderIndividualComment(c, " ", config))
       } mkString config.mandatoryLineBreak
 
       "{" +
         config.lineBreak +
         rendered +
-        renderTrailingComment(tc, fields.lastOption, config.indentLevel * (indentLevel + 1), config) +
+        renderTrailingComment(tc, fields.lastOption, indent.inc, config) +
         trailingLineBreak(tc, config) +
-        indent +
+        indent.str +
         "}"
     } else "{}"
 
-  def renderDirs(dirs: Vector[Directive], config: QueryRendererConfig, frontSep: Boolean = false, withSep: Boolean = true) =
+  def renderDirs(dirs: Vector[Directive], config: QueryRendererConfig, indent: Indent, frontSep: Boolean = false, withSep: Boolean = true) =
     (if (dirs.nonEmpty && frontSep && withSep) config.separator else "") +
-      (dirs map (render(_, config)) mkString config.separator) +
+      (dirs map (renderNode(_, config, indent.zero)) mkString config.separator) +
       (if (dirs.nonEmpty && !frontSep && withSep) config.separator else "")
 
-  def renderArgs(args: Vector[Argument], indentLevel: Int, config: QueryRendererConfig, withSep: Boolean = true) =
+  def renderArgs(args: Vector[Argument], indent: Indent, config: QueryRendererConfig, withSep: Boolean = true) =
     if (args.nonEmpty) {
       val argsRendered = args.zipWithIndex map { case (a, idx) ⇒
         (if (idx != 0 && shouldRenderComment(a, None, config)) config.lineBreak else "") +
             (if (shouldRenderComment(a, None, config)) config.mandatoryLineBreak else if (idx != 0) config.separator else "") +
-            render(a, config, if (shouldRenderComment(a, None, config)) indentLevel + 1 else 0)
+            renderNode(a, config, if (shouldRenderComment(a, None, config)) indent.inc else indent.zero)
       }
 
       "(" + (argsRendered mkString ",") + ")" + (if (withSep) config.separator else "")
     } else ""
 
-  def renderInputValueDefs(args: Vector[InputValueDefinition], indentLevel: Int, config: QueryRendererConfig, withSep: Boolean = true) =
+  def renderInputValueDefs(args: Vector[InputValueDefinition], indent: Indent, config: QueryRendererConfig, withSep: Boolean = true) =
     if (args.nonEmpty) {
       val argsRendered = args.zipWithIndex map { case (a, idx) ⇒
         (if (idx != 0 && shouldRenderComment(a, None, config)) config.lineBreak else "") +
           (if (shouldRenderComment(a, None, config)) config.mandatoryLineBreak else if (idx != 0) config.separator else "") +
-          render(a, config, if (shouldRenderComment(a, None, config)) indentLevel + 1 else 0)
+          renderNode(a, config, if (shouldRenderComment(a, None, config)) indent.inc else indent.zero)
       }
 
       "(" + (argsRendered mkString ",") + ")" + (if (withSep) config.separator else "")
     } else ""
 
-  def renderVarDefs(vars: Vector[VariableDefinition], indentLevel: Int, config: QueryRendererConfig, withSep: Boolean = true) =
+  def renderVarDefs(vars: Vector[VariableDefinition], indent: Indent, config: QueryRendererConfig, withSep: Boolean = true) =
     if (vars.nonEmpty) {
       val varsRendered = vars.zipWithIndex map { case (v, idx) ⇒
         (if (idx != 0 && shouldRenderComment(v, None, config)) config.lineBreak else "") +
           (if (shouldRenderComment(v, None, config)) config.mandatoryLineBreak else if (idx != 0) config.separator else "") +
-          render(v, config, if (shouldRenderComment(v, None, config)) indentLevel + 2 else 0)
+          renderNode(v, config, if (shouldRenderComment(v, None, config)) indent + 2 else indent.zero)
       }
 
       "(" + (varsRendered mkString ",") + ")" + (if (withSep) config.separator else "")
     } else ""
 
-  def renderInputObjectFieldDefs(fields: Vector[InputValueDefinition], tc: WithTrailingComments, indentLevel: Int, config: QueryRendererConfig) = {
+  def renderInputObjectFieldDefs(fields: Vector[InputValueDefinition], tc: WithTrailingComments, indent: Indent, config: QueryRendererConfig) = {
     val fieldsRendered = fields.zipWithIndex map { case (f, idx) ⇒
       val prev = if (idx == 0) None else Some(fields(idx - 1))
       val next = if (idx == fields.size - 1) None else Some(fields(idx + 1))
@@ -139,18 +139,18 @@ object QueryRenderer {
         trailingNext orElse (for (c ← tc.trailingComments.headOption; cp ← c.position; sp ← f.position; if cp.line == sp.line) yield c)
 
       (if (idx != 0 && shouldRenderComment(f, prev, config)) config.lineBreak else "") +
-        render(f, config, indentLevel + 1, prev = prev) +
+        renderNode(f, config, indent.inc, prev = prev) +
         trailing.fold("")(c ⇒ renderIndividualComment(c, " ", config))
     }
 
     fieldsRendered mkString config.mandatoryLineBreak
   }
 
-  def renderInterfaces(interfaces: Vector[NamedType], config: QueryRendererConfig, frontSep: Boolean = false, withSep: Boolean = true) =
+  def renderInterfaces(interfaces: Vector[NamedType], config: QueryRendererConfig, indent: Indent, frontSep: Boolean = false, withSep: Boolean = true) =
     if (interfaces.nonEmpty)
       (if (frontSep) config.mandatorySeparator else "") +
         "implements" + config.mandatorySeparator +
-        (interfaces map (render(_, config)) mkString ("," + config.separator)) +
+        (interfaces map (renderNode(_, config, indent.zero)) mkString ("," + config.separator)) +
         (if (withSep) config.separator else "")
     else ""
 
@@ -187,7 +187,7 @@ object QueryRenderer {
   def renderIndividualComment(node: Comment, indent: String, config: QueryRendererConfig): String =
     indent + "#" + (if (node.text.trim.nonEmpty && !startsWithWhitespace(node.text)) " " else "") + node.text
 
-  def renderComment(node: WithComments, prev: Option[AstNode],indent: String, config: QueryRendererConfig): String = {
+  def renderComment(node: WithComments, prev: Option[AstNode], indent: Indent, config: QueryRendererConfig): String = {
     val comments = actualComments(node, prev)
 
     if (shouldRenderComment(comments, config)) {
@@ -197,7 +197,7 @@ object QueryRenderer {
     } else ""
   }
 
-  def renderCommentLines(comments: Vector[Comment], nodePos: Option[Position], indent: String, config: QueryRendererConfig) = {
+  def renderCommentLines(comments: Vector[Comment], nodePos: Option[Position], indent: Indent, config: QueryRendererConfig) = {
     val nodeLine = nodePos.map(_.line).orElse(comments.last.position.map(_.line + 1)).fold(1)(identity)
 
     comments.foldRight((nodeLine, Vector.empty[String])) {
@@ -206,11 +206,11 @@ object QueryRenderer {
         val diffLines = lastLine - currLine
         val fill = if (diffLines  > 1) config.lineBreak else ""
 
-        currLine → ((renderIndividualComment(c, indent, config) + fill) +: acc)
+        currLine → ((renderIndividualComment(c, indent.str, config) + fill) +: acc)
     }._2
   }
 
-  def renderTrailingComment(node: WithTrailingComments, lastSelection: Option[AstNode], indent: String, config: QueryRendererConfig): String = {
+  def renderTrailingComment(node: WithTrailingComments, lastSelection: Option[AstNode], indent: Indent, config: QueryRendererConfig): String = {
     val ignoreFirst = for (ls ← lastSelection; p ← ls.position; c ← node.trailingComments.headOption; cp ← c.position) yield cp.line == p.line
     val comments = ignoreFirst match {
       case Some(true) ⇒ node.trailingComments.tail
@@ -224,86 +224,88 @@ object QueryRenderer {
     } else ""
   }
 
-  def renderInputComment(node: WithComments, indent: String, config: QueryRendererConfig) =
-    if (config.formatInputValues && shouldRenderComment(node, None, config)) renderComment(node, None, indent, config) + indent else ""
+  def renderInputComment(node: WithComments, indent: Indent, config: QueryRendererConfig) =
+    if (config.formatInputValues && shouldRenderComment(node, None, config)) renderComment(node, None, indent, config) + indent.str else ""
 
-  def renderBlockString(node: AstNode, str: String, indent: String, config: QueryRendererConfig) =
+  def renderBlockString(node: AstNode, str: String, indent: Indent, config: QueryRendererConfig) =
     if (str.trim.nonEmpty) {
-      val lines = escapeBlockString(str).split("\n").map(indent + _)
+      val ind = indent.incForce.str
+      val lines = escapeBlockString(str).split("\n").map(ind + _)
 
-      lines.mkString("\"\"\"\n", "\n", "\n" + indent + "\"\"\"")
+      lines.mkString("\"\"\"\n", "\n", "\n" + ind + "\"\"\"")
     } else "\"\""
 
-  def render(node: AstNode, config: QueryRendererConfig = Pretty, indentLevel: Int = 0, prefix: Option[String] = None, prev: Option[AstNode] = None): String = {
-    lazy val indent = config.indentLevel * indentLevel
+  def render(node: AstNode, config: QueryRendererConfig = Pretty, indentLevel: Int = 0): String =
+    renderNode(node, config, Indent(config, indentLevel, indentLevel))
 
+  def renderNode(node: AstNode, config: QueryRendererConfig, indent: Indent, prefix: Option[String] = None, prev: Option[AstNode] = None): String =
     node match {
       case d @ Document(defs, _, _, _) ⇒
-        (defs map (render(_, config, indentLevel)) mkString config.definitionSeparator) +
+        (defs map (renderNode(_, config, indent)) mkString config.definitionSeparator) +
           renderTrailingComment(d, None, indent, config)
 
       case d @ InputDocument(defs, _, _, _) ⇒
-        (defs map (render(_, config, indentLevel)) mkString config.definitionSeparator) +
+        (defs map (renderNode(_, config, indent)) mkString config.definitionSeparator) +
           renderTrailingComment(d, None, indent, config)
 
       case op @ OperationDefinition(OperationType.Query, None, vars, dirs, sels, _, _, _) if vars.isEmpty && dirs.isEmpty ⇒
-        renderComment(op, prev, indent, config) + indent + renderSelections(sels, op, indent, indentLevel, config)
+        renderComment(op, prev, indent, config) + indent.str + renderSelections(sels, op, indent, config)
 
       case op @ OperationDefinition(opType, name, vars, dirs, sels, _, _, _) ⇒
         renderComment(op, prev, indent, config) +
-          indent + renderOpType(opType) + config.mandatorySeparator +
+          indent.str + renderOpType(opType) + config.mandatorySeparator +
           (name getOrElse "") +
-          renderVarDefs(vars, indentLevel, config, withSep = false) +
+          renderVarDefs(vars, indent, config, withSep = false) +
           config.separator +
-          renderDirs(dirs, config) +
-          renderSelections(sels, op, indent, indentLevel, config)
+          renderDirs(dirs, config, indent) +
+          renderSelections(sels, op, indent, config)
 
       case fd @ FragmentDefinition(name, typeCondition, dirs, sels, _, _, _) ⇒
         renderComment(fd, prev, indent, config) +
-          indent + "fragment" + config.mandatorySeparator + name + config.mandatorySeparator + "on" +
+          indent.str + "fragment" + config.mandatorySeparator + name + config.mandatorySeparator + "on" +
           config.mandatorySeparator + typeCondition.name + config.separator +
-          renderDirs(dirs, config) +
-          renderSelections(sels, fd, indent, indentLevel, config)
+          renderDirs(dirs, config, indent) +
+          renderSelections(sels, fd, indent, config)
 
       case vd @ VariableDefinition(name, tpe, defaultValue, _, _) ⇒
         renderComment(vd, prev, indent, config) +
-          indent + "$" + name + ":" + config.separator +
-          render(tpe, config) +
-          (defaultValue map (v ⇒ config.separator + "=" + config.separator + render(v, config)) getOrElse "")
+          indent.str + "$" + name + ":" + config.separator +
+          renderNode(tpe, config, indent.zero) +
+          (defaultValue map (v ⇒ config.separator + "=" + config.separator + renderNode(v, config, indent.zero)) getOrElse "")
 
       case NotNullType(ofType, _) ⇒
-        render(ofType) + "!"
+        renderNode(ofType, config, indent.zero) + "!"
 
       case ListType(ofType, _) ⇒
-        "[" + render(ofType) + "]"
+        "[" + renderNode(ofType, config, indent.zero) + "]"
 
       case NamedType(name, _) ⇒
         name
 
       case f @ Field(alias, name, args, dirs, sels, _, _, _) ⇒
         renderComment(f, prev, indent, config) +
-          indent + (alias map (_ + ":" + config.separator) getOrElse "") + name +
-          renderArgs(args, indentLevel, config, withSep = false) +
+          indent.str + (alias map (_ + ":" + config.separator) getOrElse "") + name +
+          renderArgs(args, indent, config, withSep = false) +
           (if (dirs.nonEmpty || sels.nonEmpty) config.separator else "") +
-          renderDirs(dirs, config, withSep = sels.nonEmpty) +
-          renderSelections(sels, f, indent, indentLevel, config)
+          renderDirs(dirs, config, indent, withSep = sels.nonEmpty) +
+          renderSelections(sels, f, indent, config)
 
       case fs @ FragmentSpread(name, dirs, _, _) ⇒
         renderComment(fs, prev, indent, config) +
-          indent + "..." + name + renderDirs(dirs, config, frontSep = true)
+          indent.str + "..." + name + renderDirs(dirs, config, indent, frontSep = true)
 
       case ifr @ InlineFragment(typeCondition, dirs, sels, _, _, _) ⇒
         renderComment(ifr, prev, indent, config) +
-          indent + "..." + config.mandatorySeparator + typeCondition.fold("")("on" + config.mandatorySeparator + _.name) + config.separator +
-          renderDirs(dirs, config) +
-          renderSelections(sels, ifr, indent, indentLevel, config)
+          indent.str + "..." + config.mandatorySeparator + typeCondition.fold("")("on" + config.mandatorySeparator + _.name) + config.separator +
+          renderDirs(dirs, config, indent) +
+          renderSelections(sels, ifr, indent, config)
 
       case Directive(name, args, _, _) ⇒
-        indent + "@" + name + renderArgs(args, indentLevel, config.copy(renderComments = false), withSep = false)
+        indent.str + "@" + name + renderArgs(args, indent, config.copy(renderComments = false), withSep = false)
 
       case a @ Argument(name, value, _, _) ⇒
         renderComment(a, prev, indent, config) +
-          indent + name + ":" + config.separator + render(value, config)
+          indent.str + name + ":" + config.separator + renderNode(value, config, indent.zero)
 
       case v @ IntValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
       case v @ BigIntValue(value, _, _) ⇒ renderInputComment(v, indent, config) + value
@@ -327,69 +329,69 @@ object QueryRenderer {
           if (config.formatInputValues && shouldRenderComment(v, None, config))
             (if (idx != 0) config.lineBreak else "") +
               config.lineBreak +
-              render(v, config, indentLevel + (if (addIdent(v)) 1 else 0))
+              renderNode(v, config, indent + (if (addIdent(v)) 1 else 0))
           else
-            (if (idx != 0) config.separator else "") + render(v, config, indentLevel)
+            (if (idx != 0) config.separator else "") + renderNode(v, config, indent)
 
         renderInputComment(v, indent, config) +
           "[" + (value.zipWithIndex map {case (v, idx) ⇒ renderValue(v, idx)} mkString config.inputListSeparator) + "]"
       case v @ ObjectValue(value, _, _) ⇒
         renderInputComment(v, indent, config) +
           "{" + inputLineBreak(config) +
-          (value.zipWithIndex map {case (v, idx) ⇒ (if (idx != 0 && config.formatInputValues && shouldRenderComment(v, None, config)) config.lineBreak else "") + render(v, config, inputFieldIndent(config, indentLevel))} mkString config.inputFieldSeparator) +
+          (value.zipWithIndex map {case (v, idx) ⇒ (if (idx != 0 && config.formatInputValues && shouldRenderComment(v, None, config)) config.lineBreak else "") + renderNode(v, config, inputFieldIndent(config, indent))} mkString config.inputFieldSeparator) +
           inputLineBreak(config) + inputIndent(config, indent) + "}"
-      case VariableValue(name, _, _) ⇒ indent + "$" + name
+      case VariableValue(name, _, _) ⇒ indent.str + "$" + name
       case v @ ObjectField(name, value, _, _) ⇒
         val rendered =
             if (config.formatInputValues && shouldRenderComment(value, None, config))
-              config.lineBreak + render(value, config, indentLevel + 1)
+              config.lineBreak + renderNode(value, config, indent.inc)
             else
-              config.separator + render(value, config, indentLevel)
+              config.separator + renderNode(value, config, indent)
 
         (if (config.formatInputValues) renderComment(v, prev, indent, config) else "") +
-          indent + name + ":" + rendered
+          indent.str + name + ":" + rendered
 
-      case c @ Comment(_, _) ⇒ renderIndividualComment(c, indent, config)
+      case c @ Comment(_, _) ⇒ renderIndividualComment(c, indent.str, config)
 
       case std @ ScalarTypeDefinition(name, dirs, _, _) ⇒
         renderComment(std, prev, indent, config) +
-          indent + "scalar" + config.mandatorySeparator + name +
-          renderDirs(dirs, config, frontSep = true)
+          indent.str + "scalar" + config.mandatorySeparator + name +
+          renderDirs(dirs, config, indent, frontSep = true)
 
       case otd @ ObjectTypeDefinition(name, interfaces, fields, dirs, _, _, _) ⇒
         renderComment(otd, prev, indent, config) +
-          indent + prefix.getOrElse("") + "type" + config.mandatorySeparator + name +
+          indent.str + prefix.getOrElse("") + "type" + config.mandatorySeparator + name +
           config.mandatorySeparator +
-          renderInterfaces(interfaces, config) +
-          renderDirs(dirs, config) +
-          renderFieldDefinitions(fields, otd, indent, indentLevel, config)
+          renderInterfaces(interfaces, config, indent) +
+          renderDirs(dirs, config, indent) +
+          renderFieldDefinitions(fields, otd, indent, config)
 
       case itd @ InputObjectTypeDefinition(name, fields, dirs, _, _, _) ⇒
         renderComment(itd, prev, indent, config) +
-          indent + "input" + config.mandatorySeparator + name +
+          indent.str + "input" + config.mandatorySeparator + name +
           config.mandatorySeparator +
-          renderDirs(dirs, config) +
+          renderDirs(dirs, config, indent) +
           "{" +
           config.lineBreak +
-          renderInputObjectFieldDefs(fields, itd, indentLevel, config) +
-          renderTrailingComment(itd, fields.lastOption, config.indentLevel * (indentLevel + 1), config) +
+          renderInputObjectFieldDefs(fields, itd, indent, config) +
+          renderTrailingComment(itd, fields.lastOption, indent.inc, config) +
           trailingLineBreak(itd, config) +
-          indent +
+          indent.str +
           "}"
 
       case itd @ InterfaceTypeDefinition(name, fields, dirs, _, _, _) ⇒
         renderComment(itd, prev, indent, config) +
-          indent + "interface" + config.mandatorySeparator + name +
+          indent.str + "interface" + config.mandatorySeparator + name +
           config.separator +
-          renderDirs(dirs, config) +
-          renderFieldDefinitions(fields, itd, indent, indentLevel, config)
+          renderDirs(dirs, config, indent) +
+          renderFieldDefinitions(fields, itd, indent, config)
 
       case utd @ UnionTypeDefinition(name, types, dirs, _, _) ⇒
         renderComment(utd, prev, indent, config) +
-          indent + "union" + config.mandatorySeparator + name +
-            renderDirs(dirs, config, frontSep = true) +
+          indent.str + "union" + config.mandatorySeparator + name +
+            renderDirs(dirs, config, indent, frontSep = true) +
             config.separator + "=" + config.separator +
-            (types map(render(_, config)) mkString (config.separator + "|" + config.separator))
+            (types map(renderNode(_, config, indent.zero)) mkString (config.separator + "|" + config.separator))
 
       case etd @ EnumTypeDefinition(name, values, dirs, _, _, _) ⇒
         val renderedValues = values.zipWithIndex map {
@@ -404,81 +406,80 @@ object QueryRenderer {
               trailingNext orElse (for (c ← etd.trailingComments.headOption; cp ← c.position; sp ← value.position; if cp.line == sp.line) yield c)
 
             (if (idx != 0 && shouldRenderComment(value, prev, config)) config.lineBreak else "") +
-              render(value, config, indentLevel + 1, prev = prev) +
+              renderNode(value, config, indent.inc, prev = prev) +
               trailing.fold("")(c ⇒ renderIndividualComment(c, " ", config))
         } mkString config.mandatoryLineBreak
 
         renderComment(etd, prev, indent, config) +
-            indent + "enum" + config.mandatorySeparator + name +
+            indent.str + "enum" + config.mandatorySeparator + name +
             config.separator +
-            renderDirs(dirs, config) +
+            renderDirs(dirs, config, indent) +
             "{" +
             config.lineBreak +
             renderedValues +
-            renderTrailingComment(etd, values.lastOption, config.indentLevel * (indentLevel + 1), config) +
+            renderTrailingComment(etd, values.lastOption, indent.inc, config) +
             trailingLineBreak(etd, config) +
-            indent +
+            indent.str +
             "}"
 
       case evd @ EnumValueDefinition(name, dirs, _, _) ⇒
         renderComment(evd, prev, indent, config) +
-            indent + name +
-            renderDirs(dirs, config, frontSep = true)
+            indent.str + name +
+            renderDirs(dirs, config, indent, frontSep = true)
 
       case fd @ FieldDefinition(name, fieldType, args, dirs, _, _) ⇒
         renderComment(fd, prev, indent, config) +
-          indent + name +
-          renderInputValueDefs(args, indentLevel, config, withSep = false) +
-          ":" + config.separator + render(fieldType) +
-          renderDirs(dirs, config, frontSep = true)
+          indent.str + name +
+          renderInputValueDefs(args, indent, config, withSep = false) +
+          ":" + config.separator + renderNode(fieldType, config, indent.zero) +
+          renderDirs(dirs, config, indent, frontSep = true)
 
       case ivd @ InputValueDefinition(name, valueType, default, dirs, _, _) ⇒
         renderComment(ivd, prev, indent, config) +
-          indent + name + ":" + config.separator + render(valueType, config) +
-          default.fold("")(d ⇒ config.separator + "=" + config.separator + render(d, config)) +
-          renderDirs(dirs, config, frontSep = true)
+          indent.str + name + ":" + config.separator + renderNode(valueType, config, indent.zero) +
+          default.fold("")(d ⇒ config.separator + "=" + config.separator + renderNode(d, config, indent.zero)) +
+          renderDirs(dirs, config, indent, frontSep = true)
 
       case ted @ TypeExtensionDefinition(definition, _, _) ⇒
         renderComment(ted, prev, indent, config) +
-          render(definition.copy(comments = Vector.empty), config, indentLevel, Some("extend" + config.mandatorySeparator))
+          renderNode(definition.copy(comments = Vector.empty), config, indent, Some("extend" + config.mandatorySeparator))
 
       case dd @ DirectiveDefinition(name, args, locations, _, _) ⇒
         val locsRendered = locations.zipWithIndex map { case (l, idx) ⇒
           (if (idx != 0 && shouldRenderComment(l, None, config)) config.lineBreak else "") +
             (if (shouldRenderComment(l, None, config)) config.lineBreak else if (idx != 0) config.separator else "") +
-            render(l, config, if (shouldRenderComment(l, None, config)) indentLevel + 1 else 0)
+            renderNode(l, config, if (shouldRenderComment(l, None, config)) indent.inc else indent.zero)
         }
 
         renderComment(dd, prev, indent, config) +
-          indent + "directive" + config.separator + "@" + name +
-          renderInputValueDefs(args, indentLevel, config) + (if (args.isEmpty) config.mandatorySeparator else "") +
+          indent.str + "directive" + config.separator + "@" + name +
+          renderInputValueDefs(args, indent, config) + (if (args.isEmpty) config.mandatorySeparator else "") +
           "on" + (if (shouldRenderComment(locations.head, None, config)) "" else config.mandatorySeparator) +
           locsRendered.mkString(config.separator + "|")
 
       case dl @ DirectiveLocation(name, _, _) ⇒
-        renderComment(dl, prev, indent, config) + indent + name
+        renderComment(dl, prev, indent, config) + indent.str + name
 
       case sd @ SchemaDefinition(ops, dirs, _, _, _) ⇒
         val renderedOps = ops.zipWithIndex map { case (op, idx) ⇒
           (if (idx != 0 && shouldRenderComment(op, None, config)) config.lineBreak else "") +
-            render(op, config, indentLevel + 1)
+            renderNode(op, config, indent.inc)
         } mkString config.mandatoryLineBreak
 
         renderComment(sd, prev, indent, config) +
-          indent + "schema"  + config.separator +
-          renderDirs(dirs, config) +
+          indent.str + "schema"  + config.separator +
+          renderDirs(dirs, config, indent) +
           "{" +
           config.lineBreak +
           renderedOps +
-          renderTrailingComment(sd, None, config.indentLevel * (indentLevel + 1), config) +
+          renderTrailingComment(sd, None, indent.inc, config) +
           trailingLineBreak(sd, config) +
-          indent + "}"
+          indent.str + "}"
 
       case otd @ OperationTypeDefinition(op, tpe, _, _) ⇒
         renderComment(otd, prev, indent, config) +
-          indent + renderOpType(op) + ":" + config.separator + render(tpe, config)
+          indent.str + renderOpType(op) + ":" + config.separator + renderNode(tpe, config, indent.zero)
     }
-  }
 
   private def trailingLineBreak(tc: WithTrailingComments, config: QueryRendererConfig) =
     if (shouldRenderComment(tc, config)) config.mandatoryLineBreak else config.lineBreak
@@ -487,13 +488,36 @@ object QueryRenderer {
     if (config.formatInputValues) config.lineBreak
     else ""
 
-  def inputFieldIndent(config: QueryRendererConfig, indent: Int) =
-    if (config.formatInputValues) indent + 1
-    else 0
+  def inputFieldIndent(config: QueryRendererConfig, indent: Indent) =
+    if (config.formatInputValues) indent.inc
+    else indent.zero
 
-  def inputIndent(config: QueryRendererConfig, indent: String) =
-    if (config.formatInputValues) indent
+  def inputIndent(config: QueryRendererConfig, indent: Indent) =
+    if (config.formatInputValues) indent.str
     else ""
+}
+
+case class Indent(config: QueryRendererConfig, level: Int, prevLevel: Int) {
+  lazy val str = config.indentLevel * level
+  lazy val strPrev = config.indentLevel * prevLevel
+
+  def strForce = if (level > 0) str else strPrev
+
+  lazy val zero = copy(level = 0, prevLevel = if (level == 0) prevLevel else level)
+
+  def +(l: Int) = copy(level = level + l, prevLevel = level)
+  def -(l: Int) = {
+    val newLevel = level - l
+
+    if (newLevel >= 0) this
+    else copy(level = level + l, prevLevel = level)
+  }
+
+  def inc = this + 1
+  def dec = this - 1
+
+  def incForce =
+    if (level > 0) this + 1 else copy(level = prevLevel + 1, prevLevel = prevLevel)
 }
 
 case class QueryRendererConfig(

--- a/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -634,7 +634,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
       d.arguments.find(_.name == ReasonArg.name) match {
         case Some(reason) ⇒
           reason.value match {
-            case ast.StringValue(value, _, _) ⇒ Some(value)
+            case ast.StringValue(value, _, _, _) ⇒ Some(value)
             case _ ⇒ None
           }
         case None ⇒ Some(DefaultDeprecationReason)

--- a/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -634,7 +634,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
       d.arguments.find(_.name == ReasonArg.name) match {
         case Some(reason) ⇒
           reason.value match {
-            case ast.StringValue(value, _, _, _) ⇒ Some(value)
+            case ast.StringValue(value, _, _, _, _) ⇒ Some(value)
             case _ ⇒ None
           }
         case None ⇒ Some(DefaultDeprecationReason)

--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -140,7 +140,7 @@ package object schema {
       case _ ⇒ Left(StringCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(s, _, _, _) ⇒ Right(s)
+      case ast.StringValue(s, _, _, _, _) ⇒ Right(s)
       case _ ⇒ Left(StringCoercionViolation)
     })
 
@@ -160,7 +160,7 @@ package object schema {
       case _ ⇒ Left(IDCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(id, _, _, _) ⇒ Right(id)
+      case ast.StringValue(id, _, _, _, _) ⇒ Right(id)
       case ast.IntValue(id, _, _) ⇒ Right(id.toString)
       case ast.BigIntValue(id, _, _) ⇒ Right(id.toString)
       case _ ⇒ Left(IDCoercionViolation)

--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -140,7 +140,7 @@ package object schema {
       case _ ⇒ Left(StringCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(s, _, _) ⇒ Right(s)
+      case ast.StringValue(s, _, _, _) ⇒ Right(s)
       case _ ⇒ Left(StringCoercionViolation)
     })
 
@@ -160,7 +160,7 @@ package object schema {
       case _ ⇒ Left(IDCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(id, _, _) ⇒ Right(id)
+      case ast.StringValue(id, _, _, _) ⇒ Right(id)
       case ast.IntValue(id, _, _) ⇒ Right(id.toString)
       case ast.BigIntValue(id, _, _) ⇒ Right(id.toString)
       case _ ⇒ Left(IDCoercionViolation)

--- a/src/main/scala/sangria/util/StringUtil.scala
+++ b/src/main/scala/sangria/util/StringUtil.scala
@@ -93,4 +93,35 @@ object StringUtil {
 
   def charHex(ch: Char): String =
     Integer.toHexString(ch).toUpperCase(Locale.ENGLISH)
+
+  /**
+    * Produces the value of a block string from its parsed raw value, similar to
+    * Coffeescript's block string, Python's docstring trim or Ruby's strip_heredoc.
+    *
+    * This implements the GraphQL spec's BlockStringValue() static algorithm.
+    */
+  def blockStringValue(rawString: String): String = {
+    val lines = rawString.split("""\r\n|[\n\r]""")
+    val lineSizes = lines.map(l ⇒ l → leadingWhitespace(l))
+    val commonIndentLines = lineSizes.drop(1).collect {case (line, size) if size != line.length ⇒ size}
+    val strippedLines =
+      if (commonIndentLines.nonEmpty) {
+        val commonIndent = commonIndentLines.min
+
+        lines.take(1) ++ lines.drop(1).map(_.drop(commonIndent))
+      } else lines
+    val trimmedLines = strippedLines.reverse.dropWhile(isBlank).reverse.dropWhile(isBlank)
+
+    trimmedLines.mkString("\n")
+  }
+
+  private def leadingWhitespace(str: String) =  {
+    var i = 0
+
+    while (i < str.length && (str.charAt(i) == ' ' || str.charAt(i) == '\t')) i += 1
+
+    i
+  }
+
+  private def isBlank(str: String) = leadingWhitespace(str) == str.length
 }

--- a/src/main/scala/sangria/util/StringUtil.scala
+++ b/src/main/scala/sangria/util/StringUtil.scala
@@ -71,6 +71,8 @@ object StringUtil {
     d(a.length)(b.length)
   }
 
+  def escapeBlockString(str: String) = str.replaceAll("\"\"\"", "\\\\\"\"\"")
+
   def escapeString(str: String) =
     str flatMap {
       case ch if ch > 0xfff ⇒ "\\u" + charHex(ch)

--- a/src/test/resources/queries/block-string-rendered.graphql
+++ b/src/test/resources/queries/block-string-rendered.graphql
@@ -1,18 +1,18 @@
 query FetchLukeAndLeiaAliased($someVar: String = """
-hello \
-  world
-""") {
+  hello \
+    world
+  """) {
   luke: human(id: "1000", bar: """
- \"test
-123 \u0000
-""")
+     \"test
+    123 \u0000
+    """)
   ...Foo
 }
 
 fragment Foo on User @foo(bar: 1) {
   baz @docs(info: """
-\"""
-\""" this " is ""
-a description! \"""
-""")
+    \"""
+    \""" this " is ""
+    a description! \"""
+    """)
 }

--- a/src/test/resources/queries/block-string-rendered.graphql
+++ b/src/test/resources/queries/block-string-rendered.graphql
@@ -1,0 +1,18 @@
+query FetchLukeAndLeiaAliased($someVar: String = """
+hello \
+  world
+""") {
+  luke: human(id: "1000", bar: """
+ \"test
+123 \u0000
+""")
+  ...Foo
+}
+
+fragment Foo on User @foo(bar: 1) {
+  baz @docs(info: """
+\"""
+\""" this " is ""
+a description! \"""
+""")
+}

--- a/src/test/resources/queries/block-string.graphql
+++ b/src/test/resources/queries/block-string.graphql
@@ -1,0 +1,19 @@
+query FetchLukeAndLeiaAliased($someVar: String =
+    """
+    hello \
+      world""") {
+  luke: human(id: "1000", bar: """ \"test
+     123 \u0000
+     """)
+
+  ...Foo
+}
+
+fragment Foo on User @foo(bar: 1){
+  baz @docs(info:
+    """\"""
+    \""" this " is ""
+    a description! \"""
+    """)
+}
+      

--- a/src/test/scala/sangria/execution/QueryReducerSpec.scala
+++ b/src/test/scala/sangria/execution/QueryReducerSpec.scala
@@ -27,7 +27,7 @@ class QueryReducerSpec extends WordSpec with Matchers with FutureResultSupport {
       case _ ⇒ Left(StringCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(id, _, _, _) ⇒ Right(id)
+      case ast.StringValue(id, _, _, _, _) ⇒ Right(id)
       case _ ⇒ Left(StringCoercionViolation)
     })
 

--- a/src/test/scala/sangria/execution/QueryReducerSpec.scala
+++ b/src/test/scala/sangria/execution/QueryReducerSpec.scala
@@ -27,7 +27,7 @@ class QueryReducerSpec extends WordSpec with Matchers with FutureResultSupport {
       case _ ⇒ Left(StringCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(id, _, _) ⇒ Right(id)
+      case ast.StringValue(id, _, _, _) ⇒ Right(id)
       case _ ⇒ Left(StringCoercionViolation)
     })
 

--- a/src/test/scala/sangria/macros/LiteralMacroSpec.scala
+++ b/src/test/scala/sangria/macros/LiteralMacroSpec.scala
@@ -91,7 +91,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("1000", Vector.empty, Some(Position(176, 4, 29))),
+                      StringValue("1000", false, Vector.empty, Some(Position(176, 4, 29))),
                       Vector.empty,
                       Some(Position(172, 4, 25))
                     )),
@@ -135,7 +135,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("10103\n \u00F6 \u00F6", Vector.empty, Some(Position(284, 7, 34))),
+                      StringValue("10103\n \u00F6 \u00F6", false, Vector.empty, Some(Position(284, 7, 34))),
                       Vector.empty,
                       Some(Position(275, 7, 25))
                     )),
@@ -592,7 +592,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                         Vector(
                           ObjectField(
                             "key",
-                            StringValue("value", Vector.empty, Some(Position(1348, 46, 50))),
+                            StringValue("value", false, Vector.empty, Some(Position(1348, 46, 50))),
                             Vector.empty,
                             Some(Position(1343, 46, 45))
                           )),
@@ -772,11 +772,11 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                 FieldDefinition("one", NamedType("Type", Some(Position(498, 15, 18))), Vector.empty, Vector.empty, Vector.empty, Some(Position(493, 15, 13))),
                 FieldDefinition("two", NamedType("Type", Some(Position(542, 16, 40))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(529, 16, 27))), Some(Position(529, 16, 27))), None, Vector.empty, Vector.empty, Some(Position(519, 16, 17)))), Vector.empty, Vector.empty, Some(Position(515, 16, 13))),
                 FieldDefinition("three", NamedType("Int", Some(Position(602, 17, 56))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(575, 17, 29))), None, Vector.empty, Vector.empty, Some(Position(565, 17, 19))), InputValueDefinition("other", NamedType("String", Some(Position(593, 17, 47))), None, Vector.empty, Vector.empty, Some(Position(586, 17, 40)))), Vector.empty, Vector.empty, Some(Position(559, 17, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(653, 18, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(633, 18, 28))), Some(StringValue("string", Vector.empty, Some(Position(642, 18, 37)))), Vector.empty, Vector.empty, Some(Position(623, 18, 18)))), Vector.empty, Vector.empty, Some(Position(618, 18, 13))),
+                FieldDefinition("four", NamedType("String", Some(Position(653, 18, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(633, 18, 28))), Some(StringValue("string", false, Vector.empty, Some(Position(642, 18, 37)))), Vector.empty, Vector.empty, Some(Position(623, 18, 18)))), Vector.empty, Vector.empty, Some(Position(618, 18, 13))),
                 FieldDefinition("five", NamedType("String", Some(Position(721, 19, 62))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(688, 19, 29))), Some(Position(687, 19, 28))), Some(ListValue(
                   Vector(
-                    StringValue("string", Vector.empty, Some(Position(699, 19, 40))),
-                    StringValue("string", Vector.empty, Some(Position(709, 19, 50)))),
+                    StringValue("string", false, Vector.empty, Some(Position(699, 19, 40))),
+                    StringValue("string", false, Vector.empty, Some(Position(709, 19, 50)))),
                   Vector.empty,
                   Some(Position(698, 19, 39))
                 )), Vector.empty, Vector.empty, Some(Position(677, 19, 18)))), Vector.empty, Vector.empty, Some(Position(672, 19, 13))),
@@ -784,7 +784,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", Vector.empty, Some(Position(772, 20, 45))),
+                      StringValue("value", false, Vector.empty, Some(Position(772, 20, 45))),
                       Vector.empty,
                       Some(Position(767, 20, 40))
                     )),
@@ -800,7 +800,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(916, 24, 59))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(890, 24, 33))), Some(StringValue("default", Vector.empty, Some(Position(897, 24, 40)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(Position(916, 24, 59))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(890, 24, 33))), Some(StringValue("default", false, Vector.empty, Some(Position(897, 24, 40)))), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
@@ -817,7 +817,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", Vector.empty, Some(Position(847, 23, 47))),
+                      StringValue("value", false, Vector.empty, Some(Position(847, 23, 47))),
                       Vector.empty,
                       Some(Position(842, 23, 42))
                     )),
@@ -832,7 +832,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               "Bar",
               Vector(
                 FieldDefinition("one", NamedType("Type", Some(Position(1017, 29, 18))), Vector.empty, Vector.empty, Vector.empty, Some(Position(1012, 29, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(1069, 30, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(1049, 30, 28))), Some(StringValue("string", Vector.empty, Some(Position(1058, 30, 37)))), Vector.empty, Vector.empty, Some(Position(1039, 30, 18)))), Vector.empty, Vector.empty, Some(Position(1034, 30, 13)))),
+                FieldDefinition("four", NamedType("String", Some(Position(1069, 30, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(1049, 30, 28))), Some(StringValue("string", false, Vector.empty, Some(Position(1058, 30, 37)))), Vector.empty, Vector.empty, Some(Position(1039, 30, 18)))), Vector.empty, Vector.empty, Some(Position(1034, 30, 13)))),
               Vector.empty,
               Vector(
                 Comment(" It's an interface!", Some(Position(953, 27, 11)))),

--- a/src/test/scala/sangria/macros/LiteralMacroSpec.scala
+++ b/src/test/scala/sangria/macros/LiteralMacroSpec.scala
@@ -91,7 +91,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("1000", false, Vector.empty, Some(Position(176, 4, 29))),
+                      StringValue("1000", false, None, Vector.empty, Some(Position(176, 4, 29))),
                       Vector.empty,
                       Some(Position(172, 4, 25))
                     )),
@@ -135,7 +135,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("10103\n \u00F6 \u00F6", false, Vector.empty, Some(Position(284, 7, 34))),
+                      StringValue("10103\n \u00F6 \u00F6", false, None, Vector.empty, Some(Position(284, 7, 34))),
                       Vector.empty,
                       Some(Position(275, 7, 25))
                     )),
@@ -592,7 +592,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                         Vector(
                           ObjectField(
                             "key",
-                            StringValue("value", false, Vector.empty, Some(Position(1348, 46, 50))),
+                            StringValue("value", false, None, Vector.empty, Some(Position(1348, 46, 50))),
                             Vector.empty,
                             Some(Position(1343, 46, 45))
                           )),
@@ -772,11 +772,11 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                 FieldDefinition("one", NamedType("Type", Some(Position(498, 15, 18))), Vector.empty, Vector.empty, Vector.empty, Some(Position(493, 15, 13))),
                 FieldDefinition("two", NamedType("Type", Some(Position(542, 16, 40))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(529, 16, 27))), Some(Position(529, 16, 27))), None, Vector.empty, Vector.empty, Some(Position(519, 16, 17)))), Vector.empty, Vector.empty, Some(Position(515, 16, 13))),
                 FieldDefinition("three", NamedType("Int", Some(Position(602, 17, 56))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(575, 17, 29))), None, Vector.empty, Vector.empty, Some(Position(565, 17, 19))), InputValueDefinition("other", NamedType("String", Some(Position(593, 17, 47))), None, Vector.empty, Vector.empty, Some(Position(586, 17, 40)))), Vector.empty, Vector.empty, Some(Position(559, 17, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(653, 18, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(633, 18, 28))), Some(StringValue("string", false, Vector.empty, Some(Position(642, 18, 37)))), Vector.empty, Vector.empty, Some(Position(623, 18, 18)))), Vector.empty, Vector.empty, Some(Position(618, 18, 13))),
+                FieldDefinition("four", NamedType("String", Some(Position(653, 18, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(633, 18, 28))), Some(StringValue("string", false, None, Vector.empty, Some(Position(642, 18, 37)))), Vector.empty, Vector.empty, Some(Position(623, 18, 18)))), Vector.empty, Vector.empty, Some(Position(618, 18, 13))),
                 FieldDefinition("five", NamedType("String", Some(Position(721, 19, 62))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(688, 19, 29))), Some(Position(687, 19, 28))), Some(ListValue(
                   Vector(
-                    StringValue("string", false, Vector.empty, Some(Position(699, 19, 40))),
-                    StringValue("string", false, Vector.empty, Some(Position(709, 19, 50)))),
+                    StringValue("string", false, None, Vector.empty, Some(Position(699, 19, 40))),
+                    StringValue("string", false, None, Vector.empty, Some(Position(709, 19, 50)))),
                   Vector.empty,
                   Some(Position(698, 19, 39))
                 )), Vector.empty, Vector.empty, Some(Position(677, 19, 18)))), Vector.empty, Vector.empty, Some(Position(672, 19, 13))),
@@ -784,7 +784,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", false, Vector.empty, Some(Position(772, 20, 45))),
+                      StringValue("value", false, None, Vector.empty, Some(Position(772, 20, 45))),
                       Vector.empty,
                       Some(Position(767, 20, 40))
                     )),
@@ -800,7 +800,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(916, 24, 59))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(890, 24, 33))), Some(StringValue("default", false, Vector.empty, Some(Position(897, 24, 40)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(Position(916, 24, 59))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(890, 24, 33))), Some(StringValue("default", false, None, Vector.empty, Some(Position(897, 24, 40)))), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
@@ -817,7 +817,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", false, Vector.empty, Some(Position(847, 23, 47))),
+                      StringValue("value", false, None, Vector.empty, Some(Position(847, 23, 47))),
                       Vector.empty,
                       Some(Position(842, 23, 42))
                     )),
@@ -832,7 +832,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               "Bar",
               Vector(
                 FieldDefinition("one", NamedType("Type", Some(Position(1017, 29, 18))), Vector.empty, Vector.empty, Vector.empty, Some(Position(1012, 29, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(1069, 30, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(1049, 30, 28))), Some(StringValue("string", false, Vector.empty, Some(Position(1058, 30, 37)))), Vector.empty, Vector.empty, Some(Position(1039, 30, 18)))), Vector.empty, Vector.empty, Some(Position(1034, 30, 13)))),
+                FieldDefinition("four", NamedType("String", Some(Position(1069, 30, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(1049, 30, 28))), Some(StringValue("string", false, None, Vector.empty, Some(Position(1058, 30, 37)))), Vector.empty, Vector.empty, Some(Position(1039, 30, 18)))), Vector.empty, Vector.empty, Some(Position(1034, 30, 13)))),
               Vector.empty,
               Vector(
                 Comment(" It's an interface!", Some(Position(953, 27, 11)))),

--- a/src/test/scala/sangria/marshalling/IonSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/IonSupportSpec.scala
@@ -40,7 +40,7 @@ class IonSupportSpec extends WordSpec with Matchers with FutureResultSupport {
       case _ ⇒ Left(DateCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(s, _, _, _) ⇒ parseDate(s)
+      case ast.StringValue(s, _, _, _, _) ⇒ parseDate(s)
       case _ ⇒ Left(DateCoercionViolation)
     })
 

--- a/src/test/scala/sangria/marshalling/IonSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/IonSupportSpec.scala
@@ -40,7 +40,7 @@ class IonSupportSpec extends WordSpec with Matchers with FutureResultSupport {
       case _ ⇒ Left(DateCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(s, _, _) ⇒ parseDate(s)
+      case ast.StringValue(s, _, _, _) ⇒ parseDate(s)
       case _ ⇒ Left(DateCoercionViolation)
     })
 

--- a/src/test/scala/sangria/parser/QueryParserSpec.scala
+++ b/src/test/scala/sangria/parser/QueryParserSpec.scala
@@ -4,7 +4,7 @@ import language.postfixOps
 import org.parboiled2.Position
 import org.scalatest.{Matchers, WordSpec}
 import sangria.ast._
-import sangria.util.{FileUtil, StringMatchers}
+import sangria.util.{DebugUtil, FileUtil, StringMatchers}
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
@@ -977,6 +977,21 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             Some(BigDecimalValue(expected._2, Vector.empty, Some(Position(24, 1, 25)))))
         }
       }
+    }
+
+    "parse block string values" in {
+      val q = "\"\"\""
+
+      val stringValue =
+        s"""
+          $q
+            hello,
+              world
+          $q
+        """
+
+      QueryParser.parseInput(stripCarriageReturns(stringValue)) should be (
+        Success(StringValue("\n            hello,\n              world\n          ", true, Vector.empty, Some(Position(11, 2, 11)))))
     }
 
     "parse input values independently" in {

--- a/src/test/scala/sangria/parser/QueryParserSpec.scala
+++ b/src/test/scala/sangria/parser/QueryParserSpec.scala
@@ -68,7 +68,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("1000", Vector.empty, Some(Position(145, 3, 19))),
+                      StringValue("1000", false, Vector.empty, Some(Position(145, 3, 19))),
                       Vector.empty,
                       Some(Position(141, 3, 15))
                     )),
@@ -112,7 +112,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("10103\n \u00F6 \u00F6", Vector.empty, Some(Position(223, 6, 24))),
+                      StringValue("10103\n \u00F6 \u00F6", false, Vector.empty, Some(Position(223, 6, 24))),
                       Vector.empty,
                       Some(Position(214, 6, 15))
                     )),
@@ -516,7 +516,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                         Vector(
                           ObjectField(
                             "key",
-                            StringValue("value", Vector.empty, Some(Position(937, 45, 40))),
+                            StringValue("value", false, Vector.empty, Some(Position(937, 45, 40))),
                             Vector.empty,
                             Some(Position(932, 45, 35))
                           )),
@@ -988,14 +988,14 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
           Vector(
             BigIntValue(1, Vector.empty, Some(Position(1, 1, 2))),
             BigIntValue(2, Vector.empty, Some(Position(4, 1, 5))),
-            StringValue("test", Vector.empty, Some(Position(6, 1, 7)))),
+            StringValue("test", false, Vector.empty, Some(Position(6, 1, 7)))),
           Vector.empty,
           Some(Position(0, 1, 1))),
         "{a: 1, b: \"foo\" c: {nest: true, oops: null, e: FOO_BAR}}" →
           ObjectValue(
             Vector(
               ObjectField("a", BigIntValue(1, Vector.empty, Some(Position(4, 1, 5))), Vector.empty, Some(Position(1, 1, 2))),
-              ObjectField("b", StringValue("foo", Vector.empty, Some(Position(10, 1, 11))), Vector.empty, Some(Position(7, 1, 8))),
+              ObjectField("b", StringValue("foo", false, Vector.empty, Some(Position(10, 1, 11))), Vector.empty, Some(Position(7, 1, 8))),
               ObjectField("c",
                 ObjectValue(
                   Vector(
@@ -1019,7 +1019,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
           ObjectValue(
             Vector(
               ObjectField("a", BigIntValue(1, Vector.empty, Some(Position(26, 3, 15))), Vector.empty, Some(Position(23, 3, 12))),
-              ObjectField("b", StringValue("foo", Vector.empty, Some(Position(80, 6, 15))),
+              ObjectField("b", StringValue("foo", false, Vector.empty, Some(Position(80, 6, 15))),
                 Vector(Comment(" This is a test comment!", Some(Position(40, 5, 12)))),
                 Some(Position(77, 6, 12)))),
               Vector.empty,
@@ -1071,7 +1071,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                     Vector(
                       ObjectField(
                         "field1",
-                        StringValue("val", Vector(Comment(" comment 18.11", Some(Position(849, 61, 1))), Comment(" comment 18.12", Some(Position(865, 62, 1)))), Some(Position(881, 63, 1))),
+                        StringValue("val", false, Vector(Comment(" comment 18.11", Some(Position(849, 61, 1))), Comment(" comment 18.12", Some(Position(865, 62, 1)))), Some(Position(881, 63, 1))),
                         Vector(
                           Comment(" comment 18.7", Some(Position(779, 55, 1))),
                           Comment(" comment 18.8", Some(Position(794, 56, 1)))),

--- a/src/test/scala/sangria/parser/SchemaParserSpec.scala
+++ b/src/test/scala/sangria/parser/SchemaParserSpec.scala
@@ -39,11 +39,11 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                 FieldDefinition("one", NamedType("Type", Some(Position(377, 14, 8))), Vector.empty, Vector.empty, Vector.empty, Some(Position(372, 14, 3))),
                 FieldDefinition("two", NamedType("Type", Some(Position(411, 15, 30))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(398, 15, 17))), Some(Position(398, 15, 17))), None, Vector.empty, Vector.empty, Some(Position(388, 15, 7)))), Vector.empty, Vector.empty, Some(Position(384, 15, 3))),
                 FieldDefinition("three", NamedType("Int", Some(Position(461, 16, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(434, 16, 19))), None, Vector.empty, Vector.empty, Some(Position(424, 16, 9))), InputValueDefinition("other", NamedType("String", Some(Position(452, 16, 37))), None, Vector.empty, Vector.empty, Some(Position(445, 16, 30)))), Vector.empty, Vector.empty, Some(Position(418, 16, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(502, 17, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(482, 17, 18))), Some(StringValue("string", false, Vector.empty, Some(Position(491, 17, 27)))), Vector.empty, Vector.empty, Some(Position(472, 17, 8)))), Vector.empty, Vector.empty, Some(Position(467, 17, 3))),
+                FieldDefinition("four", NamedType("String", Some(Position(502, 17, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(482, 17, 18))), Some(StringValue("string", false, None, Vector.empty, Some(Position(491, 17, 27)))), Vector.empty, Vector.empty, Some(Position(472, 17, 8)))), Vector.empty, Vector.empty, Some(Position(467, 17, 3))),
                 FieldDefinition("five", NamedType("String", Some(Position(560, 18, 52))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(527, 18, 19))), Some(Position(526, 18, 18))), Some(ListValue(
                   Vector(
-                    StringValue("string", false, Vector.empty, Some(Position(538, 18, 30))),
-                    StringValue("string", false, Vector.empty, Some(Position(548, 18, 40)))),
+                    StringValue("string", false, None, Vector.empty, Some(Position(538, 18, 30))),
+                    StringValue("string", false, None, Vector.empty, Some(Position(548, 18, 40)))),
                   Vector.empty,
                   Some(Position(537, 18, 29))
                 )), Vector.empty, Vector.empty, Some(Position(516, 18, 8)))), Vector.empty, Vector.empty, Some(Position(511, 18, 3))),
@@ -51,7 +51,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", false, Vector.empty, Some(Position(601, 19, 35))),
+                      StringValue("value", false, None, Vector.empty, Some(Position(601, 19, 35))),
                       Vector.empty,
                       Some(Position(596, 19, 30))
                     )),
@@ -67,7 +67,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(715, 23, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(689, 23, 23))), Some(StringValue("default", false, Vector.empty, Some(Position(696, 23, 30)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(Position(715, 23, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(689, 23, 23))), Some(StringValue("default", false, None, Vector.empty, Some(Position(696, 23, 30)))), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
@@ -84,7 +84,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", false, Vector.empty, Some(Position(656, 22, 37))),
+                      StringValue("value", false, None, Vector.empty, Some(Position(656, 22, 37))),
                       Vector.empty,
                       Some(Position(651, 22, 32))
                     )),
@@ -99,7 +99,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "Bar",
               Vector(
                 FieldDefinition("one", NamedType("Type", Some(Position(776, 28, 8))), Vector.empty, Vector.empty, Vector.empty, Some(Position(771, 28, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(818, 29, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(798, 29, 18))), Some(StringValue("string", false, Vector.empty, Some(Position(807, 29, 27)))), Vector.empty, Vector.empty, Some(Position(788, 29, 8)))), Vector.empty, Vector.empty, Some(Position(783, 29, 3)))),
+                FieldDefinition("four", NamedType("String", Some(Position(818, 29, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(798, 29, 18))), Some(StringValue("string", false, None, Vector.empty, Some(Position(807, 29, 27)))), Vector.empty, Vector.empty, Some(Position(788, 29, 8)))), Vector.empty, Vector.empty, Some(Position(783, 29, 3)))),
               Vector.empty,
               Vector(
                 Comment(" It's an interface!", Some(Position(732, 26, 1)))),

--- a/src/test/scala/sangria/parser/SchemaParserSpec.scala
+++ b/src/test/scala/sangria/parser/SchemaParserSpec.scala
@@ -39,11 +39,11 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                 FieldDefinition("one", NamedType("Type", Some(Position(377, 14, 8))), Vector.empty, Vector.empty, Vector.empty, Some(Position(372, 14, 3))),
                 FieldDefinition("two", NamedType("Type", Some(Position(411, 15, 30))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(398, 15, 17))), Some(Position(398, 15, 17))), None, Vector.empty, Vector.empty, Some(Position(388, 15, 7)))), Vector.empty, Vector.empty, Some(Position(384, 15, 3))),
                 FieldDefinition("three", NamedType("Int", Some(Position(461, 16, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(434, 16, 19))), None, Vector.empty, Vector.empty, Some(Position(424, 16, 9))), InputValueDefinition("other", NamedType("String", Some(Position(452, 16, 37))), None, Vector.empty, Vector.empty, Some(Position(445, 16, 30)))), Vector.empty, Vector.empty, Some(Position(418, 16, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(502, 17, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(482, 17, 18))), Some(StringValue("string", Vector.empty, Some(Position(491, 17, 27)))), Vector.empty, Vector.empty, Some(Position(472, 17, 8)))), Vector.empty, Vector.empty, Some(Position(467, 17, 3))),
+                FieldDefinition("four", NamedType("String", Some(Position(502, 17, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(482, 17, 18))), Some(StringValue("string", false, Vector.empty, Some(Position(491, 17, 27)))), Vector.empty, Vector.empty, Some(Position(472, 17, 8)))), Vector.empty, Vector.empty, Some(Position(467, 17, 3))),
                 FieldDefinition("five", NamedType("String", Some(Position(560, 18, 52))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(527, 18, 19))), Some(Position(526, 18, 18))), Some(ListValue(
                   Vector(
-                    StringValue("string", Vector.empty, Some(Position(538, 18, 30))),
-                    StringValue("string", Vector.empty, Some(Position(548, 18, 40)))),
+                    StringValue("string", false, Vector.empty, Some(Position(538, 18, 30))),
+                    StringValue("string", false, Vector.empty, Some(Position(548, 18, 40)))),
                   Vector.empty,
                   Some(Position(537, 18, 29))
                 )), Vector.empty, Vector.empty, Some(Position(516, 18, 8)))), Vector.empty, Vector.empty, Some(Position(511, 18, 3))),
@@ -51,7 +51,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", Vector.empty, Some(Position(601, 19, 35))),
+                      StringValue("value", false, Vector.empty, Some(Position(601, 19, 35))),
                       Vector.empty,
                       Some(Position(596, 19, 30))
                     )),
@@ -67,7 +67,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(715, 23, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(689, 23, 23))), Some(StringValue("default", Vector.empty, Some(Position(696, 23, 30)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(Position(715, 23, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(689, 23, 23))), Some(StringValue("default", false, Vector.empty, Some(Position(696, 23, 30)))), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
@@ -84,7 +84,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", Vector.empty, Some(Position(656, 22, 37))),
+                      StringValue("value", false, Vector.empty, Some(Position(656, 22, 37))),
                       Vector.empty,
                       Some(Position(651, 22, 32))
                     )),
@@ -99,7 +99,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "Bar",
               Vector(
                 FieldDefinition("one", NamedType("Type", Some(Position(776, 28, 8))), Vector.empty, Vector.empty, Vector.empty, Some(Position(771, 28, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(818, 29, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(798, 29, 18))), Some(StringValue("string", Vector.empty, Some(Position(807, 29, 27)))), Vector.empty, Vector.empty, Some(Position(788, 29, 8)))), Vector.empty, Vector.empty, Some(Position(783, 29, 3)))),
+                FieldDefinition("four", NamedType("String", Some(Position(818, 29, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(798, 29, 18))), Some(StringValue("string", false, Vector.empty, Some(Position(807, 29, 27)))), Vector.empty, Vector.empty, Some(Position(788, 29, 8)))), Vector.empty, Vector.empty, Some(Position(783, 29, 3)))),
               Vector.empty,
               Vector(
                 Comment(" It's an interface!", Some(Position(732, 26, 1)))),

--- a/src/test/scala/sangria/renderer/QueryRendererSpec.scala
+++ b/src/test/scala/sangria/renderer/QueryRendererSpec.scala
@@ -617,7 +617,6 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
           "}\nfragment Foo on User@foo(bar:1){baz@docs(info:\"\\\"\\\"\\\"\\n\\\"" +
           "\\\"\\\" this \\\" is \\\"\\\"\\na description! \\\"\\\"\\\"\")}")
 
-        // TODO: improve pretty rendering for block strings
         prettyRendered should equal (FileUtil loadQuery "block-string-rendered.graphql") (after being strippedOfCarriageReturns)
       }
     }

--- a/src/test/scala/sangria/renderer/QueryRendererSpec.scala
+++ b/src/test/scala/sangria/renderer/QueryRendererSpec.scala
@@ -1,11 +1,12 @@
 package sangria.renderer
 
 import org.scalatest.{Matchers, WordSpec}
-import sangria.ast.{Directive, Field, AstNode}
+import sangria.ast._
 import sangria.parser.QueryParser
-import sangria.util.{StringMatchers, FileUtil}
+import sangria.util.{FileUtil, StringMatchers}
 import sangria.ast
 import sangria.macros._
+import sangria.visitor.VisitorCommand
 
 import scala.util.Success
 
@@ -557,6 +558,67 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
             |  }
             |}""".stripMargin) (after being strippedOfCarriageReturns)
 
+      }
+
+      "render queries with block strings (erase block meta-info)" in {
+        val Success(origAst) = QueryParser.parse(FileUtil loadQuery "block-string.graphql")
+
+        val ast = AstVisitor.visit(origAst, AstVisitor {
+          case s: StringValue ⇒ VisitorCommand.Transform(s.copy(block = false, blockRawValue = None))
+        })
+
+        val prettyRendered = QueryRenderer.render(ast, QueryRenderer.Pretty)
+        val compactRendered = QueryRenderer.render(ast, QueryRenderer.Compact)
+
+        val Success(prettyParsed) = QueryParser.parse(prettyRendered)
+        val Success(compactParsed) = QueryParser.parse(compactRendered)
+
+        AstNode.withoutPosition(ast) should be (AstNode.withoutPosition(prettyParsed))
+        AstNode.withoutPosition(ast, stripComments = true) should be (
+          AstNode.withoutPosition(compactParsed, stripComments = true))
+
+        compactRendered should be (
+          "query FetchLukeAndLeiaAliased($someVar:String=\"hello \\\\\\n  world\"" +
+          "){luke:human(id:\"1000\",bar:\" \\\\\\\"test\\n123 \\\\u0000\") ...Foo" +
+          "}\nfragment Foo on User@foo(bar:1){baz@docs(info:\"\\\"\\\"\\\"\\n\\\"" +
+          "\\\"\\\" this \\\" is \\\"\\\"\\na description! \\\"\\\"\\\"\")}")
+
+        prettyRendered should equal (
+          """query FetchLukeAndLeiaAliased($someVar: String = "hello \\\n  world") {
+            |  luke: human(id: "1000", bar: " \\\"test\n123 \\u0000")
+            |  ...Foo
+            |}
+            |
+            |fragment Foo on User @foo(bar: 1) {
+            |  baz @docs(info: "\"\"\"\n\"\"\" this \" is \"\"\na description! \"\"\"")
+            |}""".stripMargin) (after being strippedOfCarriageReturns)
+      }
+
+      "render queries with block strings " in {
+        val Success(ast) = QueryParser.parse(FileUtil loadQuery "block-string.graphql")
+
+        def withoutRaw(withRaw: Document, block: Boolean = true) = AstVisitor.visit(withRaw, AstVisitor {
+          case s: StringValue ⇒ VisitorCommand.Transform(s.copy(block = if (block) s.block else false, blockRawValue = None))
+        })
+
+        val prettyRendered = QueryRenderer.render(ast, QueryRenderer.Pretty)
+        val compactRendered = QueryRenderer.render(ast, QueryRenderer.Compact)
+        
+        val Success(prettyParsed) = QueryParser.parse(prettyRendered)
+        val Success(compactParsed) = QueryParser.parse(compactRendered)
+
+        AstNode.withoutPosition(withoutRaw(ast)) should be (AstNode.withoutPosition(withoutRaw(prettyParsed)))
+        AstNode.withoutPosition(withoutRaw(ast, block = false), stripComments = true) should be (
+          AstNode.withoutPosition(withoutRaw(compactParsed, block = false), stripComments = true))
+
+        compactRendered should be (
+          "query FetchLukeAndLeiaAliased($someVar:String=\"hello \\\\\\n  world\"" +
+          "){luke:human(id:\"1000\",bar:\" \\\\\\\"test\\n123 \\\\u0000\") ...Foo" +
+          "}\nfragment Foo on User@foo(bar:1){baz@docs(info:\"\\\"\\\"\\\"\\n\\\"" +
+          "\\\"\\\" this \\\" is \\\"\\\"\\na description! \\\"\\\"\\\"\")}")
+
+        // TODO: improve pretty rendering for block strings
+        prettyRendered should equal (FileUtil loadQuery "block-string-rendered.graphql") (after being strippedOfCarriageReturns)
       }
     }
 

--- a/src/test/scala/sangria/schema/CustomScalarSpec.scala
+++ b/src/test/scala/sangria/schema/CustomScalarSpec.scala
@@ -31,7 +31,7 @@ class CustomScalarSpec extends WordSpec with Matchers {
           case _ ⇒ Left(DateCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _) ⇒ parseDate(s)
+          case ast.StringValue(s, _, _, _) ⇒ parseDate(s)
           case _ ⇒ Left(DateCoercionViolation)
         })
 

--- a/src/test/scala/sangria/schema/CustomScalarSpec.scala
+++ b/src/test/scala/sangria/schema/CustomScalarSpec.scala
@@ -31,7 +31,7 @@ class CustomScalarSpec extends WordSpec with Matchers {
           case _ ⇒ Left(DateCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _, _) ⇒ parseDate(s)
+          case ast.StringValue(s, _, _, _, _) ⇒ parseDate(s)
           case _ ⇒ Left(DateCoercionViolation)
         })
 

--- a/src/test/scala/sangria/schema/ResolverBasedAstSchemaBuilderSpec.scala
+++ b/src/test/scala/sangria/schema/ResolverBasedAstSchemaBuilderSpec.scala
@@ -34,7 +34,7 @@ class ResolverBasedAstSchemaBuilderSpec extends WordSpec with Matchers with Futu
         case _ ⇒ Left(UUIDViolation)
       },
       coerceInput = {
-        case ast.StringValue(s, _, _, _) ⇒ parseUuid(s)
+        case ast.StringValue(s, _, _, _, _) ⇒ parseUuid(s)
         case _ ⇒ Left(UUIDViolation)
       })
 

--- a/src/test/scala/sangria/schema/ResolverBasedAstSchemaBuilderSpec.scala
+++ b/src/test/scala/sangria/schema/ResolverBasedAstSchemaBuilderSpec.scala
@@ -34,7 +34,7 @@ class ResolverBasedAstSchemaBuilderSpec extends WordSpec with Matchers with Futu
         case _ ⇒ Left(UUIDViolation)
       },
       coerceInput = {
-        case ast.StringValue(s, _, _) ⇒ parseUuid(s)
+        case ast.StringValue(s, _, _, _) ⇒ parseUuid(s)
         case _ ⇒ Left(UUIDViolation)
       })
 

--- a/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
@@ -39,7 +39,7 @@ class SchemaConstraintsSpec extends WordSpec with Matchers {
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 
@@ -66,7 +66,7 @@ class SchemaConstraintsSpec extends WordSpec with Matchers {
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 

--- a/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
@@ -39,7 +39,7 @@ class SchemaConstraintsSpec extends WordSpec with Matchers {
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 
@@ -66,7 +66,7 @@ class SchemaConstraintsSpec extends WordSpec with Matchers {
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 

--- a/src/test/scala/sangria/schema/SchemaDefinitionSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaDefinitionSpec.scala
@@ -21,7 +21,7 @@ class SchemaDefinitionSpec extends WordSpec with Matchers with FutureResultSuppo
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 

--- a/src/test/scala/sangria/schema/SchemaDefinitionSpec.scala
+++ b/src/test/scala/sangria/schema/SchemaDefinitionSpec.scala
@@ -21,7 +21,7 @@ class SchemaDefinitionSpec extends WordSpec with Matchers with FutureResultSuppo
           case _ ⇒ Left(StringCoercionViolation)
         },
         coerceInput = {
-          case ast.StringValue(s, _, _) ⇒ Right(s)
+          case ast.StringValue(s, _, _, _) ⇒ Right(s)
           case _ ⇒ Left(StringCoercionViolation)
         })
 

--- a/src/test/scala/sangria/util/CatsSupport.scala
+++ b/src/test/scala/sangria/util/CatsSupport.scala
@@ -71,14 +71,14 @@ trait CatsSupport extends FutureResultSupport { this: WordSpec with Matchers ⇒
 
   def directiveStringArg(d: ast.Directive, name: String) =
     d.arguments.collectFirst {
-      case ast.Argument(`name`, ast.StringValue(str, _, _, _), _, _) ⇒ str
+      case ast.Argument(`name`, ast.StringValue(str, _, _, _, _), _, _) ⇒ str
     }
     .getOrElse(throw new IllegalStateException(s"Can't find a directive argument $name"))
 
   def directiveStringListArg(d: ast.Directive, name: String) =
     d.arguments.collectFirst {
       case ast.Argument(`name`, ast.ListValue(values, _, _), _, _) ⇒
-        values.collect {case ast.StringValue(v, _, _, _) ⇒ v}
+        values.collect {case ast.StringValue(v, _, _, _, _) ⇒ v}
     }
     .getOrElse(throw new IllegalStateException(s"Can't find a directive argument $name"))
 

--- a/src/test/scala/sangria/util/CatsSupport.scala
+++ b/src/test/scala/sangria/util/CatsSupport.scala
@@ -71,14 +71,14 @@ trait CatsSupport extends FutureResultSupport { this: WordSpec with Matchers ⇒
 
   def directiveStringArg(d: ast.Directive, name: String) =
     d.arguments.collectFirst {
-      case ast.Argument(`name`, ast.StringValue(str, _, _), _, _) ⇒ str
+      case ast.Argument(`name`, ast.StringValue(str, _, _, _), _, _) ⇒ str
     }
     .getOrElse(throw new IllegalStateException(s"Can't find a directive argument $name"))
 
   def directiveStringListArg(d: ast.Directive, name: String) =
     d.arguments.collectFirst {
       case ast.Argument(`name`, ast.ListValue(values, _, _), _, _) ⇒
-        values.collect {case ast.StringValue(v, _, _) ⇒ v}
+        values.collect {case ast.StringValue(v, _, _, _) ⇒ v}
     }
     .getOrElse(throw new IllegalStateException(s"Can't find a directive argument $name"))
 

--- a/src/test/scala/sangria/util/StringUtilSpec.scala
+++ b/src/test/scala/sangria/util/StringUtilSpec.scala
@@ -159,6 +159,8 @@ class StringUtilSpec extends WordSpec with Matchers with StringMatchers {
       ) should equal (
         "".stripMargin
       ) (after being strippedOfCarriageReturns)
+
+      blockStringValue("") should equal ("")
     }
   }
 }

--- a/src/test/scala/sangria/util/StringUtilSpec.scala
+++ b/src/test/scala/sangria/util/StringUtilSpec.scala
@@ -3,7 +3,7 @@ package sangria.util
 import org.scalatest.{Matchers, WordSpec}
 import sangria.util.StringUtil._
 
-class StringUtilSpec extends WordSpec with Matchers {
+class StringUtilSpec extends WordSpec with Matchers with StringMatchers {
   "camelCaseToUnderscore" should {
     "convert camel-case identifiers to underscore-based one" in {
       camelCaseToUnderscore("FooBar") should be ("foo_bar")
@@ -46,6 +46,119 @@ class StringUtilSpec extends WordSpec with Matchers {
     
     "Returns options sorted based on similarity" in {
       suggestionList("abc", Seq("a", "ab", "abc")) should be (Seq("abc", "ab"))
+    }
+  }
+
+  "blockStringValue" should {
+    "removes uniform indentation from a string" in {
+      blockStringValue(
+        """
+          |    Hello,
+          |      World!
+          |
+          |    Yours,
+          |      GraphQL.
+          |""".stripMargin
+      ) should equal (
+        """Hello,
+          |  World!
+          |
+          |Yours,
+          |  GraphQL.""".stripMargin
+      ) (after being strippedOfCarriageReturns)
+    }
+
+    "removes empty leading and trailing lines" in {
+      blockStringValue(
+        """
+          |
+          |    Hello,
+          |      World!
+          |
+          |    Yours,
+          |      GraphQL.
+          |
+          |""".stripMargin
+      ) should equal (
+        """Hello,
+          |  World!
+          |
+          |Yours,
+          |  GraphQL.""".stripMargin
+      ) (after being strippedOfCarriageReturns)
+    }
+
+    "removes blank leading and trailing lines" in {
+      val spaces = " " * 10
+
+      blockStringValue(
+        s"""
+           |$spaces
+           |    Hello,
+           |      World!
+           |
+           |    Yours,
+           |      GraphQL.
+           |$spaces
+           |""".stripMargin
+      ) should equal (
+        """Hello,
+          |  World!
+          |
+          |Yours,
+          |  GraphQL.""".stripMargin
+      ) (after being strippedOfCarriageReturns)
+    }
+
+    "retains indentation from first line" in {
+      blockStringValue(
+        """    Hello,
+           |      World!
+           |
+           |    Yours,
+           |      GraphQL.
+           |""".stripMargin
+      ) should equal (
+        """    Hello,
+          |  World!
+          |
+          |Yours,
+          |  GraphQL.""".stripMargin
+      ) (after being strippedOfCarriageReturns)
+    }
+
+    "does not alter trailing spaces" in {
+      val spaces = " " * 10
+
+      blockStringValue(
+        s"""
+           |    Hello,$spaces
+           |      World!$spaces
+           |    $spaces
+           |    Yours,$spaces
+           |      GraphQL.$spaces
+           |""".stripMargin
+      ) should equal (
+        s"""Hello,$spaces
+           |  World!$spaces
+           |$spaces
+           |Yours,$spaces
+           |  GraphQL.$spaces""".stripMargin
+      ) (after being strippedOfCarriageReturns)
+    }
+
+    "handles empty strings" in {
+      val spaces = " " * 10
+
+      blockStringValue(
+        s"""
+           |$spaces
+           |
+           |$spaces
+           |""".stripMargin
+      ) should equal (
+        "".stripMargin
+      ) (after being strippedOfCarriageReturns)
     }
   }
 }


### PR DESCRIPTION
Adds support for block strings ([spec change](https://github.com/facebook/graphql/pull/327)):

```graphql
mutation {
  sendEmail(message: """
    Hello,
      World!
 
    Yours,
      GraphQL.
  """)
}
```

Closes #260 