### PR TITLE
Revert "Support implicit output lookups for interface types"

### DIFF
--- a/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
+++ b/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
@@ -19,10 +19,6 @@ object GraphQLOutputTypeLookup extends GraphQLOutputTypeLookupLowPrio {
   implicit def optionLookup[T : GraphQLOutputTypeLookup]  = new GraphQLOutputTypeLookup[Option[T]] {
     def graphqlType = OptionType(implicitly[GraphQLOutputTypeLookup[T]].graphqlType)
   }
-
-  implicit def interfaceLookup[T](implicit int: InterfaceType[_, T]) = new GraphQLOutputTypeLookup[T] {
-    override def graphqlType = int
-  }
 }
 
 trait GraphQLOutputTypeLookupLowPrio {


### PR DESCRIPTION
Reverts sangria-graphql/sangria#306

