### PR TITLE
Support implicit output lookups for interface types

### DIFF
--- a/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
+++ b/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
@@ -19,6 +19,10 @@ object GraphQLOutputTypeLookup extends GraphQLOutputTypeLookupLowPrio {
   implicit def optionLookup[T : GraphQLOutputTypeLookup]  = new GraphQLOutputTypeLookup[Option[T]] {
     def graphqlType = OptionType(implicitly[GraphQLOutputTypeLookup[T]].graphqlType)
   }
+
+  implicit def interfaceLookup[T](implicit int: InterfaceType[_, T]) = new GraphQLOutputTypeLookup[T] {
+    override def graphqlType = int
+  }
 }
 
 trait GraphQLOutputTypeLookupLowPrio {


### PR DESCRIPTION
For context from the gitter channel.

> Hey all, I seem to be having a problem with the `deriveContextObjectType` when one of the derived type's methods returns an `interface` type. I receive a `Can't find suitable GraphQL output type for services.tag.GenericTag. If you have defined it already, please consider making it implicit and ensure that it's available in the scope.` Error during compilation instead. Is this a known limitation? It seems to work if I switch the return type to a concrete type...

e.g.
```scala
// In Mutation.scala
trait Mutation {
   @GraphQLField
   addTag: Future[GenericTag] = {} // GenericTag has a GraphQL InterfaceType declaration

}

// in SchemaDefinition.scala

implicit val TagType = InterfaceType("Tag", "",  () => fields[UserContext, GenericTag]()
implicit val ConcreteTagType = deriveObjectType[UserContext, GenericTag](Interfaces(PossibleInterface[UserContext, ListTag](TagType)))

val MutationType = deriveContextObjectType[UserContext, Mutation, Unit](
    _.mutation,
    IncludeMethods("addTag"),
    Interfaces(PossibleInterface[UserContext, Unit](TagType))
  )

```

The problem seemed to be that scala has a hard time determining the implicit `GraphQLOutputTypeLookup` for an `InterfaceType`.