### PR TITLE
Initialize symbols before checking their annotations.

### DIFF
--- a/src/main/scala/sangria/macros/derive/DeriveObjectTypeMacro.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveObjectTypeMacro.scala
@@ -130,7 +130,7 @@ class DeriveObjectTypeMacro(context: blackbox.Context) extends {
         val allFields = classFields ++ additionalFields(config)
 
         if (allFields.nonEmpty) Right(allFields)
-        else Left(List(c.enclosingPosition → "Field list is empty"))
+        else Left(List(c.enclosingPosition → s"$targetType: Field list is empty"))
       case errors ⇒ Left(errors)
     }
   }
@@ -201,7 +201,9 @@ class DeriveObjectTypeMacro(context: blackbox.Context) extends {
   }
 
   private def findKnownMembers(tpe: Type, includeMethods: Set[String]): List[KnownMember] =
-    tpe.members.collect {
+    // we "force" m by calling info. This makes sure its type information is complete, in particular that
+    // annotations are available through `.annotations`
+    tpe.members.map { m => m.info; m }.collect {
       case m: MethodSymbol if m.isCaseAccessor ⇒
         KnownMember(tpe, m, findCaseClassAccessorAnnotations(tpe, m), accessor = true)
       case m: MethodSymbol if memberField(m.annotations) || includeMethods.contains(m.name.decodedName.toString) ⇒


### PR DESCRIPTION
The Scala compiler uses laziness extensively to deal with recursive types. Annotations are one instance where an uninitialized type will be incorrect, so we call `info` before checking method annotations inside macros. The proper method, initialize, is not available in the public API so I just called .info, which is what most places in the compiler do, anyway.

Fix #172