### PR TITLE
Allow to rename, describe and set default arguments using `DeriveObjectSetting`s.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria"
 organization := "org.sangria-graphql"
-version := "1.3.3"
+version := "1.3.3-fork-fehu"
 
 description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria"
 organization := "org.sangria-graphql"
-version := "1.3.3-fork-fehu-2"
+version := "1.3.4-SNAPSHOT"
 
 description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria"
 organization := "org.sangria-graphql"
-version := "1.3.3-fork-fehu"
+version := "1.3.3-fork-fehu-2"
 
 description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
@@ -22,3 +22,6 @@ case class ReplaceField[Ctx, Val](fieldName: String, field: Field[Ctx, Val]) ext
 case class AddFields[Ctx, Val](fields: Field[Ctx, Val]*) extends DeriveObjectSetting[Ctx, Val]
 
 case class TransformFieldNames[Ctx, Val](transformer: String ⇒ String) extends DeriveObjectSetting[Ctx, Val]
+
+case class MethodArgument[Ctx, Val](methodName: String, argName: String, description: String) extends DeriveObjectSetting[Ctx, Val]
+case class MethodArguments[Ctx, Val](methodName: String, descriptions: (String, String)*) extends DeriveObjectSetting[Ctx, Val]

--- a/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
@@ -23,6 +23,7 @@ case class AddFields[Ctx, Val](fields: Field[Ctx, Val]*) extends DeriveObjectSet
 
 case class TransformFieldNames[Ctx, Val](transformer: String ⇒ String) extends DeriveObjectSetting[Ctx, Val]
 
+case class MethodArgumentRename[Ctx, Val](methodName: String, argName: String, newName: String) extends DeriveObjectSetting[Ctx, Val]
 case class MethodArgumentDescription[Ctx, Val](methodName: String, argName: String, description: String) extends DeriveObjectSetting[Ctx, Val]
 case class MethodArgumentsDescription[Ctx, Val](methodName: String, descriptions: (String, String)*) extends DeriveObjectSetting[Ctx, Val]
 case class MethodArgumentDefault[Ctx, Val, Arg](methodName: String, argName: String, default: Arg) extends DeriveObjectSetting[Ctx, Val]

--- a/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveObjectSetting.scala
@@ -23,5 +23,7 @@ case class AddFields[Ctx, Val](fields: Field[Ctx, Val]*) extends DeriveObjectSet
 
 case class TransformFieldNames[Ctx, Val](transformer: String ⇒ String) extends DeriveObjectSetting[Ctx, Val]
 
-case class MethodArgument[Ctx, Val](methodName: String, argName: String, description: String) extends DeriveObjectSetting[Ctx, Val]
-case class MethodArguments[Ctx, Val](methodName: String, descriptions: (String, String)*) extends DeriveObjectSetting[Ctx, Val]
+case class MethodArgumentDescription[Ctx, Val](methodName: String, argName: String, description: String) extends DeriveObjectSetting[Ctx, Val]
+case class MethodArgumentsDescription[Ctx, Val](methodName: String, descriptions: (String, String)*) extends DeriveObjectSetting[Ctx, Val]
+case class MethodArgumentDefault[Ctx, Val, Arg](methodName: String, argName: String, default: Arg) extends DeriveObjectSetting[Ctx, Val]
+case class MethodArgument[Ctx, Val, Arg](methodName: String, argName: String, description: String, default: Arg) extends DeriveObjectSetting[Ctx, Val]

--- a/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -501,7 +501,7 @@ class DeriveObjectTypeMacroSpec extends WordSpec with Matchers with FutureResult
         IntrospectionInputValue("color", None, IntrospectionNamedTypeRef(TypeKind.Enum, "Color"), None),
         IntrospectionInputValue("pet", None, IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"), None)))
     }
-    "allow to set arguments descriptions and default values with config" in {
+    "allow to rename arguments, set arguments descriptions and default values with config" in {
       object MyJsonProtocol extends DefaultJsonProtocol {
         implicit val PetFormat = jsonFormat2(Pet.apply)
       }
@@ -524,9 +524,10 @@ class DeriveObjectTypeMacroSpec extends WordSpec with Matchers with FutureResult
 
       val tpe = deriveContextObjectType[Ctx, FooBar, Unit](_.fooBar,
         IncludeMethods("hello", "opt"),
-        MethodArgumentDescription( "hello", "id", "`id`"),
-        MethodArgumentDescription( "hello", "songs", "`songs`"),
-        MethodArgumentsDescription("opt", "str"   -> "string", "color" -> "a color"),
+        MethodArgumentDescription("hello", "id", "`id`"),
+        MethodArgumentDescription("hello", "songs", "`songs`"),
+        MethodArgumentRename("opt", "str", "description"),
+        MethodArgumentsDescription("opt", "str" -> "Optional description", "color" -> "a color"),
         MethodArgumentDefault("hello", "songs",  "My favorite song" :: Nil),
         MethodArgument("hello", "pet", "`pet`", Pet("Octocat", None))
       )
@@ -561,9 +562,12 @@ class DeriveObjectTypeMacroSpec extends WordSpec with Matchers with FutureResult
       optField.args should have size 3
 
       optField.args should be (List(
-        IntrospectionInputValue("str", Some("string"), IntrospectionNamedTypeRef(TypeKind.Scalar, "String"), None),
-        IntrospectionInputValue("color", Some("a color"), IntrospectionNamedTypeRef(TypeKind.Enum, "Color"), None),
-        IntrospectionInputValue("pet", None, IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"), None)))
+        IntrospectionInputValue("description", Some("Optional description"),
+          IntrospectionNamedTypeRef(TypeKind.Scalar, "String"), None),
+        IntrospectionInputValue("color", Some("a color"),
+          IntrospectionNamedTypeRef(TypeKind.Enum, "Color"), None),
+        IntrospectionInputValue("pet", None,
+          IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"), None)))
     }
 
     "validate known argument names" in {


### PR DESCRIPTION
#318: Added the following `DeriveObjectSetting`s:

| Setting name | Description |
|------------------|----------------|
| `MethodArgumentRename` | change name of single argument |
| `MethodArgumentDescription` | set description for a single argument |
| `MethodArgumentsDescription` | set descriptions for multiple arguments |
| `MethodArgumentDefault` | set default value for a single argument |
| `MethodArgument` | set description and default value for a single argument |