### PR TITLE
Make empty string invalid for IDType

### DIFF
--- a/src/main/scala/sangria/schema/package.scala
+++ b/src/main/scala/sangria/schema/package.scala
@@ -153,14 +153,14 @@ package object schema {
       "(such as `4`) input value will be accepted as an ID."),
     coerceOutput = valueOutput,
     coerceUserInput = {
-      case s: String ⇒ Right(s)
+      case s: String if s.trim.nonEmpty ⇒ Right(s)
       case i: Int ⇒ Right(i.toString)
       case i: Long ⇒ Right(i.toString)
       case i: BigInt ⇒ Right(i.toString)
       case _ ⇒ Left(IDCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(id, _, _, _, _) ⇒ Right(id)
+      case ast.StringValue(id, _, _, _, _) if id.trim.nonEmpty ⇒ Right(id)
       case ast.IntValue(id, _, _) ⇒ Right(id.toString)
       case ast.BigIntValue(id, _, _) ⇒ Right(id.toString)
       case _ ⇒ Left(IDCoercionViolation)

--- a/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
+++ b/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
@@ -34,6 +34,8 @@ class ValueCoercionHelperSpec extends WordSpec with Matchers {
       check(opt(StringType), "123", None)
       check(opt(StringType), "true", None)
       check(opt(IDType), "123.456", None)
+      check(opt(IDType), "\"\"", None)
+      check(opt(IDType), "\"    \"", None)
     }
 
     val testEnum = EnumType("TestColor", values = List(


### PR DESCRIPTION
Hey @OlegIlyenko,

we stumbled about this one in our app. Right now a query such as 

```graphql
query demo {
   car(id: "    ") {
      doors 
  }
}
```

reaches the resolvers. Is that intended? I would argue that `ID` should never be an empty string.

I quickly glanced over what the `GraphQL` spec is telling about blank strings for `ID` but couldn't find anything. 

This PR patches `IDType` so that it doesn't accept blank strings. What do you think?