### PR TITLE
Improved AST location handling and support for multi-source AST `Document`s

### DIFF
--- a/src/main/scala/sangria/ast/QueryAst.scala
+++ b/src/main/scala/sangria/ast/QueryAst.scala
@@ -1,6 +1,5 @@
 package sangria.ast
 
-import org.parboiled2.Position
 import sangria.execution.InputDocumentMaterializer
 import sangria.marshalling.{FromInput, InputUnmarshaller}
 import sangria.parser.{DeliveryScheme, SourceMapper}
@@ -13,7 +12,7 @@ import sangria.visitor._
 import scala.util.control.Breaks._
 import scala.collection.immutable.ListMap
 
-case class Document(definitions: Vector[Definition], trailingComments: Vector[Comment] = Vector.empty, position: Option[Position] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
+case class Document(definitions: Vector[Definition], trailingComments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
   lazy val operations = Map(definitions collect {case op: OperationDefinition ⇒ op.name → op}: _*)
   lazy val fragments = Map(definitions collect {case fragment: FragmentDefinition ⇒ fragment.name → fragment}: _*)
   lazy val source: Option[String] = sourceMapper map (_.source)
@@ -54,11 +53,11 @@ case class Document(definitions: Vector[Definition], trailingComments: Vector[Co
     case that: Document ⇒
       (that canEqual this) &&
           definitions == that.definitions &&
-          position == that.position
+          location == that.location
     case _ ⇒ false
   }
 
-  private lazy val hash = Seq(definitions, position).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
+  private lazy val hash = Seq(definitions, location).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
 
   override def hashCode(): Int = hash
 }
@@ -84,7 +83,7 @@ object Document {
         FieldDefinition("stub", NamedType("String"), Vector.empty)))))
 }
 
-case class InputDocument(values: Vector[Value], trailingComments: Vector[Comment] = Vector.empty, position: Option[Position] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
+case class InputDocument(values: Vector[Value], trailingComments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None, sourceMapper: Option[SourceMapper] = None) extends AstNode with WithTrailingComments {
   lazy val source: Option[String] = sourceMapper map (_.source)
 
   /**
@@ -124,12 +123,12 @@ case class InputDocument(values: Vector[Value], trailingComments: Vector[Comment
     case that: InputDocument ⇒
       (that canEqual this) &&
           values == that.values &&
-          position == that.position
+          location == that.location
     case _ ⇒ false
   }
 
   override def hashCode(): Int =
-    Seq(values, position).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
+    Seq(values, location).map(_.hashCode()).foldLeft(0)((a, b) ⇒ 31 * a + b)
 }
 
 object InputDocument {
@@ -155,7 +154,7 @@ sealed trait WithTrailingComments {
 
 sealed trait SelectionContainer extends AstNode with WithComments with WithTrailingComments {
   def selections: Vector[Selection]
-  def position: Option[Position]
+  def location: Option[AstLocation]
 }
 
 sealed trait Definition extends AstNode
@@ -168,7 +167,7 @@ case class OperationDefinition(
   selections: Vector[Selection],
   comments: Vector[Comment] = Vector.empty,
   trailingComments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends Definition with WithDirectives with SelectionContainer
+  location: Option[AstLocation] = None) extends Definition with WithDirectives with SelectionContainer
 
 case class FragmentDefinition(
     name: String,
@@ -178,7 +177,7 @@ case class FragmentDefinition(
     variables: Vector[VariableDefinition] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends Definition with ConditionalFragment with WithDirectives with SelectionContainer {
+    location: Option[AstLocation] = None) extends Definition with ConditionalFragment with WithDirectives with SelectionContainer {
   lazy val typeConditionOpt = Some(typeCondition)
 }
 
@@ -195,7 +194,7 @@ case class VariableDefinition(
   tpe: Type,
   defaultValue: Option[Value],
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends AstNode with WithComments
+  location: Option[AstLocation] = None) extends AstNode with WithComments
 
 sealed trait Type extends AstNode {
   def namedType: NamedType = {
@@ -210,9 +209,9 @@ sealed trait Type extends AstNode {
   }
 }
 
-case class NamedType(name: String, position: Option[Position] = None) extends Type
-case class NotNullType(ofType: Type, position: Option[Position] = None) extends Type
-case class ListType(ofType: Type, position: Option[Position] = None) extends Type
+case class NamedType(name: String, location: Option[AstLocation] = None) extends Type
+case class NotNullType(ofType: Type, location: Option[AstLocation] = None) extends Type
+case class ListType(ofType: Type, location: Option[AstLocation] = None) extends Type
 
 sealed trait WithArguments extends AstNode {
   def arguments: Vector[Argument]
@@ -228,7 +227,7 @@ case class Field(
     selections: Vector[Selection],
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends Selection with SelectionContainer with WithArguments {
+    location: Option[AstLocation] = None) extends Selection with SelectionContainer with WithArguments {
   lazy val outputName = alias getOrElse name
 }
 
@@ -236,7 +235,7 @@ case class FragmentSpread(
   name: String,
   directives: Vector[Directive],
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends Selection
+  location: Option[AstLocation] = None) extends Selection
 
 case class InlineFragment(
     typeCondition: Option[NamedType],
@@ -244,7 +243,7 @@ case class InlineFragment(
     selections: Vector[Selection],
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends Selection with ConditionalFragment with SelectionContainer {
+    location: Option[AstLocation] = None) extends Selection with ConditionalFragment with SelectionContainer {
   def typeConditionOpt = typeCondition
 }
 
@@ -257,8 +256,8 @@ sealed trait WithDirectives extends AstNode {
   def directives: Vector[Directive]
 }
 
-case class Directive(name: String, arguments: Vector[Argument], comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends AstNode with WithArguments
-case class Argument(name: String, value: Value, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends NameValue
+case class Directive(name: String, arguments: Vector[Argument], comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends AstNode with WithArguments
+case class Argument(name: String, value: Value, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends NameValue
 
 sealed trait Value extends AstNode with WithComments {
   override def renderPretty: String = QueryRenderer.render(this, QueryRenderer.PrettyInput)
@@ -266,17 +265,17 @@ sealed trait Value extends AstNode with WithComments {
 
 sealed trait ScalarValue extends Value
 
-case class IntValue(value: Int, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class BigIntValue(value: BigInt, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class FloatValue(value: Double, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class BigDecimalValue(value: BigDecimal, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class StringValue(value: String, block: Boolean = false, blockRawValue: Option[String] = None, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class BooleanValue(value: Boolean, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends ScalarValue
-case class EnumValue(value: String, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
-case class ListValue(values: Vector[Value], comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
-case class VariableValue(name: String, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
-case class NullValue(comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value
-case class ObjectValue(fields: Vector[ObjectField], comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends Value {
+case class IntValue(value: Int, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class BigIntValue(value: BigInt, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class FloatValue(value: Double, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class BigDecimalValue(value: BigDecimal, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class StringValue(value: String, block: Boolean = false, blockRawValue: Option[String] = None, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class BooleanValue(value: Boolean, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends ScalarValue
+case class EnumValue(value: String, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends Value
+case class ListValue(values: Vector[Value], comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends Value
+case class VariableValue(name: String, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends Value
+case class NullValue(comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends Value
+case class ObjectValue(fields: Vector[ObjectField], comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends Value {
   lazy val fieldsByName =
     fields.foldLeft(ListMap.empty[String, Value]) {
       case (acc, field) ⇒ acc + (field.name → field.value)
@@ -287,9 +286,9 @@ object ObjectValue {
   def apply(fields: (String, Value)*): ObjectValue = ObjectValue(fields.toVector map (f ⇒ ObjectField(f._1, f._2)))
 }
 
-case class ObjectField(name: String, value: Value, comments: Vector[Comment] = Vector.empty, position: Option[Position] = None) extends NameValue
+case class ObjectField(name: String, value: Value, comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None) extends NameValue
 
-case class Comment(text: String, position: Option[Position] = None) extends AstNode
+case class Comment(text: String, location: Option[AstLocation] = None) extends AstNode
 
 // Schema Definition
 
@@ -298,7 +297,7 @@ case class ScalarTypeDefinition(
     directives: Vector[Directive] = Vector.empty,
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -309,7 +308,7 @@ case class FieldDefinition(
   directives: Vector[Directive] = Vector.empty,
   description: Option[StringValue] = None,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends SchemaAstNode with WithDirectives with WithDescription
+  location: Option[AstLocation] = None) extends SchemaAstNode with WithDirectives with WithDescription
 
 case class InputValueDefinition(
   name: String,
@@ -318,7 +317,7 @@ case class InputValueDefinition(
   directives: Vector[Directive] = Vector.empty,
   description: Option[StringValue] = None,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends SchemaAstNode with WithDirectives with WithDescription
+  location: Option[AstLocation] = None) extends SchemaAstNode with WithDirectives with WithDescription
 
 case class ObjectTypeDefinition(
     name: String,
@@ -328,7 +327,7 @@ case class ObjectTypeDefinition(
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -339,7 +338,7 @@ case class InterfaceTypeDefinition(
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -349,7 +348,7 @@ case class UnionTypeDefinition(
     directives: Vector[Directive] = Vector.empty,
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -360,7 +359,7 @@ case class EnumTypeDefinition(
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -369,7 +368,7 @@ case class EnumValueDefinition(
   directives: Vector[Directive] = Vector.empty,
   description: Option[StringValue] = None,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends SchemaAstNode with WithDirectives with WithDescription
+  location: Option[AstLocation] = None) extends SchemaAstNode with WithDirectives with WithDescription
 
 case class InputObjectTypeDefinition(
     name: String,
@@ -378,7 +377,7 @@ case class InputObjectTypeDefinition(
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
+    location: Option[AstLocation] = None) extends TypeDefinition with WithTrailingComments with WithDescription {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -389,7 +388,7 @@ case class ObjectTypeExtensionDefinition(
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends ObjectLikeTypeExtensionDefinition with WithTrailingComments {
+    location: Option[AstLocation] = None) extends ObjectLikeTypeExtensionDefinition with WithTrailingComments {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -399,7 +398,7 @@ case class InterfaceTypeExtensionDefinition(
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends ObjectLikeTypeExtensionDefinition with WithTrailingComments {
+    location: Option[AstLocation] = None) extends ObjectLikeTypeExtensionDefinition with WithTrailingComments {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -409,7 +408,7 @@ case class InputObjectTypeExtensionDefinition(
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeExtensionDefinition with WithTrailingComments {
+    location: Option[AstLocation] = None) extends TypeExtensionDefinition with WithTrailingComments {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -419,7 +418,7 @@ case class EnumTypeExtensionDefinition(
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeExtensionDefinition with WithTrailingComments {
+    location: Option[AstLocation] = None) extends TypeExtensionDefinition with WithTrailingComments {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -428,7 +427,7 @@ case class UnionTypeExtensionDefinition(
     types: Vector[NamedType],
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeExtensionDefinition {
+    location: Option[AstLocation] = None) extends TypeExtensionDefinition {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -436,7 +435,7 @@ case class ScalarTypeExtensionDefinition(
     name: String,
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
-    position: Option[Position] = None) extends TypeExtensionDefinition {
+    location: Option[AstLocation] = None) extends TypeExtensionDefinition {
   def rename(newName: String) = copy(name = newName)
 }
 
@@ -446,28 +445,35 @@ case class DirectiveDefinition(
   locations: Vector[DirectiveLocation],
   description: Option[StringValue] = None,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends TypeSystemDefinition with WithDescription
+  location: Option[AstLocation] = None) extends TypeSystemDefinition with WithDescription
 
 case class DirectiveLocation(
   name: String,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends SchemaAstNode
+  location: Option[AstLocation] = None) extends SchemaAstNode
 
 case class SchemaDefinition(
   operationTypes: Vector[OperationTypeDefinition],
   directives: Vector[Directive] = Vector.empty,
   comments: Vector[Comment] = Vector.empty,
   trailingComments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends TypeSystemDefinition with WithTrailingComments with WithDirectives
+  location: Option[AstLocation] = None) extends TypeSystemDefinition with WithTrailingComments with WithDirectives
 
 case class OperationTypeDefinition(
   operation: OperationType,
   tpe: NamedType,
   comments: Vector[Comment] = Vector.empty,
-  position: Option[Position] = None) extends SchemaAstNode
+  location: Option[AstLocation] = None) extends SchemaAstNode
+
+case class AstLocation(sourceId: String, index: Int, line: Int, column: Int)
+
+object AstLocation {
+  def apply(index: Int, line: Int, column: Int): AstLocation =
+    AstLocation("", index, line, column)
+}
 
 sealed trait AstNode {
-  def position: Option[Position]
+  def location: Option[AstLocation]
   def cacheKeyHash: Int = System.identityHashCode(this)
 
   def renderPretty: String = QueryRenderer.render(this, QueryRenderer.Pretty)
@@ -492,12 +498,12 @@ sealed trait ObjectLikeTypeExtensionDefinition extends TypeExtensionDefinition {
 }
 
 object AstNode {
-  def withoutPosition[T <: AstNode](node: T, stripComments: Boolean = false): T = {
-    val enterComment = (_: Comment) ⇒ if (stripComments) VisitorCommand.Delete else VisitorCommand.Skip
+  def withoutAstLocations[T <: AstNode](node: T, stripComments: Boolean = false): T = {
+    val enterComment = (_: Comment) ⇒ if (stripComments) VisitorCommand.Delete else VisitorCommand.Continue
 
     visit[AstNode](node,
       Visit[Comment](enterComment),
-      VisitAnyField[AstNode, Option[Position]]((_, _) ⇒ VisitorCommand.Transform(None))).asInstanceOf[T]
+      VisitAnyField[AstNode, Option[AstLocation]]((_, _) ⇒ VisitorCommand.Transform(None))).asInstanceOf[T]
   }
 }
 

--- a/src/main/scala/sangria/execution/ExceptionHandler.scala
+++ b/src/main/scala/sangria/execution/ExceptionHandler.scala
@@ -1,6 +1,6 @@
 package sangria.execution
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import sangria.marshalling.ResultMarshaller
 import sangria.validation.Violation
 
@@ -15,13 +15,13 @@ object ExceptionHandler {
 
 sealed trait HandledException
 
-case class SingleHandledException(message: String, additionalFields: Map[String, ResultMarshaller#Node] = Map.empty, positions: List[Position] = Nil) extends HandledException
-case class MultipleHandledExceptions(messages: Vector[(String, Map[String, ResultMarshaller#Node], List[Position])]) extends HandledException
+case class SingleHandledException(message: String, additionalFields: Map[String, ResultMarshaller#Node] = Map.empty, positions: List[AstLocation] = Nil) extends HandledException
+case class MultipleHandledExceptions(messages: Vector[(String, Map[String, ResultMarshaller#Node], List[AstLocation])]) extends HandledException
 
 object HandledException {
-  def apply(message: String, additionalFields: Map[String, ResultMarshaller#Node] = Map.empty, positions: List[Position] = Nil) =
+  def apply(message: String, additionalFields: Map[String, ResultMarshaller#Node] = Map.empty, positions: List[AstLocation] = Nil) =
     SingleHandledException(message, additionalFields, positions)
 
-  def apply(messages: Vector[(String, Map[String, ResultMarshaller#Node], List[Position])]) =
+  def apply(messages: Vector[(String, Map[String, ResultMarshaller#Node], List[AstLocation])]) =
     MultipleHandledExceptions(messages)
 }

--- a/src/main/scala/sangria/execution/ExecutionError.scala
+++ b/src/main/scala/sangria/execution/ExecutionError.scala
@@ -1,6 +1,6 @@
 package sangria.execution
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import sangria.marshalling.ResultMarshaller
 import sangria.parser.SourceMapper
 import sangria.schema.{AbstractType, InterfaceType, ObjectType, UnionType}
@@ -23,7 +23,7 @@ trait ErrorWithResolver {
     new ResultResolver(marshaller, exceptionHandler, false).resolveError(this).asInstanceOf[marshaller.Node]
 }
 
-class ExecutionError(message: String, val exceptionHandler: ExceptionHandler, val sourceMapper: Option[SourceMapper] = None, val positions: List[Position] = Nil) extends Exception(message) with AstNodeLocation with UserFacingError with ErrorWithResolver {
+class ExecutionError(message: String, val exceptionHandler: ExceptionHandler, val sourceMapper: Option[SourceMapper] = None, val locations: List[AstLocation] = Nil) extends Exception(message) with AstNodeLocation with UserFacingError with ErrorWithResolver {
   override def simpleErrorMessage = super.getMessage
   override def getMessage() = super.getMessage + astLocation
 }
@@ -33,7 +33,7 @@ abstract class InternalExecutionError(message: String) extends Exception(message
   override def getMessage() = super.getMessage + astLocation
 }
 
-case class UndefinedConcreteTypeError(path: ExecutionPath, abstractType: AbstractType, possibleTypes: Vector[ObjectType[_, _]], value: Any, exceptionHandler: ExceptionHandler, sourceMapper: Option[SourceMapper] = None, positions: List[Position] = Nil)
+case class UndefinedConcreteTypeError(path: ExecutionPath, abstractType: AbstractType, possibleTypes: Vector[ObjectType[_, _]], value: Any, exceptionHandler: ExceptionHandler, sourceMapper: Option[SourceMapper] = None, locations: List[AstLocation] = Nil)
   extends InternalExecutionError(s"Can't find appropriate subtype of ${UndefinedConcreteTypeError.renderAbstractType(abstractType)} type '${abstractType.name}' for value of class '${UndefinedConcreteTypeError.renderValueClass(value)}' at path '$path'. Possible types: ${UndefinedConcreteTypeError.renderPossibleTypes(possibleTypes)}. Got value: $value.")
 
 object UndefinedConcreteTypeError {
@@ -74,5 +74,5 @@ case class MaterializedSchemaValidationError(violations: Vector[Violation], eh: 
 
 case class QueryReducingError(cause: Throwable, exceptionHandler: ExceptionHandler) extends Exception(s"Query reducing error: ${cause.getMessage}", cause) with QueryAnalysisError
 
-case class OperationSelectionError(message: String, eh: ExceptionHandler, sm: Option[SourceMapper] = None, pos: List[Position] = Nil)
+case class OperationSelectionError(message: String, eh: ExceptionHandler, sm: Option[SourceMapper] = None, pos: List[AstLocation] = Nil)
   extends ExecutionError(message, eh, sm, pos) with QueryAnalysisError

--- a/src/main/scala/sangria/execution/Executor.scala
+++ b/src/main/scala/sangria/execution/Executor.scala
@@ -221,10 +221,10 @@ object Executor {
       Success(schema.query)
     case ast.OperationType.Mutation ⇒
       schema.mutation map (Success(_)) getOrElse
-        Failure(OperationSelectionError("Schema is not configured for mutations", exceptionHandler, sourceMapper, operation.position.toList))
+        Failure(OperationSelectionError("Schema is not configured for mutations", exceptionHandler, sourceMapper, operation.location.toList))
     case ast.OperationType.Subscription ⇒
       schema.subscription map (Success(_)) getOrElse
-        Failure(OperationSelectionError("Schema is not configured for subscriptions", exceptionHandler, sourceMapper, operation.position.toList))
+        Failure(OperationSelectionError("Schema is not configured for subscriptions", exceptionHandler, sourceMapper, operation.location.toList))
   }
 
   def getOperation(exceptionHandler: ExceptionHandler, document: ast.Document, operationName: Option[String]): Try[ast.OperationDefinition] =

--- a/src/main/scala/sangria/execution/FieldCollector.scala
+++ b/src/main/scala/sangria/execution/FieldCollector.scala
@@ -88,22 +88,22 @@ class FieldCollector[Ctx, Val](
           .get(d.name)
           .map(dd ⇒ selection match {
             case _: ast.Field if !dd.locations.contains(DirectiveLocation.Field) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fields", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fields", exceptionHandler, sourceMapper, d.location.toList))
             case _: ast.InlineFragment if !dd.locations.contains(DirectiveLocation.InlineFragment) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on inline fragment", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on inline fragment", exceptionHandler, sourceMapper, d.location.toList))
             case _: ast.FragmentSpread if !dd.locations.contains(DirectiveLocation.FragmentSpread) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fragment spread", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fragment spread", exceptionHandler, sourceMapper, d.location.toList))
             case _: ast.FragmentDefinition if !dd.locations.contains(DirectiveLocation.FragmentDefinition) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fragment definition", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on fragment definition", exceptionHandler, sourceMapper, d.location.toList))
             case op: ast.OperationDefinition if op.operationType == OperationType.Query && !dd.locations.contains(DirectiveLocation.Query) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on query operation", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on query operation", exceptionHandler, sourceMapper, d.location.toList))
             case op: ast.OperationDefinition if op.operationType == OperationType.Mutation && !dd.locations.contains(DirectiveLocation.Mutation) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on mutation operation", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on mutation operation", exceptionHandler, sourceMapper, d.location.toList))
             case op: ast.OperationDefinition if op.operationType == OperationType.Subscription && !dd.locations.contains(DirectiveLocation.Subscription) ⇒
-              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on subscription operation", exceptionHandler, sourceMapper, d.position.toList))
+              Failure(new ExecutionError(s"Directive '${dd.name}' is not allowed to be used on subscription operation", exceptionHandler, sourceMapper, d.location.toList))
             case _ ⇒ Success(d → dd)
           })
-          .getOrElse(Failure(new ExecutionError(s"Directive '${d.name}' not found.", exceptionHandler, sourceMapper, d.position.toList))))
+          .getOrElse(Failure(new ExecutionError(s"Directive '${d.name}' not found.", exceptionHandler, sourceMapper, d.location.toList))))
         .map(_.flatMap{case (astDir, dir) ⇒ valueCollector.getArgumentValues(dir.arguments, astDir.arguments, variables) map (dir → _)})
 
     possibleDirs.collect{case Failure(error) ⇒ error}.headOption map (Failure(_)) getOrElse {
@@ -119,7 +119,7 @@ class FieldCollector[Ctx, Val](
       case Some(tc) ⇒
         schema.outputTypes.get(tc.name)
           .map(condTpe ⇒ Success(condTpe.name == tpe.name || (condTpe.isInstanceOf[AbstractType] && schema.isPossibleType(condTpe.name, tpe))))
-          .getOrElse(Failure(new ExecutionError(s"Unknown type '${tc.name}'.", exceptionHandler, sourceMapper, conditional.position.toList)))
+          .getOrElse(Failure(new ExecutionError(s"Unknown type '${tc.name}'.", exceptionHandler, sourceMapper, conditional.location.toList)))
       case None ⇒ Success(true)
     }
 }

--- a/src/main/scala/sangria/execution/ValueCollector.scala
+++ b/src/main/scala/sangria/execution/ValueCollector.scala
@@ -23,7 +23,7 @@ class ValueCollector[Ctx, Input](schema: Schema[_, _], inputVars: Input, sourceM
         case (acc, varDef) ⇒
           val value = schema.getInputType(varDef.tpe)
             .map(coercionHelper.getVariableValue(varDef, _, um.getRootMapValue(inputVars, varDef.name), fromScalarMiddleware))
-            .getOrElse(Left(Vector(UnknownVariableTypeViolation(varDef.name, QueryRenderer.render(varDef.tpe), sourceMapper, varDef.position.toList))))
+            .getOrElse(Left(Vector(UnknownVariableTypeViolation(varDef.name, QueryRenderer.render(varDef.tpe), sourceMapper, varDef.location.toList))))
 
           value match {
             case Right(Some(v)) ⇒ acc :+ (varDef.name → Right(v))
@@ -88,7 +88,7 @@ object ValueCollector {
               acc, astValue map (coerceInputValue(argDef.argumentType, argPath, _, Some(variables), marshaller, fromInput.marshaller, fromScalarMiddleware = fromScalarMiddleware, isArgument = true)))
           } catch {
             case InputParsingError(e) ⇒
-              errors ++= e.map(InvalidInputValueViolation(argDef.name, _, sourceMapper, astValue.flatMap(_.position).toList))
+              errors ++= e.map(InvalidInputValueViolation(argDef.name, _, sourceMapper, astValue.flatMap(_.location).toList))
               acc
           }
       }

--- a/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -299,7 +299,7 @@ object BatchExecutor {
         else {
           val violations =
             exportedAll.values.flatMap { op ⇒
-              findUndefinedVariableUsages(op).map(UndefinedVariableDefinitionViolation(op.operationName, _, queryAst.sourceMapper, op.variableUsages.flatMap(_.node.position).toList))
+              findUndefinedVariableUsages(op).map(UndefinedVariableDefinitionViolation(op.operationName, _, queryAst.sourceMapper, op.variableUsages.flatMap(_.node.location).toList))
             }
 
           if (violations.nonEmpty)
@@ -324,7 +324,7 @@ object BatchExecutor {
 
     def loop(src: String, deps: Vector[(String, Set[String])], path: Vector[(String, String)]): Unit =
       if (path.exists(_._1 == src))
-        violations += CircularOperationDependencyViolation(src, path.map(_._2), queryAst.sourceMapper, queryAst.operations(Some(src)).position.toList)
+        violations += CircularOperationDependencyViolation(src, path.map(_._2), queryAst.sourceMapper, queryAst.operations(Some(src)).location.toList)
       else {
         deps.foreach { d ⇒
           loop(d._1, dependencies(d._1), path :+ ((src, s"$src(${d._2.map("$" + _).mkString(", ")})")))
@@ -386,7 +386,7 @@ object BatchExecutor {
                   firstAstType.renderPretty,
                   currAstType.renderPretty,
                   queryAst.sourceMapper,
-                  first.node.position.toList ++ curr.node.position.toList)
+                  first.node.location.toList ++ curr.node.location.toList)
             }
 
             if (violations.nonEmpty)

--- a/src/main/scala/sangria/execution/batch/batchViolations.scala
+++ b/src/main/scala/sangria/execution/batch/batchViolations.scala
@@ -1,21 +1,21 @@
 package sangria.execution.batch
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import sangria.execution.{ExecutionError, Executor, QueryAnalysisError, WithViolations}
 import sangria.parser.SourceMapper
 import sangria.validation.{AstNodeViolation, Violation}
 
 case class BatchExecutionError(message: String, eh: Executor.ExceptionHandler) extends ExecutionError(message, eh) with QueryAnalysisError
 
-case class VariableDefinitionInferenceViolation(operationName: String, variableName: String, type1: String, type2: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class VariableDefinitionInferenceViolation(operationName: String, variableName: String, type1: String, type2: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Inferred variable '$$$variableName' in operation '$operationName' is used with two conflicting types: '$type1' and '$type2'."
 }
 
-case class UndefinedVariableDefinitionViolation(operationName: String, variableName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UndefinedVariableDefinitionViolation(operationName: String, variableName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$variableName' is not defined in the operation '$operationName'."
 }
 
-case class CircularOperationDependencyViolation(operationName: String, path: Vector[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class CircularOperationDependencyViolation(operationName: String, path: Vector[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Operation '$operationName' has a circular dependency at path '${path.mkString(" -> ")} -> $operationName'."
 }
 

--- a/src/main/scala/sangria/macros/AstLiftable.scala
+++ b/src/main/scala/sangria/macros/AstLiftable.scala
@@ -18,9 +18,9 @@ trait AstLiftable {
     q"_root_.scala.collection.immutable.Vector(..$seq)"
   }
 
-  implicit def liftPosition: Liftable[org.parboiled2.Position] = Liftable {
-    case org.parboiled2.Position(i, l, c) ⇒
-      q"_root_.org.parboiled2.Position($i, $l, $c)"
+  implicit def liftPosition: Liftable[sangria.ast.AstLocation] = Liftable {
+    case sangria.ast.AstLocation(id, i, l, c) ⇒
+      q"_root_.sangria.ast.AstLocation($id, $i, $l, $c)"
   }
 
   implicit def liftOperationType: Liftable[OperationType] = Liftable {
@@ -143,11 +143,11 @@ trait AstLiftable {
   }
 
   implicit def liftDocument: Liftable[Document] = Liftable {
-    case doc @ Document(d, c, p, _) ⇒ q"_root_.sangria.ast.Document($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.Parboiled2SourceMapper(_root_.org.parboiled2.ParserInput(${doc.source.get}))))"
+    case doc @ Document(d, c, p, _) ⇒ q"_root_.sangria.ast.Document($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.DefaultSourceMapper(${doc.sourceMapper.get.id}, _root_.org.parboiled2.ParserInput(${doc.source.get}))))"
   }
 
   implicit def liftInputDocument: Liftable[InputDocument] = Liftable {
-    case doc @ InputDocument(d, c, p, _) ⇒ q"_root_.sangria.ast.InputDocument($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.Parboiled2SourceMapper(_root_.org.parboiled2.ParserInput(${doc.source.get}))))"
+    case doc @ InputDocument(d, c, p, _) ⇒ q"_root_.sangria.ast.InputDocument($d, $c, $p, _root_.scala.Some(new _root_.sangria.parser.DefaultSourceMapper(${doc.sourceMapper.get.id}, _root_.org.parboiled2.ParserInput(${doc.source.get}))))"
   }
 }
 

--- a/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/src/main/scala/sangria/parser/PositionTracking.scala
@@ -1,16 +1,20 @@
 package sangria.parser
 
 import org.parboiled2._
+import sangria.ast.AstLocation
 
 trait PositionTracking { this: Parser ⇒
   private var lineIdx = Vector(0)
+
+  def sourceId: String
 
   def trackNewLine: Rule0 = rule { run(if (!(lineIdx contains cursor)) lineIdx = lineIdx :+ cursor) }
 
   def trackPos = rule {
     push {
       val currLines = lineIdx.takeWhile(_ <= cursor)
-      Position(cursor, currLines.size, cursor - currLines.last + 1)
+
+      AstLocation(sourceId, cursor, currLines.size, cursor - currLines.last + 1)
     }
   }
 }

--- a/src/main/scala/sangria/parser/SourceMapper.scala
+++ b/src/main/scala/sangria/parser/SourceMapper.scala
@@ -3,6 +3,8 @@ package sangria.parser
 import org.parboiled2.ParserInput
 import sangria.ast.AstLocation
 
+import scala.collection.breakOut
+
 trait SourceMapper {
   def id: String
   def source: String
@@ -11,13 +13,23 @@ trait SourceMapper {
 }
 
 class DefaultSourceMapper(val id: String, val parserInput: ParserInput) extends SourceMapper {
-  override def source = parserInput.sliceString(0, parserInput.length)
+  lazy val source = parserInput.sliceString(0, parserInput.length)
 
-  override def renderLocation(location: AstLocation) =
+  def renderLocation(location: AstLocation) =
     s"(line ${location.line}, column ${location.column})"
 
-  override def renderLinePosition(location: AstLocation, prefix: String = "") =
+  def renderLinePosition(location: AstLocation, prefix: String = "") =
     parserInput.getLine(location.line).replace("\r", "") + "\n" + prefix + (" " * (location.column - 1)) + "^"
 }
 
+class AggregateSourceMapper(val id: String, val delegates: Vector[SourceMapper]) extends SourceMapper {
+  lazy val delegateById: Map[String, SourceMapper] = delegates.map(d ⇒ d.id → d)(breakOut)
 
+  lazy val source = delegates.map(_.source.trim) mkString "\n\n"
+
+  def renderLocation(location: AstLocation) =
+    delegateById.get(location.sourceId).fold("")(sm ⇒ sm.renderLocation(location))
+
+  def renderLinePosition(location: AstLocation, prefix: String = "") =
+    delegateById.get(location.sourceId).fold("")(sm ⇒ sm.renderLinePosition(location, prefix))
+}

--- a/src/main/scala/sangria/parser/SourceMapper.scala
+++ b/src/main/scala/sangria/parser/SourceMapper.scala
@@ -1,21 +1,23 @@
 package sangria.parser
 
-import org.parboiled2.{ParserInput, Position}
+import org.parboiled2.ParserInput
+import sangria.ast.AstLocation
 
 trait SourceMapper {
+  def id: String
   def source: String
-  def renderLocation(position: Position): String
-  def renderLinePosition(position: Position): String
+  def renderLocation(location: AstLocation): String
+  def renderLinePosition(location: AstLocation, prefix: String = ""): String
 }
 
-class Parboiled2SourceMapper(parserInput: ParserInput) extends SourceMapper {
+class DefaultSourceMapper(val id: String, val parserInput: ParserInput) extends SourceMapper {
   override def source = parserInput.sliceString(0, parserInput.length)
 
-  override def renderLocation(position: Position) =
-    s"(line ${position.line}, column ${position.column})"
+  override def renderLocation(location: AstLocation) =
+    s"(line ${location.line}, column ${location.column})"
 
-  override def renderLinePosition(position: Position) =
-    parserInput.getLine(position.line).replace("\r", "") + "\n" + (" " * (position.column - 1)) + "^"
+  override def renderLinePosition(location: AstLocation, prefix: String = "") =
+    parserInput.getLine(location.line).replace("\r", "") + "\n" + prefix + (" " * (location.column - 1)) + "^"
 }
 
 

--- a/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -260,10 +260,10 @@ object AstSchemaBuilder {
 
   def extractDescription(node: ast.WithComments): Option[String] =
     if (node.comments.nonEmpty) {
-      node.position.map(_.line).orElse(node.comments.last.position.map(_.line + 1)) match {
+      node.location.map(_.line).orElse(node.comments.last.location.map(_.line + 1)) match {
         case Some(nodeLine) ⇒
           val (_, relevantComments) = node.comments.foldRight((nodeLine - 1, Vector.empty[String])) {
-            case (c, (expectedLine, acc)) if c.position.isDefined && c.position.get.line == expectedLine ⇒
+            case (c, (expectedLine, acc)) if c.location.isDefined && c.location.get.line == expectedLine ⇒
               (expectedLine - 1) → (c.text +: acc)
             case (c, acc ) ⇒ acc
           }

--- a/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
@@ -120,7 +120,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
             fieldsFn = fields,
             interfaces = interfaces,
             instanceCheck = (value: Any, clazz: Class[_], _: ObjectType[Ctx, Any]) ⇒ fn(value, clazz),
-            astDirectives = Vector.empty)
+            astDirectives = Vector.empty,
+            astNodes = Vector.empty)
         case None ⇒
           ObjectType[Ctx, Any](
             name = typeName(definition),
@@ -128,7 +129,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
             fieldsFn = fields,
             interfaces = interfaces,
             instanceCheck = ObjectType.defaultInstanceCheck[Ctx, Any],
-            astDirectives = Vector.empty)
+            astDirectives = Vector.empty,
+            astNodes = Vector.empty)
       }
 
     Some(objectType)
@@ -142,7 +144,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       name = typeName(definition),
       description = typeDescription(definition),
       fieldsFn = fields,
-      astDirectives = Vector.empty))
+      astDirectives = Vector.empty,
+      astNodes = Vector.empty))
 
   def buildInterfaceType(
       definition: IntrospectionInterfaceType,
@@ -154,7 +157,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       fieldsFn = fields,
       interfaces = Nil,
       manualPossibleTypes = () ⇒ Nil,
-      astDirectives = Vector.empty))
+      astDirectives = Vector.empty,
+      astNodes = Vector.empty))
 
   def buildUnionType(
       definition: IntrospectionUnionType,
@@ -212,7 +216,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       deprecationReason = fieldDeprecationReason(definition),
       complexity = fieldComplexity(typeDefinition, definition),
       manualPossibleTypes = () ⇒ Nil,
-      astDirectives = Vector.empty))
+      astDirectives = Vector.empty,
+      astNodes = Vector.empty))
 
   def buildInputField(
       typeDefinition: IntrospectionInputObjectType,
@@ -225,7 +230,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       description = inputFieldDescription(definition),
       fieldType = tpe,
       defaultValue = defaultValue,
-      astDirectives = Vector.empty))
+      astDirectives = Vector.empty,
+      astNodes = Vector.empty))
 
   def buildArgument(
       fieldDefinition: Option[IntrospectionField],
@@ -239,7 +245,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       argumentType = tpe,
       defaultValue = defaultValue,
       fromInput = argumentFromInput(fieldDefinition, definition),
-      astDirectives = Vector.empty))
+      astDirectives = Vector.empty,
+      astNodes = Vector.empty))
 
   def buildDirective(
       definition: IntrospectionDirective,

--- a/src/main/scala/sangria/schema/SchemaComparator.scala
+++ b/src/main/scala/sangria/schema/SchemaComparator.scala
@@ -323,8 +323,8 @@ object SchemaComparator {
     added: (ast.Directive) ⇒ SchemaChange,
     removed: (ast.Directive) ⇒ SchemaChange
   ): Vector[SchemaChange] = {
-    val oldD = oldDirectives.map(AstNode.withoutPosition(_)).toSet
-    val newD = newDirectives.map(AstNode.withoutPosition(_)).toSet
+    val oldD = oldDirectives.map(AstNode.withoutAstLocations(_)).toSet
+    val newD = newDirectives.map(AstNode.withoutAstLocations(_)).toSet
 
     val remove = oldD.diff(newD).toVector map removed
     val add = newD.diff(oldD).toVector map added
@@ -340,8 +340,8 @@ object SchemaComparator {
     dirAdded: ast.Directive ⇒ SchemaChange,
     dirRemoved: ast.Directive ⇒ SchemaChange
   ): Vector[SchemaChange] = {
-    val oldDefault = oldArg.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, oldArg.argumentType, coercionHelper).map(v ⇒ AstNode.withoutPosition(v)))
-    val newDefault = newArg.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, newArg.argumentType, coercionHelper).map(v ⇒ AstNode.withoutPosition(v)))
+    val oldDefault = oldArg.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, oldArg.argumentType, coercionHelper).map(v ⇒ AstNode.withoutAstLocations(v)))
+    val newDefault = newArg.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, newArg.argumentType, coercionHelper).map(v ⇒ AstNode.withoutAstLocations(v)))
 
     val withDefault =
       if (oldDefault != newDefault)
@@ -366,8 +366,8 @@ object SchemaComparator {
   }
 
   private def findInInputFields(oldType: InputObjectType[_], newType: InputObjectType[_], oldField: InputField[_], newField: InputField[_]): Vector[SchemaChange] = {
-    val oldDefault = oldField.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, oldField.fieldType, coercionHelper).map(v ⇒ AstNode.withoutPosition(v)))
-    val newDefault = newField.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, newField.fieldType, coercionHelper).map(v ⇒ AstNode.withoutPosition(v)))
+    val oldDefault = oldField.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, oldField.fieldType, coercionHelper).map(v ⇒ AstNode.withoutAstLocations(v)))
+    val newDefault = newField.defaultValue.flatMap(dv ⇒ DefaultValueRenderer.renderInputValue(dv, newField.fieldType, coercionHelper).map(v ⇒ AstNode.withoutAstLocations(v)))
 
     val withDefault =
       if (oldDefault != newDefault)

--- a/src/main/scala/sangria/schema/SchemaValidationRule.scala
+++ b/src/main/scala/sangria/schema/SchemaValidationRule.scala
@@ -16,6 +16,7 @@ trait SchemaValidationRule {
 
 object SchemaValidationRule {
   val empty: List[SchemaValidationRule] = Nil
+
   val default: List[SchemaValidationRule] = List(
     new DefaultValuesValidationRule,
     new InterfaceImplementationValidationRule,
@@ -24,6 +25,15 @@ object SchemaValidationRule {
     new FieldValidationRule,
     new EnumValueNameValidationRule)
 
+  def validate[Ctx, Val](schema: Schema[Ctx, Val], validationRules: List[SchemaValidationRule]): List[Violation] =
+    validationRules flatMap (_.validate(schema))
+
+  def validateWithException[Ctx, Val](schema: Schema[Ctx, Val], validationRules: List[SchemaValidationRule]): Schema[Ctx, Val] = {
+    val validationErrors = validate(schema, validationRules)
+
+    if (validationErrors.nonEmpty) throw SchemaValidationException(validationErrors)
+    else schema
+  }
 }
 
 class DefaultValuesValidationRule extends SchemaValidationRule {

--- a/src/main/scala/sangria/validation/DocumentAnalyzer.scala
+++ b/src/main/scala/sangria/validation/DocumentAnalyzer.scala
@@ -72,7 +72,7 @@ case class DocumentAnalyzer(document: ast.Document) {
     }
 
   def separateOperation(definition: OperationDefinition): ast.Document = {
-    val definitions = (definition +: getRecursivelyReferencedFragments(definition)).sortBy(_.position match {
+    val definitions = (definition +: getRecursivelyReferencedFragments(definition)).sortBy(_.location match {
       case Some(pos) ⇒ pos.line
       case _ ⇒ 0
     })

--- a/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/src/main/scala/sangria/validation/QueryValidator.scala
@@ -150,11 +150,11 @@ object ValidationContext {
         case (elem, idx) ⇒ isValidLiteralValue(ofType, elem, sourceMapper) map (ListValueViolation(idx, _, sourceMapper, pos.toList))
       }
     case (ListInputType(ofType), v) ⇒
-      isValidLiteralValue(ofType, v, sourceMapper) map (ListValueViolation(0, _, sourceMapper, v.position.toList))
+      isValidLiteralValue(ofType, v, sourceMapper) map (ListValueViolation(0, _, sourceMapper, v.location.toList))
     case (io: InputObjectType[_], ast.ObjectValue(fields, _, pos)) ⇒
       val unknownFields = fields.collect {
         case f if !io.fieldsByName.contains(f.name) ⇒
-          UnknownInputObjectFieldViolation(SchemaRenderer.renderTypeName(io, true), f.name, sourceMapper, f.position.toList)
+          UnknownInputObjectFieldViolation(SchemaRenderer.renderTypeName(io, true), f.name, sourceMapper, f.location.toList)
       }
 
       val fieldViolations =
@@ -167,13 +167,13 @@ object ValidationContext {
             case (None, t) ⇒
               Vector(NotNullInputObjectFieldMissingViolation(io.name, field.name, SchemaRenderer.renderTypeName(t), sourceMapper, pos.toList))
             case (Some(af), _) ⇒
-              isValidLiteralValue(field.fieldType, af.value, sourceMapper) map (MapValueViolation(field.name, _, sourceMapper, af.position.toList))
+              isValidLiteralValue(field.fieldType, af.value, sourceMapper) map (MapValueViolation(field.name, _, sourceMapper, af.location.toList))
           }
         }
 
       unknownFields ++ fieldViolations
     case (io: InputObjectType[_], v) ⇒
-      Vector(InputObjectIsOfWrongTypeMissingViolation(SchemaRenderer.renderTypeName(io, true), sourceMapper, v.position.toList))
+      Vector(InputObjectIsOfWrongTypeMissingViolation(SchemaRenderer.renderTypeName(io, true), sourceMapper, v.location.toList))
     case (s: ScalarType[_], v) ⇒
       s.coerceInput(v) match {
         case Left(violation) ⇒ Vector(violation)

--- a/src/main/scala/sangria/validation/Violation.scala
+++ b/src/main/scala/sangria/validation/Violation.scala
@@ -1,6 +1,6 @@
 package sangria.validation
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import sangria.ast.Definition
 import sangria.parser.SourceMapper
 import sangria.util.StringUtil
@@ -22,12 +22,12 @@ abstract class BaseViolation(val errorMessage: String) extends Violation
 
 trait AstNodeLocation {
   def sourceMapper: Option[SourceMapper]
-  def positions: List[Position]
+  def locations: List[AstLocation]
   def simpleErrorMessage: String
 
   lazy val astLocation = (for {
     sm ← sourceMapper
-  } yield positions map (p ⇒ s" ${sm.renderLocation(p)}:\n${sm.renderLinePosition(p)}") mkString "\n") getOrElse ""
+  } yield locations map (p ⇒ s" ${sm.renderLocation(p)}:\n${sm.renderLinePosition(p)}") mkString "\n") getOrElse ""
 
   final def errorMessage = simpleErrorMessage + astLocation
 }
@@ -53,15 +53,15 @@ case class EnumValueCoercionViolation(name: String, typeName: String, knownValue
   ValueCoercionViolation(s"Enum value '$name' is undefined in enum type '$typeName'. Known values are: ${knownValues mkString ", "}.")
 case object EnumCoercionViolation extends ValueCoercionViolation(s"Enum value expected")
 
-case class FieldCoercionViolation(fieldPath: List[String], valueViolation: Violation, ownSourceMapper: Option[SourceMapper], ownPositions: List[Position], errorPrefix: String, isArgument: Boolean) extends AstNodeViolation {
+case class FieldCoercionViolation(fieldPath: List[String], valueViolation: Violation, ownSourceMapper: Option[SourceMapper], ownLocations: List[AstLocation], errorPrefix: String, isArgument: Boolean) extends AstNodeViolation {
   lazy val sourceMapper = valueViolation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ ownSourceMapper
   }
 
-  lazy val positions = valueViolation match {
-    case astv: AstNodeViolation ⇒ (ownPositions ++ astv.positions).distinct
-    case _ ⇒ ownPositions
+  lazy val locations = valueViolation match {
+    case astv: AstNodeViolation ⇒ (ownLocations ++ astv.locations).distinct
+    case _ ⇒ ownLocations
   }
 
   lazy val violationMessage = valueViolation match {
@@ -72,15 +72,15 @@ case class FieldCoercionViolation(fieldPath: List[String], valueViolation: Viola
   lazy val simpleErrorMessage = s"${errorPrefix}${if (isArgument) "Argument" else "Field"} '${fieldPath mkString "."}' has wrong value: $violationMessage."
 }
 
-case class VarTypeMismatchViolation(definitionName: String, expectedType: String, input: Option[String], violation: Violation, ownSourceMapper: Option[SourceMapper], ownPositions: List[Position]) extends AstNodeViolation {
+case class VarTypeMismatchViolation(definitionName: String, expectedType: String, input: Option[String], violation: Violation, ownSourceMapper: Option[SourceMapper], ownLocations: List[AstLocation]) extends AstNodeViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ ownSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ (ownPositions ++ astv.positions).distinct
-    case _ ⇒ ownPositions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ (ownLocations ++ astv.locations).distinct
+    case _ ⇒ ownLocations
   }
 
   lazy val violationMessage = violation match {
@@ -91,29 +91,29 @@ case class VarTypeMismatchViolation(definitionName: String, expectedType: String
   lazy val simpleErrorMessage = s"Variable '$$$definitionName' expected value of type '$expectedType' but ${input map ("got: " + _) getOrElse "value is undefined"}. Reason: $violationMessage"
 }
 
-case class UnknownVariableTypeViolation(definitionName: String, varType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownVariableTypeViolation(definitionName: String, varType: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$varType' expected value of type '$$$definitionName' which cannot be used as an input type."
 }
 
-case class NullValueForNotNullTypeViolation(fieldPath: List[String], typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class NullValueForNotNullTypeViolation(fieldPath: List[String], typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Null value was provided for the NotNull Type '$typeName' at path '${fieldPath mkString "."}'."
 }
 
-case class InputObjectTypeMismatchViolation(fieldPath: List[String], typeName: String, value: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class InputObjectTypeMismatchViolation(fieldPath: List[String], typeName: String, value: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Value '$value' of wrong type was provided to the field of type '$typeName' at path '${fieldPath mkString "."}'."
 }
 
 // validation
 
-case class BadValueViolation(argName: String, typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownPositions: List[Position]) extends AstNodeViolation {
+case class BadValueViolation(argName: String, typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownLocations: List[AstLocation]) extends AstNodeViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ ownSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ (ownPositions ++ astv.positions).distinct
-    case _ ⇒ ownPositions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ (ownLocations ++ astv.locations).distinct
+    case _ ⇒ ownLocations
   }
 
   lazy val violationMessage = violation match {
@@ -124,15 +124,15 @@ case class BadValueViolation(argName: String, typeName: String, value: String, v
   lazy val simpleErrorMessage = s"Argument '$argName' expected type '$typeName' but got: $value. Reason: $violationMessage"
 }
 
-case class InvalidInputDocumentViolation(typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownPositions: List[Position]) extends AstNodeViolation {
+case class InvalidInputDocumentViolation(typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownLocations: List[AstLocation]) extends AstNodeViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ ownSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ (ownPositions ++ astv.positions).distinct
-    case _ ⇒ ownPositions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ (ownLocations ++ astv.locations).distinct
+    case _ ⇒ ownLocations
   }
 
   lazy val violationMessage = violation match {
@@ -143,15 +143,15 @@ case class InvalidInputDocumentViolation(typeName: String, value: String, violat
   lazy val simpleErrorMessage = s"At path $violationMessage"
 }
 
-case class BadValueForDefaultArgViolation(varName: String, typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownPositions: List[Position]) extends AstNodeViolation {
+case class BadValueForDefaultArgViolation(varName: String, typeName: String, value: String, violation: Violation, ownSourceMapper: Option[SourceMapper], ownLocations: List[AstLocation]) extends AstNodeViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ ownSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ (ownPositions ++ astv.positions).distinct
-    case _ ⇒ ownPositions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ (ownLocations ++ astv.locations).distinct
+    case _ ⇒ ownLocations
   }
 
   lazy val violationMessage = violation match {
@@ -162,7 +162,7 @@ case class BadValueForDefaultArgViolation(varName: String, typeName: String, val
   lazy val simpleErrorMessage = s"Variable '$$$varName' of type '$typeName' has invalid default value: $value. Reason: $violationMessage"
 }
 
-case class DefaultForNonNullArgViolation(varName: String, typeName: String, guessTypeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DefaultForNonNullArgViolation(varName: String, typeName: String, guessTypeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$varName' of type '$typeName' is required and will never use the default value. Perhaps you meant to use type '$guessTypeName'."
 }
 
@@ -172,7 +172,7 @@ case class UndefinedFieldViolation(
   suggestedTypeNames: Seq[String],
   suggestedFieldNames: Seq[String],
   sourceMapper: Option[SourceMapper],
-  positions: List[Position]
+  locations: List[AstLocation]
 ) extends AstNodeViolation {
   lazy val simpleErrorMessage = {
     val message = s"Cannot query field '$fieldName' on type '$typeName'."
@@ -184,98 +184,98 @@ case class UndefinedFieldViolation(
   }
 }
 
-case class InlineFragmentOnNonCompositeErrorViolation(typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class InlineFragmentOnNonCompositeErrorViolation(typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Fragment cannot condition on non composite type '$typeName'."
 }
 
-case class FragmentOnNonCompositeErrorViolation(fragName: String, typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class FragmentOnNonCompositeErrorViolation(fragName: String, typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Fragment '$fragName' cannot condition on non composite type '$typeName'."
 }
 
-case class UnknownArgViolation(argName: String, fieldName: String, typeName: String, suggestedArgs: Seq[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownArgViolation(argName: String, fieldName: String, typeName: String, suggestedArgs: Seq[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Unknown argument '$argName' on field '$fieldName' of type '$typeName'.${Violation.didYouMean(suggestedArgs)}"
 }
 
-case class UnknownDirectiveArgViolation(argName: String, dirName: String, suggestedArgs: Seq[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownDirectiveArgViolation(argName: String, dirName: String, suggestedArgs: Seq[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Unknown argument '$argName' on directive '$dirName'.${Violation.didYouMean(suggestedArgs)}"
 }
 
-case class UnknownDirectiveViolation(name: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownDirectiveViolation(name: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Unknown directive '$name'."
 }
 
-case class MisplacedDirectiveViolation(name: String, placement: Option[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class MisplacedDirectiveViolation(name: String, placement: Option[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Directive '$name' may not be used ${placement.fold("here")("on " + _)}."
 }
 
-case class UnknownFragmentViolation(name: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownFragmentViolation(name: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Unknown fragment '$name'."
 }
 
-case class UnknownTypeViolation(name: String, suggestedTypes: Seq[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnknownTypeViolation(name: String, suggestedTypes: Seq[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Unknown type '$name'.${Violation.didYouMean(suggestedTypes)}"
 }
 
-case class CycleErrorViolation(fragmentName: String, spreadNames: List[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class CycleErrorViolation(fragmentName: String, spreadNames: List[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Cannot spread fragment '$fragmentName' within itself${if (spreadNames.nonEmpty) s" via ${spreadNames map ("'" + _ + "'") mkString ", " }" else ""}."
 }
 
-case class UndefinedVarByOpViolation(varName: String, operationName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UndefinedVarByOpViolation(varName: String, operationName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$varName' is not defined by operation '$operationName'."
 }
 
-case class UndefinedVarViolation(varName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UndefinedVarViolation(varName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$varName' is not defined."
 }
 
-case class UnusedFragmentViolation(name: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnusedFragmentViolation(name: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Fragment '$name' is not used."
 }
 
-case class UnusedVariableViolation(name: String, operationName: Option[String], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class UnusedVariableViolation(name: String, operationName: Option[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$name' is not used${operationName.fold("")(" in operation " + _)}."
 }
 
-case class NoSubselectionAllowedViolation(fieldName: String, typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class NoSubselectionAllowedViolation(fieldName: String, typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Field '$fieldName' of type '$typeName' must not have a sub selection."
 }
 
-case class RequiredSubselectionViolation(fieldName: String, typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class RequiredSubselectionViolation(fieldName: String, typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Field '$fieldName' of type '$typeName' must have a sub selection."
 }
 
-case class NonExecutableDefinitionViolation(name: Option[String], definition: Definition, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class NonExecutableDefinitionViolation(name: Option[String], definition: Definition, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = name match {
     case Some(n) ⇒ s"The '$n' definition is not executable."
     case None ⇒ "Query document contains non-executable definitions."
   }
 }
 
-case class DuplicateDirectiveViolation(directiveName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateDirectiveViolation(directiveName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"The directive '$directiveName' can only be used once at this location."
 }
 
-case class TypeIncompatibleAnonSpreadViolation(parentTypeName: String, fragTypeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class TypeIncompatibleAnonSpreadViolation(parentTypeName: String, fragTypeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Fragment cannot be spread here as objects of type '$parentTypeName' can never be of type '$fragTypeName'."
 }
 
-case class TypeIncompatibleSpreadViolation(fragName: String, parentTypeName: String, fragTypeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class TypeIncompatibleSpreadViolation(fragName: String, parentTypeName: String, fragTypeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Fragment '$fragName' cannot be spread here as objects of type '$parentTypeName' can never be of type '$fragTypeName'."
 }
 
-case class NonInputTypeOnVarViolation(varName: String, typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class NonInputTypeOnVarViolation(varName: String, typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$varName' cannot be non input type '$typeName'."
 }
 
-case class BadVarPositionViolation(varName: String, varType: String, expectedType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class BadVarPositionViolation(varName: String, varType: String, expectedType: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$$$varName' of type '$varType' used in position expecting type '$expectedType'."
 }
 
-case class MissingFieldArgViolation(fieldName: String, argName: String, typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class MissingFieldArgViolation(fieldName: String, argName: String, typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Field '$fieldName' argument '$argName' of type '$typeName' is required but not provided."
 }
 
-case class FieldsConflictViolation(outputName: String, reason: Either[String, Vector[ConflictReason]], sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class FieldsConflictViolation(outputName: String, reason: Either[String, Vector[ConflictReason]], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Field '$outputName' conflict because ${reasonMessage(reason)}. Use different aliases on the fields to fetch both if this was intentional."
 
   private def reasonMessage(reason: Either[String, Vector[ConflictReason]]): String = reason match {
@@ -284,23 +284,23 @@ case class FieldsConflictViolation(outputName: String, reason: Either[String, Ve
   }
 }
 
-case class AnonOperationNotAloneViolation(sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class AnonOperationNotAloneViolation(sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"This anonymous operation must be the only defined operation."
 }
 
-case class DuplicateFragmentNameViolation(fragName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateFragmentNameViolation(fragName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"There can only be one fragment named '$fragName'."
 }
 
-case class DuplicateOperationNameViolation(opName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateOperationNameViolation(opName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"There can only be one operation named '$opName'."
 }
 
-case class DuplicateArgNameViolation(argName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateArgNameViolation(argName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"There can be only one argument named '$argName'."
 }
 
-case class DuplicateInputFieldViolation(name: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateInputFieldViolation(name: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"There can be only one input field named '$name'."
 }
 
@@ -337,14 +337,14 @@ trait PathBasedViolation {
   def errorMessageWithoutPath: String
 }
 
-case class ListValueViolation(index: Int, violation: Violation, listSourceMapper: Option[SourceMapper], listPosition: List[Position]) extends AstNodeViolation with PathBasedViolation {
+case class ListValueViolation(index: Int, violation: Violation, listSourceMapper: Option[SourceMapper], listPosition: List[AstLocation]) extends AstNodeViolation with PathBasedViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ listSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ listPosition ++ astv.positions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ listPosition ++ astv.locations
     case _ ⇒ listPosition
   }
 
@@ -362,14 +362,14 @@ case class ListValueViolation(index: Int, violation: Violation, listSourceMapper
   lazy val simpleErrorMessage = s"'$pathString' $errorMessageWithoutPath"
 }
 
-case class MapValueViolation(fieldName: String, violation: Violation, mapSourceMapper: Option[SourceMapper], mapPosition: List[Position]) extends AstNodeViolation with PathBasedViolation {
+case class MapValueViolation(fieldName: String, violation: Violation, mapSourceMapper: Option[SourceMapper], mapPosition: List[AstLocation]) extends AstNodeViolation with PathBasedViolation {
   lazy val sourceMapper = violation match {
     case astv: AstNodeViolation ⇒ astv.sourceMapper
     case _ ⇒ mapSourceMapper
   }
 
-  lazy val positions = violation match {
-    case astv: AstNodeViolation ⇒ mapPosition ++ astv.positions
+  lazy val locations = violation match {
+    case astv: AstNodeViolation ⇒ mapPosition ++ astv.locations
     case _ ⇒ mapPosition
   }
 
@@ -387,7 +387,7 @@ case class MapValueViolation(fieldName: String, violation: Violation, mapSourceM
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
-case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation with PathBasedViolation {
+case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation with PathBasedViolation {
   lazy val pathString = "." + fieldName
 
   lazy val errorMessageWithoutPath = s"Field '$fieldName' is not defined in the input type '$typeName'."
@@ -395,7 +395,7 @@ case class UnknownInputObjectFieldViolation(typeName: String, fieldName: String,
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
-case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: String, fieldType: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation with PathBasedViolation {
+case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: String, fieldType: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation with PathBasedViolation {
   lazy val pathString = "." + fieldName
 
   lazy val errorMessageWithoutPath = s"Not-null field '$fieldName' of type '$fieldType' defined in the '$typeName' input type is missing."
@@ -403,27 +403,27 @@ case class NotNullInputObjectFieldMissingViolation(typeName: String, fieldName: 
   lazy val simpleErrorMessage = s"'${pathString substring 1}' $errorMessageWithoutPath"
 }
 
-case class NotNullValueIsNullViolation(sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class NotNullValueIsNullViolation(sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Expected non-null value, found null."
 }
 
-case class InputObjectIsOfWrongTypeMissingViolation(typeName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class InputObjectIsOfWrongTypeMissingViolation(typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Expected '$typeName', found not an object."
 }
 
-case class GenericInvalidValueViolation(sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class GenericInvalidValueViolation(sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Invalid value"
 }
 
-case class VariableNotAllowedViolation(varName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class VariableNotAllowedViolation(varName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Variable '$varName' is used in a place where it is not allowed to be used."
 }
 
-case class InvalidInputValueViolation(argumentName: String, errorText: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class InvalidInputValueViolation(argumentName: String, errorText: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Argument '$argumentName' has invalid value: $errorText"
 }
 
-case class DuplicateVariableViolation(variableName: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class DuplicateVariableViolation(variableName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"There can be only one variable named '$variableName'."
 }
 
@@ -447,6 +447,6 @@ case class ReservedEnumValueNameViolation(typeName: String, valueName: String) e
   lazy val errorMessage = s"'Name '$typeName.$valueName' can not be used as an Enum value."
 }
 
-case class VariableInferenceViolation(variableName: String, type1: String, type2: String, sourceMapper: Option[SourceMapper], positions: List[Position]) extends AstNodeViolation {
+case class VariableInferenceViolation(variableName: String, type1: String, type2: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Inferred variable '$$$variableName' is used with two conflicting types: '$type1' and '$type2'."
 }

--- a/src/main/scala/sangria/validation/rules/ArgumentsOfCorrectType.scala
+++ b/src/main/scala/sangria/validation/rules/ArgumentsOfCorrectType.scala
@@ -26,7 +26,7 @@ class ArgumentsOfCorrectType extends ValidationRule {
               QueryRenderer.render(value),
               violation,
               ctx.sourceMapper,
-              value.position.toList)))
+              value.location.toList)))
           else
             AstVisitorCommand.RightContinue
         } getOrElse AstVisitorCommand.RightContinue

--- a/src/main/scala/sangria/validation/rules/DefaultValuesOfCorrectType.scala
+++ b/src/main/scala/sangria/validation/rules/DefaultValuesOfCorrectType.scala
@@ -25,7 +25,7 @@ class DefaultValuesOfCorrectType extends ValidationRule {
                 SchemaRenderer.renderTypeName(it),
                 SchemaRenderer.renderTypeName(OptionInputType(it)),
                 ctx.sourceMapper,
-                d.position.toList))
+                d.location.toList))
             case _ ⇒ Vector.empty
           }
 
@@ -42,7 +42,7 @@ class DefaultValuesOfCorrectType extends ValidationRule {
                     QueryRenderer.render(defaultValue),
                     violation,
                     ctx.sourceMapper,
-                    defaultValue.position.toList))
+                    defaultValue.location.toList))
               else
                 Vector.empty
             case _ ⇒ Vector.empty

--- a/src/main/scala/sangria/validation/rules/ExecutableDefinitions.scala
+++ b/src/main/scala/sangria/validation/rules/ExecutableDefinitions.scala
@@ -17,7 +17,7 @@ class ExecutableDefinitions extends ValidationRule {
         val errors =
           definitions.collect {
             case d if !d.isInstanceOf[ast.OperationDefinition] && !d.isInstanceOf[ast.FragmentDefinition] ⇒
-              NonExecutableDefinitionViolation(definitionName(d), d, ctx.sourceMapper, d.position.toList)
+              NonExecutableDefinitionViolation(definitionName(d), d, ctx.sourceMapper, d.location.toList)
           }
 
         if (errors.nonEmpty) Left(errors)

--- a/src/main/scala/sangria/validation/rules/FragmentsOnCompositeType.scala
+++ b/src/main/scala/sangria/validation/rules/FragmentsOnCompositeType.scala
@@ -18,14 +18,14 @@ class FragmentsOnCompositeType extends ValidationRule {
       case ast.InlineFragment(Some(cond), _, _, _, _, pos) ⇒
         ctx.typeInfo.tpe match {
           case Some(tpe) if !tpe.isInstanceOf[CompositeType[_]] ⇒
-            Left(Vector(InlineFragmentOnNonCompositeErrorViolation(cond.name, ctx.sourceMapper, cond.position.toList)))
+            Left(Vector(InlineFragmentOnNonCompositeErrorViolation(cond.name, ctx.sourceMapper, cond.location.toList)))
           case _ ⇒
             AstVisitorCommand.RightContinue
         }
       case ast.FragmentDefinition(name, cond, _, _, _, _, _, pos) ⇒
         ctx.typeInfo.tpe match {
           case Some(tpe) if !tpe.isInstanceOf[CompositeType[_]] ⇒
-            Left(Vector(FragmentOnNonCompositeErrorViolation(name, cond.name, ctx.sourceMapper, cond.position.toList)))
+            Left(Vector(FragmentOnNonCompositeErrorViolation(name, cond.name, ctx.sourceMapper, cond.location.toList)))
           case _ ⇒
             AstVisitorCommand.RightContinue
         }

--- a/src/main/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInference.scala
+++ b/src/main/scala/sangria/validation/rules/InputDocumentNonConflictingVariableInference.scala
@@ -1,6 +1,6 @@
 package sangria.validation.rules
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import sangria.ast
 import sangria.ast.AstVisitorCommand
 import sangria.renderer.SchemaRenderer
@@ -14,7 +14,7 @@ import scala.collection.mutable
 class InputDocumentNonConflictingVariableInference extends ValidationRule {
   override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
     private var inInputDocument = false
-    private val usedVariables = new mutable.HashMap[String, (ast.Type, List[Position])]
+    private val usedVariables = new mutable.HashMap[String, (ast.Type, List[AstLocation])]
 
     override val onEnter: ValidationVisit = {
       case _: ast.InputDocument ⇒
@@ -27,9 +27,9 @@ class InputDocumentNonConflictingVariableInference extends ValidationRule {
 
         usedVariables.get(v.name) match {
           case Some((existing, otherPos)) if existing != parentTypeAst ⇒
-            Left(Vector(VariableInferenceViolation(v.name, existing.renderCompact, parentTypeAst.renderCompact, ctx.sourceMapper, v.position.toList ++ otherPos)))
+            Left(Vector(VariableInferenceViolation(v.name, existing.renderCompact, parentTypeAst.renderCompact, ctx.sourceMapper, v.location.toList ++ otherPos)))
           case None ⇒
-            usedVariables(v.name) = (parentTypeAst, v.position.toList)
+            usedVariables(v.name) = (parentTypeAst, v.location.toList)
             AstVisitorCommand.RightContinue
           case _ ⇒ AstVisitorCommand.RightContinue
         }

--- a/src/main/scala/sangria/validation/rules/LoneAnonymousOperation.scala
+++ b/src/main/scala/sangria/validation/rules/LoneAnonymousOperation.scala
@@ -21,7 +21,7 @@ class LoneAnonymousOperation extends ValidationRule {
         AstVisitorCommand.RightContinue
       case op: ast.OperationDefinition ⇒
         if (op.name.isEmpty && operationCount > 1)
-          Left(Vector(AnonOperationNotAloneViolation(ctx.sourceMapper, op.position.toList)))
+          Left(Vector(AnonOperationNotAloneViolation(ctx.sourceMapper, op.location.toList)))
         else
           AstVisitorCommand.RightContinue
     }

--- a/src/main/scala/sangria/validation/rules/NoFragmentCycles.scala
+++ b/src/main/scala/sangria/validation/rules/NoFragmentCycles.scala
@@ -43,7 +43,7 @@ class NoFragmentCycles extends ValidationRule {
                  spreadNode.name,
                  cyclePath map (_.name),
                  ctx.sourceMapper,
-                 (cyclePath :+ spreadNode).flatMap(_.position))
+                 (cyclePath :+ spreadNode).flatMap(_.location))
            }
          }
 

--- a/src/main/scala/sangria/validation/rules/NoUndefinedVariables.scala
+++ b/src/main/scala/sangria/validation/rules/NoUndefinedVariables.scala
@@ -33,9 +33,9 @@ class NoUndefinedVariables extends ValidationRule {
         val errors = usages.filterNot(vu ⇒ variableNameDefined.contains(vu.node.name)).toVector.map { vu ⇒
           operation.name match {
             case Some(opName) ⇒
-              UndefinedVarByOpViolation(vu.node.name, opName, ctx.sourceMapper, vu.node.position.toList ++ operation.position.toList)
+              UndefinedVarByOpViolation(vu.node.name, opName, ctx.sourceMapper, vu.node.location.toList ++ operation.location.toList)
             case None ⇒
-              UndefinedVarViolation(vu.node.name, ctx.sourceMapper, vu.node.position.toList ++ operation.position.toList)
+              UndefinedVarViolation(vu.node.name, ctx.sourceMapper, vu.node.location.toList ++ operation.location.toList)
           }
         }
 

--- a/src/main/scala/sangria/validation/rules/NoUnusedFragments.scala
+++ b/src/main/scala/sangria/validation/rules/NoUnusedFragments.scala
@@ -37,7 +37,7 @@ class NoUnusedFragments extends ValidationRule {
 
         val errors = fragmentDefs.toVector
           .filter(fd ⇒ !fragmentNameUsed.contains(fd.name))
-          .map(fd ⇒ UnusedFragmentViolation(fd.name, ctx.sourceMapper, fd.position.toList))
+          .map(fd ⇒ UnusedFragmentViolation(fd.name, ctx.sourceMapper, fd.location.toList))
 
         if (errors.nonEmpty) Left(errors) else AstVisitorCommand.RightContinue
     }

--- a/src/main/scala/sangria/validation/rules/NoUnusedVariables.scala
+++ b/src/main/scala/sangria/validation/rules/NoUnusedVariables.scala
@@ -32,7 +32,7 @@ class NoUnusedVariables extends ValidationRule {
         val variableNameUsed = usages.map(_.node.name).toSet
 
         val errors = variableDefs.filterNot(vd ⇒ variableNameUsed.contains(vd.name)).toVector.map(vd ⇒
-          UnusedVariableViolation(vd.name, operation.name, ctx.sourceMapper, vd.position.toList))
+          UnusedVariableViolation(vd.name, operation.name, ctx.sourceMapper, vd.location.toList))
 
         if (errors.nonEmpty) Left(errors.distinct) else AstVisitorCommand.RightContinue
     }

--- a/src/main/scala/sangria/validation/rules/OverlappingFieldsCanBeMerged.scala
+++ b/src/main/scala/sangria/validation/rules/OverlappingFieldsCanBeMerged.scala
@@ -88,7 +88,7 @@ class OverlappingFieldsCanBeMerged extends ValidationRule {
         val conflicts = findConflictsWithinSelectionSet(ctx.typeInfo.parentType, selCont, Set.empty)
 
         if (conflicts.nonEmpty)
-          Left(conflicts.toVector.map(c ⇒ FieldsConflictViolation(c.reason.fieldName, c.reason.reason, ctx.sourceMapper, (c.fields1 ++ c.fields2) flatMap (_.position))))
+          Left(conflicts.toVector.map(c ⇒ FieldsConflictViolation(c.reason.fieldName, c.reason.reason, ctx.sourceMapper, (c.fields1 ++ c.fields2) flatMap (_.location))))
         else
           AstVisitorCommand.RightContinue
     }

--- a/src/main/scala/sangria/validation/rules/PossibleFragmentSpreads.scala
+++ b/src/main/scala/sangria/validation/rules/PossibleFragmentSpreads.scala
@@ -27,7 +27,7 @@ class PossibleFragmentSpreads extends ValidationRule {
               SchemaRenderer.renderTypeName(parent, topLevel = true),
               SchemaRenderer.renderTypeName(tpe, topLevel = true),
               ctx.sourceMapper,
-              f.position.toList
+              f.location.toList
             ))
         else Vector.empty
 
@@ -46,7 +46,7 @@ class PossibleFragmentSpreads extends ValidationRule {
               SchemaRenderer.renderTypeName(parent, topLevel = true),
               SchemaRenderer.renderTypeName(tpe, topLevel = true),
               ctx.sourceMapper,
-              fs.position.toList
+              fs.location.toList
             ))
           else Vector.empty
 

--- a/src/main/scala/sangria/validation/rules/UniqueDirectivesPerLocation.scala
+++ b/src/main/scala/sangria/validation/rules/UniqueDirectivesPerLocation.scala
@@ -23,7 +23,7 @@ class UniqueDirectivesPerLocation extends ValidationRule {
 
         val errors = node.directives.foldLeft(Vector.empty[Violation]) {
           case (errors, d) if knownDirectives contains d.name ⇒
-            errors :+ DuplicateDirectiveViolation(d.name, ctx.sourceMapper, knownDirectives(d.name).position.toList ++ d.position.toList )
+            errors :+ DuplicateDirectiveViolation(d.name, ctx.sourceMapper, knownDirectives(d.name).location.toList ++ d.location.toList )
           case (errors, d) ⇒
             knownDirectives(d.name) = d
             errors

--- a/src/main/scala/sangria/validation/rules/UniqueFragmentNames.scala
+++ b/src/main/scala/sangria/validation/rules/UniqueFragmentNames.scala
@@ -18,7 +18,7 @@ class UniqueFragmentNames extends ValidationRule {
     override val onEnter: ValidationVisit = {
       case fragDef: ast.FragmentDefinition ⇒
         if (knownFragmentNames contains fragDef.name)
-          Left(Vector(DuplicateFragmentNameViolation(fragDef.name, ctx.sourceMapper, fragDef.position.toList)))
+          Left(Vector(DuplicateFragmentNameViolation(fragDef.name, ctx.sourceMapper, fragDef.location.toList)))
         else {
           knownFragmentNames += fragDef.name
           AstVisitorCommand.RightContinue

--- a/src/main/scala/sangria/validation/rules/UniqueInputFieldNames.scala
+++ b/src/main/scala/sangria/validation/rules/UniqueInputFieldNames.scala
@@ -1,6 +1,6 @@
 package sangria.validation.rules
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 
 import scala.collection.mutable.{Map ⇒ MutableMap}
 
@@ -16,13 +16,13 @@ import sangria.validation._
  */
 class UniqueInputFieldNames extends ValidationRule {
   override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
-    val knownNameStack = ValidatorStack.empty[MutableMap[String, Option[Position]]]
-    var knownNames = MutableMap[String, Option[Position]]()
+    val knownNameStack = ValidatorStack.empty[MutableMap[String, Option[AstLocation]]]
+    var knownNames = MutableMap[String, Option[AstLocation]]()
 
     override val onEnter: ValidationVisit = {
       case ast.ObjectValue(_, _, _) ⇒
         knownNameStack.push(knownNames)
-        knownNames = MutableMap[String, Option[Position]]()
+        knownNames = MutableMap[String, Option[AstLocation]]()
 
         AstVisitorCommand.RightContinue
 

--- a/src/main/scala/sangria/validation/rules/UniqueVariableNames.scala
+++ b/src/main/scala/sangria/validation/rules/UniqueVariableNames.scala
@@ -1,8 +1,6 @@
 package sangria.validation.rules
 
-import org.parboiled2.Position
-
-
+import sangria.ast.AstLocation
 import sangria.ast
 import sangria.ast.AstVisitorCommand
 import sangria.validation._
@@ -16,7 +14,7 @@ import scala.collection.mutable.{Map ⇒ MutableMap}
   */
 class UniqueVariableNames extends ValidationRule {
   override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
-    val knownVariableNames = MutableMap[String, List[Position]]()
+    val knownVariableNames = MutableMap[String, List[AstLocation]]()
 
     override val onEnter: ValidationVisit = {
       case _: ast.OperationDefinition ⇒

--- a/src/main/scala/sangria/validation/rules/VariablesAreInputTypes.scala
+++ b/src/main/scala/sangria/validation/rules/VariablesAreInputTypes.scala
@@ -19,7 +19,7 @@ class VariablesAreInputTypes extends ValidationRule {
         ctx.schema.getInputType(tpe) match {
           case Some(_) ⇒ AstVisitorCommand.RightContinue
           case None ⇒ Left(Vector(
-            NonInputTypeOnVarViolation(name, QueryRenderer.render(tpe), ctx.sourceMapper, tpe.position.toList)))
+            NonInputTypeOnVarViolation(name, QueryRenderer.render(tpe), ctx.sourceMapper, tpe.location.toList)))
         }
     }
   }

--- a/src/main/scala/sangria/validation/rules/VariablesInAllowedPosition.scala
+++ b/src/main/scala/sangria/validation/rules/VariablesInAllowedPosition.scala
@@ -47,7 +47,7 @@ class VariablesInAllowedPosition extends ValidationRule {
             SchemaRenderer.renderTypeName(inputTpe),
             SchemaRenderer.renderTypeName(tpe),
             ctx.sourceMapper,
-            varDef.position.toList ++ usage.node.position.toList)
+            varDef.location.toList ++ usage.node.location.toList)
         }
 
         if (errors.nonEmpty) Left(errors.distinct) else AstVisitorCommand.RightContinue

--- a/src/test/scala/sangria/execution/ExceptionHandlingSpec.scala
+++ b/src/test/scala/sangria/execution/ExceptionHandlingSpec.scala
@@ -212,7 +212,7 @@ class ExceptionHandlingSpec extends WordSpec with Matchers with FutureResultSupp
           HandledException(
             Vector(
               ("Error 1", Map("errorCode" → m.scalarNode("OOPS", "String", Set.empty)), Nil),
-              ("Error 2", Map.empty[String, m.Node], doc.operations.head._2.position.toList)))
+              ("Error 2", Map.empty[String, m.Node], doc.operations.head._2.location.toList)))
       }
 
       Executor.execute(schema, doc, exceptionHandler = exceptionHandler).await should be  (

--- a/src/test/scala/sangria/macros/LiteralMacroSpec.scala
+++ b/src/test/scala/sangria/macros/LiteralMacroSpec.scala
@@ -1,6 +1,6 @@
 package sangria.macros
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import org.scalatest.{Matchers, WordSpec}
 import sangria.ast._
 import sangria.util.DebugUtil
@@ -39,7 +39,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
 
       ast.sourceMapper should not be 'empty
 
-      ast.withoutSourceMapper should be (
+      AstNode.withoutAstLocations(ast.withoutSourceMapper) should be (
         Document(
           Vector(
             OperationDefinition(
@@ -48,17 +48,17 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               Vector(
                 VariableDefinition(
                   "someVar",
-                  NamedType("Int", Some(Position(74, 3, 51))),
-                  Some(BigDecimalValue(1.23, Vector.empty, Some(Position(80, 3, 57)))),
+                  NamedType("Int", None),
+                  Some(BigDecimalValue(1.23, Vector.empty, None)),
                   Vector.empty,
-                  Some(Position(64, 3, 41))
+                  None
                 ),
                 VariableDefinition(
                   "anotherVar",
-                  NamedType("Int", Some(Position(98, 3, 75))),
-                  Some(BigIntValue(123, Vector.empty, Some(Position(104, 3, 81)))),
+                  NamedType("Int", None),
+                  Some(BigIntValue(123, Vector.empty, None)),
                   Vector.empty,
-                  Some(Position(85, 3, 62))
+                  None
                 )),
               Vector(
                 Directive(
@@ -66,24 +66,24 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "if",
-                      BooleanValue(true, Vector.empty, Some(Position(121, 3, 98))),
+                      BooleanValue(true, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(117, 3, 94))
+                      None
                     )),
                   Vector.empty,
-                  Some(Position(108, 3, 85))
+                  None
                 ),
                 Directive(
                   "include",
                   Vector(
                     Argument(
                       "if",
-                      BooleanValue(false, Vector.empty, Some(Position(140, 3, 117))),
+                      BooleanValue(false, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(136, 3, 113))
+                      None
                     )),
                   Vector.empty,
-                  Some(Position(127, 3, 104))
+                  None
                 )),
               Vector(
                 Field(
@@ -92,9 +92,9 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("1000", false, None, Vector.empty, Some(Position(176, 4, 29))),
+                      StringValue("1000", false, None, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(172, 4, 25))
+                      None
                     )),
                   Vector(
                     Directive(
@@ -102,12 +102,12 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                       Vector(
                         Argument(
                           "if",
-                          BooleanValue(true, Vector.empty, Some(Position(196, 4, 49))),
+                          BooleanValue(true, Vector.empty, None),
                           Vector.empty,
-                          Some(Position(192, 4, 45))
+                          None
                         )),
                       Vector.empty,
-                      Some(Position(183, 4, 36))
+                      None
                     )),
                   Vector(
                     Field(
@@ -116,19 +116,19 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                       Vector(
                         Argument(
                           "sort",
-                          EnumValue("NAME", Vector.empty, Some(Position(231, 5, 29))),
+                          EnumValue("NAME", Vector.empty, None),
                           Vector.empty,
-                          Some(Position(225, 5, 23))
+                          None
                         )),
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(217, 5, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(160, 4, 13))
+                  None
                 ),
                 Field(
                   Some("leia"),
@@ -136,9 +136,9 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("10103\n \u00F6 \u00F6", false, None, Vector.empty, Some(Position(284, 7, 34))),
+                      StringValue("10103\n \u00F6 \u00F6", false, None, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(275, 7, 25))
+                      None
                     )),
                   Vector.empty,
                   Vector(
@@ -150,15 +150,15 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(315, 8, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector(
-                    Comment(" some name", Some(Position(320, 8, 20)))),
-                  Some(Position(263, 7, 13))
+                    Comment(" some name", None)),
+                  None
                 ),
                 InlineFragment(
-                  Some(NamedType("User", Some(Position(366, 11, 20)))),
+                  Some(NamedType("User", None)),
                   Vector.empty,
                   Vector(
                     Field(
@@ -175,37 +175,37 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                           Vector.empty,
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(393, 12, 21))
+                          None
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(387, 12, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(359, 11, 13))
+                  None
                 ),
-                FragmentSpread("Foo", Vector.empty, Vector.empty, Some(Position(425, 15, 13)))),
+                FragmentSpread("Foo", Vector.empty, Vector.empty, None)),
               Vector(
-                Comment(" test query", Some(Position(11, 2, 11)))),
+                Comment(" test query", None)),
               Vector.empty,
-              Some(Position(34, 3, 11))
+              None
             ),
             FragmentDefinition(
               "Foo",
-              NamedType("User", Some(Position(471, 18, 27))),
+              NamedType("User", None),
               Vector(
                 Directive(
                   "foo",
                   Vector(
                     Argument(
                       "bar",
-                      BigIntValue(1, Vector.empty, Some(Position(486, 18, 42))),
+                      BigIntValue(1, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(481, 18, 37))
+                      None
                     )),
                   Vector.empty,
-                  Some(Position(476, 18, 32))
+                  None
                 )),
               Vector(
                 Field(
@@ -216,16 +216,16 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(502, 19, 13))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
               Vector(
-                Comment(" field in fragment!", Some(Position(506, 19, 17)))),
-              Some(Position(455, 18, 11))
+                Comment(" field in fragment!", None)),
+              None
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          None,
           None
         ))
     }
@@ -288,7 +288,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
 
       ast.sourceMapper should not be 'empty
 
-      ast.withoutSourceMapper should be (
+      AstNode.withoutAstLocations(ast.withoutSourceMapper) should be (
         Document(
           Vector(
             OperationDefinition(
@@ -297,17 +297,17 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               Vector(
                 VariableDefinition(
                   "foo",
-                  NamedType("ComplexType", Some(Position(381, 9, 33))),
+                  NamedType("ComplexType", None),
                   None,
                   Vector.empty,
-                  Some(Position(375, 9, 27))
+                  None
                 ),
                 VariableDefinition(
                   "site",
-                  NamedType("Site", Some(Position(401, 9, 53))),
-                  Some(EnumValue("MOBILE", Vector.empty, Some(Position(408, 9, 60)))),
+                  NamedType("Site", None),
+                  Some(EnumValue("MOBILE", Vector.empty, None)),
                   Vector.empty,
-                  Some(Position(394, 9, 46))
+                  None
                 )),
               Vector.empty,
               Vector(
@@ -319,13 +319,13 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                       "id",
                       ListValue(
                         Vector(
-                          BigIntValue(123, Vector.empty, Some(Position(454, 10, 37))),
-                          BigIntValue(456, Vector.empty, Some(Position(459, 10, 42)))),
+                          BigIntValue(123, Vector.empty, None),
+                          BigIntValue(456, Vector.empty, None)),
                         Vector.empty,
-                        Some(Position(453, 10, 36))
+                        None
                       ),
                       Vector.empty,
-                      Some(Position(449, 10, 32))
+                      None
                     )),
                   Vector.empty,
                   Vector(
@@ -337,16 +337,16 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(481, 11, 15))
+                      None
                     ),
                     InlineFragment(
-                      Some(NamedType("User", Some(Position(507, 12, 22)))),
+                      Some(NamedType("User", None)),
                       Vector(
                         Directive(
                           "defer",
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(512, 12, 27))
+                          None
                         )),
                       Vector(
                         Field(
@@ -363,7 +363,7 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(564, 14, 19))
+                              None
                             ),
                             Field(
                               Some("alias"),
@@ -371,15 +371,15 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                               Vector(
                                 Argument(
                                   "first",
-                                  BigIntValue(10, Vector.empty, Some(Position(607, 15, 39))),
+                                  BigIntValue(10, Vector.empty, None),
                                   Vector.empty,
-                                  Some(Position(601, 15, 33))
+                                  None
                                 ),
                                 Argument(
                                   "after",
-                                  VariableValue("foo", Vector.empty, Some(Position(617, 15, 49))),
+                                  VariableValue("foo", Vector.empty, None),
                                   Vector.empty,
-                                  Some(Position(611, 15, 43))
+                                  None
                                 )),
                               Vector(
                                 Directive(
@@ -387,12 +387,12 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                                   Vector(
                                     Argument(
                                       "if",
-                                      VariableValue("foo", Vector.empty, Some(Position(637, 15, 69))),
+                                      VariableValue("foo", Vector.empty, None),
                                       Vector.empty,
-                                      Some(Position(633, 15, 65))
+                                      None
                                     )),
                                   Vector.empty,
-                                  Some(Position(624, 15, 56))
+                                  None
                                 )),
                               Vector(
                                 Field(
@@ -403,34 +403,34 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                                   Vector.empty,
                                   Vector.empty,
                                   Vector.empty,
-                                  Some(Position(665, 16, 21))
+                                  None
                                 ),
-                                FragmentSpread("frag", Vector.empty, Vector.empty, Some(Position(689, 17, 21)))),
+                                FragmentSpread("frag", Vector.empty, Vector.empty, None)),
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(587, 15, 19))
+                              None
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(537, 13, 17))
+                          None
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(500, 12, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(430, 10, 13))
+                  None
                 )),
               Vector(
-                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(Position(11, 2, 11))),
-                Comment(" All rights reserved.", Some(Position(58, 3, 11))),
-                Comment("", Some(Position(91, 4, 11))),
-                Comment(" This source code is licensed under the BSD-style license found in the", Some(Position(103, 5, 11))),
-                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(Position(185, 6, 11))),
-                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(Position(273, 7, 11)))),
+                Comment(" Copyright (c) 2015, Facebook, Inc.", None),
+                Comment(" All rights reserved.", None),
+                Comment("", None),
+                Comment(" This source code is licensed under the BSD-style license found in the", None),
+                Comment(" LICENSE file in the root directory of this source tree. An additional grant", None),
+                Comment(" of patent rights can be found in the PATENTS file in the same directory.", None)),
               Vector.empty,
-              Some(Position(359, 9, 11))
+              None
             ),
             OperationDefinition(
               OperationType.Subscription,
@@ -438,10 +438,10 @@ class LiteralMacroSpec extends WordSpec with Matchers {
               Vector(
                 VariableDefinition(
                   "input",
-                  NamedType("StoryLikeSubscribeInput", Some(Position(831, 24, 54))),
+                  NamedType("StoryLikeSubscribeInput", None),
                   None,
                   Vector.empty,
-                  Some(Position(823, 24, 46))
+                  None
                 )),
               Vector.empty,
               Vector(
@@ -451,9 +451,9 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "input",
-                      VariableValue("input", Vector.empty, Some(Position(896, 25, 39))),
+                      VariableValue("input", Vector.empty, None),
                       Vector.empty,
-                      Some(Position(889, 25, 32))
+                      None
                     )),
                   Vector.empty,
                   Vector(
@@ -477,11 +477,11 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(971, 28, 19))
+                              None
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(944, 27, 17))
+                          None
                         ),
                         Field(
                           None,
@@ -497,23 +497,23 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(1044, 31, 19))
+                              None
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(1011, 30, 17))
+                          None
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(920, 26, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(870, 25, 13))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(788, 24, 11))
+              None
             ),
             OperationDefinition(
               OperationType.Mutation,
@@ -527,16 +527,16 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "story",
-                      BigIntValue(123, Vector.empty, Some(Position(1165, 38, 25))),
+                      BigIntValue(123, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(1158, 38, 18))
+                      None
                     )),
                   Vector(
                     Directive(
                       "defer",
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(1170, 38, 30))
+                      None
                     )),
                   Vector(
                     Field(
@@ -553,23 +553,23 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                           Vector.empty,
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(1217, 40, 17))
+                          None
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(1193, 39, 15))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1153, 38, 13))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(1120, 37, 11))
+              None
             ),
             FragmentDefinition(
               "frag",
-              NamedType("Friend", Some(Position(1290, 45, 28))),
+              NamedType("Friend", None),
               Vector.empty,
               Vector(
                 Field(
@@ -578,15 +578,15 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "size",
-                      VariableValue("size", Vector.empty, Some(Position(1321, 46, 23))),
+                      VariableValue("size", Vector.empty, None),
                       Vector.empty,
-                      Some(Position(1315, 46, 17))
+                      None
                     ),
                     Argument(
                       "bar",
-                      VariableValue("b", Vector.empty, Some(Position(1333, 46, 35))),
+                      VariableValue("b", Vector.empty, None),
                       Vector.empty,
-                      Some(Position(1328, 46, 30))
+                      None
                     ),
                     Argument(
                       "obj",
@@ -594,26 +594,26 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                         Vector(
                           ObjectField(
                             "key",
-                            StringValue("value", false, None, Vector.empty, Some(Position(1348, 46, 50))),
+                            StringValue("value", false, None, Vector.empty, None),
                             Vector.empty,
-                            Some(Position(1343, 46, 45))
+                            None
                           )),
                         Vector.empty,
-                        Some(Position(1342, 46, 44))
+                        None
                       ),
                       Vector.empty,
-                      Some(Position(1337, 46, 39))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1311, 46, 13))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(1273, 45, 11))
+              None
             ),
             OperationDefinition(
               OperationType.Query,
@@ -627,21 +627,21 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector(
                     Argument(
                       "truthy",
-                      BooleanValue(true, Vector.empty, Some(Position(1411, 50, 29))),
+                      BooleanValue(true, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(1403, 50, 21))
+                      None
                     ),
                     Argument(
                       "falsey",
-                      BooleanValue(false, Vector.empty, Some(Position(1425, 50, 43))),
+                      BooleanValue(false, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(1417, 50, 35))
+                      None
                     )),
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1395, 50, 13))
+                  None
                 ),
                 Field(
                   None,
@@ -651,14 +651,14 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1445, 51, 13))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(1381, 49, 11))
+              None
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          None,
           None
         )
       )
@@ -751,161 +751,161 @@ class LiteralMacroSpec extends WordSpec with Matchers {
 
       ast.sourceMapper should not be 'empty
 
-      ast.withoutSourceMapper should be (
+      AstNode.withoutAstLocations(ast.withoutSourceMapper) should be (
         Document(
           Vector(
             SchemaDefinition(
               Vector(
-                OperationTypeDefinition(OperationType.Query, NamedType("QueryType", Some(Position(387, 10, 20))), Vector.empty, Some(Position(380, 10, 13))),
-                OperationTypeDefinition(OperationType.Mutation, NamedType("MutationType", Some(Position(419, 11, 23))), Vector.empty, Some(Position(409, 11, 13)))),
+                OperationTypeDefinition(OperationType.Query, NamedType("QueryType", None), Vector.empty, None),
+                OperationTypeDefinition(OperationType.Mutation, NamedType("MutationType", None), Vector.empty, None)),
               Vector.empty,
               Vector(
-                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(Position(11, 2, 11))),
-                Comment(" All rights reserved.", Some(Position(58, 3, 11))),
-                Comment("", Some(Position(91, 4, 11))),
-                Comment(" This source code is licensed under the BSD-style license found in the", Some(Position(103, 5, 11))),
-                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(Position(185, 6, 11))),
-                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(Position(273, 7, 11)))),
+                Comment(" Copyright (c) 2015, Facebook, Inc.", None),
+                Comment(" All rights reserved.", None),
+                Comment("", None),
+                Comment(" This source code is licensed under the BSD-style license found in the", None),
+                Comment(" LICENSE file in the root directory of this source tree. An additional grant", None),
+                Comment(" of patent rights can be found in the PATENTS file in the same directory.", None)),
               Vector.empty,
-              Some(Position(359, 9, 11))
+              None
             ),
             ObjectTypeDefinition(
               "Foo",
               Vector(
-                NamedType("Bar", Some(Position(511, 15, 31)))),
+                NamedType("Bar", None)),
               Vector(
-                FieldDefinition("one", NamedType("Type", Some(Position(534, 16, 18))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(529, 16, 13))),
-                FieldDefinition("two", NamedType("Type", Some(Position(612, 18, 40))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(599, 18, 27))), Some(Position(599, 18, 27))), None, Vector.empty, None, Vector.empty, Some(Position(589, 18, 17)))), Vector.empty, Some(StringValue("another description", false, None, Vector.empty, Some(Position(551, 17, 13)))), Vector.empty, Some(Position(585, 18, 13))),
-                FieldDefinition("three", NamedType("Int", Some(Position(672, 19, 56))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(645, 19, 29))), None, Vector.empty, None, Vector.empty, Some(Position(635, 19, 19))), InputValueDefinition("other", NamedType("String", Some(Position(663, 19, 47))), None, Vector.empty, None, Vector.empty, Some(Position(656, 19, 40)))), Vector.empty, None, Vector.empty, Some(Position(629, 19, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(723, 20, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(703, 20, 28))), Some(StringValue("string", false, None, Vector.empty, Some(Position(712, 20, 37)))), Vector.empty, None, Vector.empty, Some(Position(693, 20, 18)))), Vector.empty, None, Vector.empty, Some(Position(688, 20, 13))),
-                FieldDefinition("five", NamedType("String", Some(Position(791, 21, 62))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(758, 21, 29))), Some(Position(757, 21, 28))), Some(ListValue(
+                FieldDefinition("one", NamedType("Type", None), Vector.empty, Vector.empty, None, Vector.empty, None),
+                FieldDefinition("two", NamedType("Type", None), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", None), None), None, Vector.empty, None, Vector.empty, None)), Vector.empty, Some(StringValue("another description", false, None, Vector.empty, None)), Vector.empty, None),
+                FieldDefinition("three", NamedType("Int", None), Vector(InputValueDefinition("argument", NamedType("InputType", None), None, Vector.empty, None, Vector.empty, None), InputValueDefinition("other", NamedType("String", None), None, Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None),
+                FieldDefinition("four", NamedType("String", None), Vector(InputValueDefinition("argument", NamedType("String", None), Some(StringValue("string", false, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None),
+                FieldDefinition("five", NamedType("String", None), Vector(InputValueDefinition("argument", ListType(NamedType("String", None), None), Some(ListValue(
                   Vector(
-                    StringValue("string", false, None, Vector.empty, Some(Position(769, 21, 40))),
-                    StringValue("string", false, None, Vector.empty, Some(Position(779, 21, 50)))),
+                    StringValue("string", false, None, Vector.empty, None),
+                    StringValue("string", false, None, Vector.empty, None)),
                   Vector.empty,
-                  Some(Position(768, 21, 39))
-                )), Vector.empty, None, Vector.empty, Some(Position(747, 21, 18)))), Vector.empty, None, Vector.empty, Some(Position(742, 21, 13))),
-                FieldDefinition("six", NamedType("Type", Some(Position(853, 22, 56))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(824, 22, 27))), Some(ObjectValue(
+                  None
+                )), Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None),
+                FieldDefinition("six", NamedType("Type", None), Vector(InputValueDefinition("argument", NamedType("InputType", None), Some(ObjectValue(
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", false, None, Vector.empty, Some(Position(842, 22, 45))),
+                      StringValue("value", false, None, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(837, 22, 40))
+                      None
                     )),
                   Vector.empty,
-                  Some(Position(836, 22, 39))
-                )), Vector.empty, None, Vector.empty, Some(Position(814, 22, 17)))), Vector.empty, None, Vector.empty, Some(Position(810, 22, 13)))),
+                  None
+                )), Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None)),
               Vector.empty,
-              Some(StringValue("Type description *test*", false, None, Vector.empty, Some(Position(455, 14, 11)))),
+              Some(StringValue("Type description *test*", false, None, Vector.empty, None)),
               Vector.empty,
               Vector.empty,
-              Some(Position(491, 15, 11))
+              None
             ),
             ObjectTypeDefinition(
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(986, 26, 59))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(960, 26, 33))), Some(StringValue("default", false, None, Vector.empty, Some(Position(967, 26, 40)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", None), Vector(InputValueDefinition("arg", NamedType("Type", None), Some(StringValue("default", false, None, Vector.empty, None)), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(977, 26, 50))
-                )), None, Vector.empty, Some(Position(955, 26, 28)))), Vector(Directive(
+                  None
+                )), None, Vector.empty, None)), Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(991, 26, 64))
-                )), None, Vector.empty, Some(Position(940, 26, 13)))),
+                  None
+                )), None, Vector.empty, None)),
               Vector(
                 Directive(
                   "onObject",
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", false, None, Vector.empty, Some(Position(917, 25, 47))),
+                      StringValue("value", false, None, Vector.empty, None),
                       Vector.empty,
-                      Some(Position(912, 25, 42))
+                      None
                     )),
                   Vector.empty,
-                  Some(Position(902, 25, 32))
+                  None
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(881, 25, 11))
+              None
             ),
             InterfaceTypeDefinition(
               "Bar",
               Vector(
-                FieldDefinition("one", NamedType("Type", Some(Position(1087, 31, 18))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(1082, 31, 13))),
-                FieldDefinition("four", NamedType("String", Some(Position(1139, 32, 48))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(1119, 32, 28))), Some(StringValue("string", false, None, Vector.empty, Some(Position(1128, 32, 37)))), Vector.empty, None, Vector.empty, Some(Position(1109, 32, 18)))), Vector.empty, None, Vector.empty, Some(Position(1104, 32, 13)))),
+                FieldDefinition("one", NamedType("Type", None), Vector.empty, Vector.empty, None, Vector.empty, None),
+                FieldDefinition("four", NamedType("String", None), Vector(InputValueDefinition("argument", NamedType("String", None), Some(StringValue("string", false, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None)),
               Vector.empty,
               None,
               Vector(
-                Comment(" It's an interface!", Some(Position(1023, 29, 11)))),
+                Comment(" It's an interface!", None)),
               Vector.empty,
-              Some(Position(1054, 30, 11))
+              None
             ),
             InterfaceTypeDefinition(
               "AnnotatedInterface",
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(1259, 36, 47))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(1245, 36, 33))), None, Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", None), Vector(InputValueDefinition("arg", NamedType("Type", None), None, Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1250, 36, 38))
-                )), None, Vector.empty, Some(Position(1240, 36, 28)))), Vector(Directive(
+                  None
+                )), None, Vector.empty, None)), Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1264, 36, 52))
-                )), None, Vector.empty, Some(Position(1225, 36, 13)))),
+                  None
+                )), None, Vector.empty, None)),
               Vector(
                 Directive(
                   "onInterface",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1198, 35, 40))
+                  None
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1169, 35, 11))
+              None
             ),
             UnionTypeDefinition(
               "Feed",
               Vector(
-                NamedType("Story", Some(Position(1309, 39, 24))),
-                NamedType("Article", Some(Position(1317, 39, 32))),
-                NamedType("Advert", Some(Position(1327, 39, 42)))),
+                NamedType("Story", None),
+                NamedType("Article", None),
+                NamedType("Advert", None)),
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(1296, 39, 11))
+              None
             ),
             UnionTypeDefinition(
               "AnnotatedUnion",
               Vector(
-                NamedType("A", Some(Position(1377, 41, 43))),
-                NamedType("B", Some(Position(1381, 41, 47)))),
+                NamedType("A", None),
+                NamedType("B", None)),
               Vector(
                 Directive(
                   "onUnion",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1366, 41, 32))
+                  None
                 )),
               None,
               Vector.empty,
-              Some(Position(1345, 41, 11))
+              None
             ),
             ScalarTypeDefinition(
               "CustomScalar",
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(1394, 43, 11))
+              None
             ),
             ScalarTypeDefinition(
               "AnnotatedScalar",
@@ -914,22 +914,22 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   "onScalar",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1448, 45, 34))
+                  None
                 )),
               None,
               Vector.empty,
-              Some(Position(1425, 45, 11))
+              None
             ),
             EnumTypeDefinition(
               "Site",
               Vector(
-                EnumValueDefinition("DESKTOP", Vector.empty, None, Vector(Comment(" value 1", Some(Position(1493, 48, 13)))), Some(Position(1515, 49, 13))),
-                EnumValueDefinition("MOBILE", Vector.empty, None, Vector(Comment(" value 2", Some(Position(1535, 50, 13)))), Some(Position(1557, 51, 13)))),
+                EnumValueDefinition("DESKTOP", Vector.empty, None, Vector(Comment(" value 1", None)), None),
+                EnumValueDefinition("MOBILE", Vector.empty, None, Vector(Comment(" value 2", None)), None)),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1469, 47, 11))
+              None
             ),
             EnumTypeDefinition(
               "AnnotatedEnum",
@@ -938,105 +938,105 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                   "onEnumValue",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1644, 55, 29))
-                )), None, Vector.empty, Some(Position(1628, 55, 13))),
-                EnumValueDefinition("OTHER_VALUE", Vector.empty, None, Vector.empty, Some(Position(1669, 56, 13)))),
+                  None
+                )), None, Vector.empty, None),
+                EnumValueDefinition("OTHER_VALUE", Vector.empty, None, Vector.empty, None)),
               Vector(
                 Directive(
                   "onEnum",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1606, 54, 30))
+                  None
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1587, 54, 11))
+              None
             ),
             InputObjectTypeDefinition(
               "InputType",
               Vector(
-                InputValueDefinition("key", NotNullType(NamedType("String", Some(Position(1739, 60, 18))), Some(Position(1739, 60, 18))), None, Vector.empty, None, Vector.empty, Some(Position(1734, 60, 13))),
-                InputValueDefinition("answer", NamedType("Int", Some(Position(1767, 61, 21))), Some(BigIntValue(42, Vector.empty, Some(Position(1773, 61, 27)))), Vector.empty, None, Vector.empty, Some(Position(1759, 61, 13)))),
+                InputValueDefinition("key", NotNullType(NamedType("String", None), None), None, Vector.empty, None, Vector.empty, None),
+                InputValueDefinition("answer", NamedType("Int", None), Some(BigIntValue(42, Vector.empty, None)), Vector.empty, None, Vector.empty, None)),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1704, 59, 11))
+              None
             ),
             InputObjectTypeDefinition(
               "AnnotatedInput",
               Vector(
-                InputValueDefinition("annotatedField", NamedType("Type", Some(Position(1897, 66, 29))), None, Vector(Directive(
+                InputValueDefinition("annotatedField", NamedType("Type", None), None, Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1902, 66, 34))
-                )), None, Vector(Comment(" field comment", Some(Position(1853, 65, 13)))), Some(Position(1881, 66, 13)))),
+                  None
+                )), None, Vector(Comment(" field comment", None)), None)),
               Vector(
                 Directive(
                   "onInputObjectType",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1820, 64, 32))
+                  None
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1799, 64, 11))
+              None
             ),
             ObjectTypeExtensionDefinition(
               "Foo",
               Vector.empty,
               Vector(
-                FieldDefinition("seven", NamedType("Type", Some(Position(1991, 70, 40))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(1981, 70, 30))), Some(Position(1980, 70, 29))), None, Vector.empty, None, Vector.empty, Some(Position(1970, 70, 19)))), Vector.empty, None, Vector.empty, Some(Position(1964, 70, 13)))),
+                FieldDefinition("seven", NamedType("Type", None), Vector(InputValueDefinition("argument", ListType(NamedType("String", None), None), None, Vector.empty, None, Vector.empty, None)), Vector.empty, None, Vector.empty, None)),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(1934, 69, 11))
+              None
             ),
             ObjectTypeExtensionDefinition(
               "Foo",
               Vector.empty,
               Vector(
-                FieldDefinition("foo", NamedType("String", Some(Position(2062, 74, 18))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(2057, 74, 13)))),
+                FieldDefinition("foo", NamedType("String", None), Vector.empty, Vector.empty, None, Vector.empty, None)),
               Vector(
                 Directive(
                   "onType",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(2035, 73, 27))
+                  None
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(2019, 73, 11))
+              None
             ),
             DirectiveDefinition(
               "skip",
               Vector(
-                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(Position(2112, 77, 31))), Some(Position(2112, 77, 31))), None, Vector.empty, None, Vector.empty, Some(Position(2108, 77, 27)))),
+                InputValueDefinition("if", NotNullType(NamedType("Boolean", None), None), None, Vector.empty, None, Vector.empty, None)),
               Vector(
-                DirectiveLocation("FIELD", Vector.empty, Some(Position(2125, 77, 44))),
-                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(Position(2133, 77, 52))),
-                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(Position(2151, 77, 70)))),
+                DirectiveLocation("FIELD", Vector.empty, None),
+                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, None),
+                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, None)),
               None,
               Vector.empty,
-              Some(Position(2092, 77, 11))
+              None
             ),
             DirectiveDefinition(
               "include",
               Vector(
-                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(Position(2201, 79, 34))), Some(Position(2201, 79, 34))), None, Vector.empty, None, Vector.empty, Some(Position(2197, 79, 30)))),
+                InputValueDefinition("if", NotNullType(NamedType("Boolean", None), None), None, Vector.empty, None, Vector.empty, None)),
               Vector(
-                DirectiveLocation("FIELD", Vector.empty, Some(Position(2226, 80, 16))),
-                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(Position(2234, 80, 24))),
-                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(Position(2252, 80, 42)))),
+                DirectiveLocation("FIELD", Vector.empty, None),
+                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, None),
+                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, None)),
               None,
               Vector.empty,
-              Some(Position(2178, 79, 11))
+              None
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          None,
           None
         ))
     }
@@ -1060,16 +1060,16 @@ class LiteralMacroSpec extends WordSpec with Matchers {
           Vector(
             ObjectField(
               "a",
-              NullValue(Vector.empty, Some(Position(24, 3, 14))),
+              NullValue(Vector.empty, Some(AstLocation(24, 3, 14))),
               Vector.empty,
-              Some(Position(21, 3, 11))
+              Some(AstLocation(21, 3, 11))
             ),
             ObjectField(
               "b",
-              BigIntValue(1, Vector.empty, Some(Position(68, 6, 14))),
+              BigIntValue(1, Vector.empty, Some(AstLocation(68, 6, 14))),
               Vector(
-                Comment(" test comment", Some(Position(40, 5, 11)))),
-              Some(Position(65, 6, 11))
+                Comment(" test comment", Some(AstLocation(40, 5, 11)))),
+              Some(AstLocation(65, 6, 11))
             ),
             ObjectField(
               "c",
@@ -1077,24 +1077,24 @@ class LiteralMacroSpec extends WordSpec with Matchers {
                 Vector(
                   ObjectField(
                     "someNull",
-                    NullValue(Vector.empty, Some(Position(107, 8, 23))),
+                    NullValue(Vector.empty, Some(AstLocation(107, 8, 23))),
                     Vector.empty,
-                    Some(Position(97, 8, 13))
+                    Some(AstLocation(97, 8, 13))
                   ),
                   ObjectField(
                     "enum",
-                    EnumValue("HELLO", Vector.empty, Some(Position(130, 9, 19))),
+                    EnumValue("HELLO", Vector.empty, Some(AstLocation(130, 9, 19))),
                     Vector.empty,
-                    Some(Position(124, 9, 13))
+                    Some(AstLocation(124, 9, 13))
                   )),
                 Vector.empty,
-                Some(Position(83, 7, 14))
+                Some(AstLocation(83, 7, 14))
               ),
               Vector.empty,
-              Some(Position(80, 7, 11))
+              Some(AstLocation(80, 7, 11))
             )),
           Vector.empty,
-          Some(Position(9, 2, 9))
+          Some(AstLocation(9, 2, 9))
         ))
     }
 

--- a/src/test/scala/sangria/parser/QueryParserSpec.scala
+++ b/src/test/scala/sangria/parser/QueryParserSpec.scala
@@ -1,8 +1,9 @@
 package sangria.parser
 
 import language.postfixOps
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import org.scalatest.{Matchers, WordSpec}
+import sangria.ast
 import sangria.ast._
 import sangria.util.{DebugUtil, FileUtil, StringMatchers}
 
@@ -10,6 +11,9 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 
 class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
+
+  def parseQuery(query: String)(implicit scheme: DeliveryScheme[ast.Document]): scheme.Result =
+    QueryParser.parse(query, ParserConfig.default.withEmptySourceId.withEmptySourceMapper)(scheme)
 
   "QueryParser" should {
     "parse complex query" in {
@@ -24,17 +28,17 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
               Vector(
                 VariableDefinition(
                   "someVar",
-                  NamedType("Int", Some(Position(53, 2, 41))),
-                  Some(BigDecimalValue(1.23, Vector.empty, Some(Position(59, 2, 47)))),
+                  NamedType("Int", Some(AstLocation(53, 2, 41))),
+                  Some(BigDecimalValue(1.23, Vector.empty, Some(AstLocation(59, 2, 47)))),
                   Vector.empty,
-                  Some(Position(43, 2, 31))
+                  Some(AstLocation(43, 2, 31))
                 ),
                 VariableDefinition(
                   "anotherVar",
-                  NamedType("Int", Some(Position(77, 2, 65))),
-                  Some(BigIntValue(123, Vector.empty, Some(Position(83, 2, 71)))),
+                  NamedType("Int", Some(AstLocation(77, 2, 65))),
+                  Some(BigIntValue(123, Vector.empty, Some(AstLocation(83, 2, 71)))),
                   Vector.empty,
-                  Some(Position(64, 2, 52))
+                  Some(AstLocation(64, 2, 52))
                 )),
               Vector(
                 Directive(
@@ -42,24 +46,24 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "if",
-                      BooleanValue(true, Vector.empty, Some(Position(100, 2, 88))),
+                      BooleanValue(true, Vector.empty, Some(AstLocation(100, 2, 88))),
                       Vector.empty,
-                      Some(Position(96, 2, 84))
+                      Some(AstLocation(96, 2, 84))
                     )),
                   Vector.empty,
-                  Some(Position(87, 2, 75))
+                  Some(AstLocation(87, 2, 75))
                 ),
                 Directive(
                   "include",
                   Vector(
                     Argument(
                       "if",
-                      BooleanValue(false, Vector.empty, Some(Position(119, 2, 107))),
+                      BooleanValue(false, Vector.empty, Some(AstLocation(119, 2, 107))),
                       Vector.empty,
-                      Some(Position(115, 2, 103))
+                      Some(AstLocation(115, 2, 103))
                     )),
                   Vector.empty,
-                  Some(Position(106, 2, 94))
+                  Some(AstLocation(106, 2, 94))
                 )),
               Vector(
                 Field(
@@ -68,9 +72,9 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("1000", false, None, Vector.empty, Some(Position(145, 3, 19))),
+                      StringValue("1000", false, None, Vector.empty, Some(AstLocation(145, 3, 19))),
                       Vector.empty,
-                      Some(Position(141, 3, 15))
+                      Some(AstLocation(141, 3, 15))
                     )),
                   Vector(
                     Directive(
@@ -78,12 +82,12 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector(
                         Argument(
                           "if",
-                          BooleanValue(true, Vector.empty, Some(Position(165, 3, 39))),
+                          BooleanValue(true, Vector.empty, Some(AstLocation(165, 3, 39))),
                           Vector.empty,
-                          Some(Position(161, 3, 35))
+                          Some(AstLocation(161, 3, 35))
                         )),
                       Vector.empty,
-                      Some(Position(152, 3, 26))
+                      Some(AstLocation(152, 3, 26))
                     )),
                   Vector(
                     Field(
@@ -92,19 +96,19 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector(
                         Argument(
                           "sort",
-                          EnumValue("NAME", Vector.empty, Some(Position(190, 4, 19))),
+                          EnumValue("NAME", Vector.empty, Some(AstLocation(190, 4, 19))),
                           Vector.empty,
-                          Some(Position(184, 4, 13))
+                          Some(AstLocation(184, 4, 13))
                         )),
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(176, 4, 5))
+                      Some(AstLocation(176, 4, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(129, 3, 3))
+                  Some(AstLocation(129, 3, 3))
                 ),
                 Field(
                   Some("leia"),
@@ -112,9 +116,9 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "id",
-                      StringValue("10103\n \u00F6 \u00F6", false, None, Vector.empty, Some(Position(223, 6, 24))),
+                      StringValue("10103\n \u00F6 \u00F6", false, None, Vector.empty, Some(AstLocation(223, 6, 24))),
                       Vector.empty,
-                      Some(Position(214, 6, 15))
+                      Some(AstLocation(214, 6, 15))
                     )),
                   Vector.empty,
                   Vector(
@@ -126,15 +130,15 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(249, 7, 5))
+                      Some(AstLocation(249, 7, 5))
                     )),
                   Vector.empty,
                   Vector(
-                    Comment(" some name", Some(Position(254, 7, 10)))),
-                  Some(Position(202, 6, 3))
+                    Comment(" some name", Some(AstLocation(254, 7, 10)))),
+                  Some(AstLocation(202, 6, 3))
                 ),
                 InlineFragment(
-                  Some(NamedType("User", Some(Position(280, 10, 10)))),
+                  Some(NamedType("User", Some(AstLocation(280, 10, 10)))),
                   Vector.empty,
                   Vector(
                     Field(
@@ -151,37 +155,37 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                           Vector.empty,
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(297, 11, 11))
+                          Some(AstLocation(297, 11, 11))
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(291, 11, 5))
+                      Some(AstLocation(291, 11, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(273, 10, 3))
+                  Some(AstLocation(273, 10, 3))
                 ),
-                FragmentSpread("Foo", Vector.empty, Vector.empty, Some(Position(309, 14, 3)))),
+                FragmentSpread("Foo", Vector.empty, Vector.empty, Some(AstLocation(309, 14, 3)))),
               Vector(
-                Comment(" test query", Some(Position(0, 1, 1)))),
+                Comment(" test query", Some(AstLocation(0, 1, 1)))),
               Vector.empty,
-              Some(Position(13, 2, 1))
+              Some(AstLocation(13, 2, 1))
             ),
             FragmentDefinition(
               "Foo",
-              NamedType("User", Some(Position(335, 17, 17))),
+              NamedType("User", Some(AstLocation(335, 17, 17))),
               Vector(
                 Directive(
                   "foo",
                   Vector(
                     Argument(
                       "bar",
-                      BigIntValue(1, Vector.empty, Some(Position(350, 17, 32))),
+                      BigIntValue(1, Vector.empty, Some(AstLocation(350, 17, 32))),
                       Vector.empty,
-                      Some(Position(345, 17, 27))
+                      Some(AstLocation(345, 17, 27))
                     )),
                   Vector.empty,
-                  Some(Position(340, 17, 22))
+                  Some(AstLocation(340, 17, 22))
                 )),
               Vector(
                 Field(
@@ -192,20 +196,20 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(356, 18, 3))
+                  Some(AstLocation(356, 18, 3))
                 )),
               Vector.empty,
               Vector.empty,
               Vector(
-                Comment(" field in fragment!", Some(Position(360, 18, 7)))),
-              Some(Position(319, 17, 1))
+                Comment(" field in fragment!", Some(AstLocation(360, 18, 7)))),
+              Some(AstLocation(319, 17, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         )
 
-      QueryParser.parse(query) map (_.withoutSourceMapper) should be (Success(expectedAst))
+      parseQuery(query) should be (Success(expectedAst))
     }
 
     "parse kitchen sink" in {
@@ -220,17 +224,17 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
               Vector(
                 VariableDefinition(
                   "foo",
-                  NamedType("ComplexType", Some(Position(310, 8, 23))),
+                  NamedType("ComplexType", Some(AstLocation(310, 8, 23))),
                   None,
                   Vector.empty,
-                  Some(Position(304, 8, 17))
+                  Some(AstLocation(304, 8, 17))
                 ),
                 VariableDefinition(
                   "site",
-                  NamedType("Site", Some(Position(330, 8, 43))),
-                  Some(EnumValue("MOBILE", Vector.empty, Some(Position(337, 8, 50)))),
+                  NamedType("Site", Some(AstLocation(330, 8, 43))),
+                  Some(EnumValue("MOBILE", Vector.empty, Some(AstLocation(337, 8, 50)))),
                   Vector.empty,
-                  Some(Position(323, 8, 36))
+                  Some(AstLocation(323, 8, 36))
                 )),
               Vector.empty,
               Vector(
@@ -242,13 +246,13 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       "id",
                       ListValue(
                         Vector(
-                          BigIntValue(123, Vector.empty, Some(Position(373, 9, 27))),
-                          BigIntValue(456, Vector.empty, Some(Position(378, 9, 32)))),
+                          BigIntValue(123, Vector.empty, Some(AstLocation(373, 9, 27))),
+                          BigIntValue(456, Vector.empty, Some(AstLocation(378, 9, 32)))),
                         Vector.empty,
-                        Some(Position(372, 9, 26))
+                        Some(AstLocation(372, 9, 26))
                       ),
                       Vector.empty,
-                      Some(Position(368, 9, 22))
+                      Some(AstLocation(368, 9, 22))
                     )),
                   Vector.empty,
                   Vector(
@@ -260,16 +264,16 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(390, 10, 5))
+                      Some(AstLocation(390, 10, 5))
                     ),
                     InlineFragment(
-                      Some(NamedType("User", Some(Position(406, 11, 12)))),
+                      Some(NamedType("User", Some(AstLocation(406, 11, 12)))),
                       Vector(
                         Directive(
                           "defer",
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(411, 11, 17))
+                          Some(AstLocation(411, 11, 17))
                         )),
                       Vector(
                         Field(
@@ -286,7 +290,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(443, 13, 9))
+                              Some(AstLocation(443, 13, 9))
                             ),
                             Field(
                               Some("alias"),
@@ -294,15 +298,15 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                               Vector(
                                 Argument(
                                   "first",
-                                  BigIntValue(10, Vector.empty, Some(Position(476, 14, 29))),
+                                  BigIntValue(10, Vector.empty, Some(AstLocation(476, 14, 29))),
                                   Vector.empty,
-                                  Some(Position(470, 14, 23))
+                                  Some(AstLocation(470, 14, 23))
                                 ),
                                 Argument(
                                   "after",
-                                  VariableValue("foo", Vector.empty, Some(Position(486, 14, 39))),
+                                  VariableValue("foo", Vector.empty, Some(AstLocation(486, 14, 39))),
                                   Vector.empty,
-                                  Some(Position(480, 14, 33))
+                                  Some(AstLocation(480, 14, 33))
                                 )),
                               Vector(
                                 Directive(
@@ -310,12 +314,12 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                                   Vector(
                                     Argument(
                                       "if",
-                                      VariableValue("foo", Vector.empty, Some(Position(506, 14, 59))),
+                                      VariableValue("foo", Vector.empty, Some(AstLocation(506, 14, 59))),
                                       Vector.empty,
-                                      Some(Position(502, 14, 55))
+                                      Some(AstLocation(502, 14, 55))
                                     )),
                                   Vector.empty,
-                                  Some(Position(493, 14, 46))
+                                  Some(AstLocation(493, 14, 46))
                                 )),
                               Vector(
                                 Field(
@@ -326,34 +330,34 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                                   Vector.empty,
                                   Vector.empty,
                                   Vector.empty,
-                                  Some(Position(524, 15, 11))
+                                  Some(AstLocation(524, 15, 11))
                                 ),
-                                FragmentSpread("frag", Vector.empty, Vector.empty, Some(Position(538, 16, 11)))),
+                                FragmentSpread("frag", Vector.empty, Vector.empty, Some(AstLocation(538, 16, 11)))),
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(456, 14, 9))
+                              Some(AstLocation(456, 14, 9))
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(426, 12, 7))
+                          Some(AstLocation(426, 12, 7))
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(399, 11, 5))
+                      Some(AstLocation(399, 11, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(349, 9, 3))
+                  Some(AstLocation(349, 9, 3))
                 )),
               Vector(
-                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(Position(0, 1, 1))),
-                Comment(" All rights reserved.", Some(Position(37, 2, 1))),
-                Comment("", Some(Position(60, 3, 1))),
-                Comment(" This source code is licensed under the BSD-style license found in the", Some(Position(62, 4, 1))),
-                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(Position(134, 5, 1))),
-                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(Position(212, 6, 1)))),
+                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(AstLocation(0, 1, 1))),
+                Comment(" All rights reserved.", Some(AstLocation(37, 2, 1))),
+                Comment("", Some(AstLocation(60, 3, 1))),
+                Comment(" This source code is licensed under the BSD-style license found in the", Some(AstLocation(62, 4, 1))),
+                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(AstLocation(134, 5, 1))),
+                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(AstLocation(212, 6, 1)))),
               Vector.empty,
-              Some(Position(288, 8, 1))
+              Some(AstLocation(288, 8, 1))
             ),
             OperationDefinition(
               OperationType.Mutation,
@@ -367,16 +371,16 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "story",
-                      BigIntValue(123, Vector.empty, Some(Position(612, 24, 15))),
+                      BigIntValue(123, Vector.empty, Some(AstLocation(612, 24, 15))),
                       Vector.empty,
-                      Some(Position(605, 24, 8))
+                      Some(AstLocation(605, 24, 8))
                     )),
                   Vector(
                     Directive(
                       "defer",
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(617, 24, 20))
+                      Some(AstLocation(617, 24, 20))
                     )),
                   Vector(
                     Field(
@@ -393,19 +397,19 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                           Vector.empty,
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(644, 26, 7))
+                          Some(AstLocation(644, 26, 7))
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(630, 25, 5))
+                      Some(AstLocation(630, 25, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(600, 24, 3))
+                  Some(AstLocation(600, 24, 3))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(577, 23, 1))
+              Some(AstLocation(577, 23, 1))
             ),
             OperationDefinition(
               OperationType.Subscription,
@@ -413,10 +417,10 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
               Vector(
                 VariableDefinition(
                   "input",
-                  NamedType("StoryLikeSubscribeInput", Some(Position(703, 31, 44))),
+                  NamedType("StoryLikeSubscribeInput", Some(AstLocation(703, 31, 44))),
                   None,
                   Vector.empty,
-                  Some(Position(695, 31, 36))
+                  Some(AstLocation(695, 31, 36))
                 )),
               Vector.empty,
               Vector(
@@ -426,9 +430,9 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "input",
-                      VariableValue("input", Vector.empty, Some(Position(758, 32, 29))),
+                      VariableValue("input", Vector.empty, Some(AstLocation(758, 32, 29))),
                       Vector.empty,
-                      Some(Position(751, 32, 22))
+                      Some(AstLocation(751, 32, 22))
                     )),
                   Vector.empty,
                   Vector(
@@ -452,11 +456,11 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(803, 35, 9))
+                              Some(AstLocation(803, 35, 9))
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(786, 34, 7))
+                          Some(AstLocation(786, 34, 7))
                         ),
                         Field(
                           None,
@@ -472,27 +476,27 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                               Vector.empty,
                               Vector.empty,
                               Vector.empty,
-                              Some(Position(846, 38, 9))
+                              Some(AstLocation(846, 38, 9))
                             )),
                           Vector.empty,
                           Vector.empty,
-                          Some(Position(823, 37, 7))
+                          Some(AstLocation(823, 37, 7))
                         )),
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(772, 33, 5))
+                      Some(AstLocation(772, 33, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(732, 32, 3))
+                  Some(AstLocation(732, 32, 3))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(660, 31, 1))
+              Some(AstLocation(660, 31, 1))
             ),
             FragmentDefinition(
               "frag",
-              NamedType("Friend", Some(Position(889, 44, 18))),
+              NamedType("Friend", Some(AstLocation(889, 44, 18))),
               Vector.empty,
               Vector(
                 Field(
@@ -501,15 +505,15 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "size",
-                      VariableValue("size", Vector.empty, Some(Position(910, 45, 13))),
+                      VariableValue("size", Vector.empty, Some(AstLocation(910, 45, 13))),
                       Vector.empty,
-                      Some(Position(904, 45, 7))
+                      Some(AstLocation(904, 45, 7))
                     ),
                     Argument(
                       "bar",
-                      VariableValue("b", Vector.empty, Some(Position(922, 45, 25))),
+                      VariableValue("b", Vector.empty, Some(AstLocation(922, 45, 25))),
                       Vector.empty,
-                      Some(Position(917, 45, 20))
+                      Some(AstLocation(917, 45, 20))
                     ),
                     Argument(
                       "obj",
@@ -517,26 +521,26 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                         Vector(
                           ObjectField(
                             "key",
-                            StringValue("value", false, None, Vector.empty, Some(Position(937, 45, 40))),
+                            StringValue("value", false, None, Vector.empty, Some(AstLocation(937, 45, 40))),
                             Vector.empty,
-                            Some(Position(932, 45, 35))
+                            Some(AstLocation(932, 45, 35))
                           )),
                         Vector.empty,
-                        Some(Position(931, 45, 34))
+                        Some(AstLocation(931, 45, 34))
                       ),
                       Vector.empty,
-                      Some(Position(926, 45, 29))
+                      Some(AstLocation(926, 45, 29))
                     )),
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(900, 45, 3))
+                  Some(AstLocation(900, 45, 3))
                 )),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(872, 44, 1))
+              Some(AstLocation(872, 44, 1))
             ),
             OperationDefinition(
               OperationType.Query,
@@ -550,21 +554,21 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "truthy",
-                      BooleanValue(true, Vector.empty, Some(Position(970, 49, 19))),
+                      BooleanValue(true, Vector.empty, Some(AstLocation(970, 49, 19))),
                       Vector.empty,
-                      Some(Position(962, 49, 11))
+                      Some(AstLocation(962, 49, 11))
                     ),
                     Argument(
                       "falsey",
-                      BooleanValue(false, Vector.empty, Some(Position(984, 49, 33))),
+                      BooleanValue(false, Vector.empty, Some(AstLocation(984, 49, 33))),
                       Vector.empty,
-                      Some(Position(976, 49, 25))
+                      Some(AstLocation(976, 49, 25))
                     )),
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(954, 49, 3))
+                  Some(AstLocation(954, 49, 3))
                 ),
                 Field(
                   None,
@@ -574,7 +578,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(994, 50, 3))
+                  Some(AstLocation(994, 50, 3))
                 ),
                 InlineFragment(
                   None,
@@ -584,12 +588,12 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector(
                         Argument(
                           "unless",
-                          VariableValue("foo", Vector.empty, Some(Position(1021, 52, 21))),
+                          VariableValue("foo", Vector.empty, Some(AstLocation(1021, 52, 21))),
                           Vector.empty,
-                          Some(Position(1013, 52, 13))
+                          Some(AstLocation(1013, 52, 13))
                         )),
                       Vector.empty,
-                      Some(Position(1007, 52, 7))
+                      Some(AstLocation(1007, 52, 7))
                     )),
                   Vector(
                     Field(
@@ -600,11 +604,11 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(1033, 53, 5))
+                      Some(AstLocation(1033, 53, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1003, 52, 3))
+                  Some(AstLocation(1003, 52, 3))
                 ),
                 InlineFragment(
                   None,
@@ -618,22 +622,22 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector.empty,
-                      Some(Position(1052, 56, 5))
+                      Some(AstLocation(1052, 56, 5))
                     )),
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1042, 55, 3))
+                  Some(AstLocation(1042, 55, 3))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(950, 48, 1))
+              Some(AstLocation(950, 48, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         )
 
-      QueryParser.parse(query) map (_.withoutSourceMapper) should be (Success(expectedAst))
+      parseQuery(query) should be (Success(expectedAst))
     }
 
     "parse anonymous query" in {
@@ -653,17 +657,17 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             Vector.empty,
             Vector.empty,
             Vector(
-              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(31, 3, 13))),
-              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(35, 3, 17))),
-              Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(52, 4, 13)))),
+              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(31, 3, 13))),
+              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(35, 3, 17))),
+              Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(52, 4, 13)))),
             Vector.empty,
             Vector.empty,
-            Some(Position(11, 2, 11)))),
+            Some(AstLocation(11, 2, 11)))),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None)
 
-      QueryParser.parse(stripCarriageReturns(query)) map (_.copy(sourceMapper = None)) should be (Success(expectedAst))
+      parseQuery(stripCarriageReturns(query)) should be (Success(expectedAst))
     }
 
     "parse inline fragments without type condition" in {
@@ -684,28 +688,28 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
         Document(Vector(
           OperationDefinition(OperationType.Query, None, Vector.empty, Vector.empty, Vector(
             InlineFragment(None, Vector.empty, Vector(
-              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(51, 4, 15))),
-              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(55, 4, 19)))),
+              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(51, 4, 15))),
+              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(55, 4, 19)))),
               Vector.empty,
               Vector.empty,
-              Some(Position(31, 3, 13))),
+              Some(AstLocation(31, 3, 13))),
             InlineFragment(None,
               Vector(Directive("include", Vector(
-                Argument("if", BooleanValue(true, Vector.empty, Some(Position(103, 7, 30))),
-                  Vector.empty, Some(Position(99, 7, 26)))),
+                Argument("if", BooleanValue(true, Vector.empty, Some(AstLocation(103, 7, 30))),
+                  Vector.empty, Some(AstLocation(99, 7, 26)))),
                 Vector.empty,
-                Some(Position(90, 7, 17)))),
-              Vector(Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(125, 8, 15)))),
+                Some(AstLocation(90, 7, 17)))),
+              Vector(Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(125, 8, 15)))),
               Vector.empty,
               Vector.empty,
-              Some(Position(86, 7, 13)))),
+              Some(AstLocation(86, 7, 13)))),
             Vector.empty,
             Vector.empty,
-            Some(Position(11, 2, 11)))),
+            Some(AstLocation(11, 2, 11)))),
           Vector.empty,
-          Some(Position(11, 2, 11)), None)
+          Some(AstLocation(11, 2, 11)), None)
 
-      QueryParser.parse(stripCarriageReturns(query)) map (_.copy(sourceMapper = None)) should be (Success(expectedAst))
+      parseQuery(stripCarriageReturns(query)) should be (Success(expectedAst))
     }
 
     "parse anonymous mutation" in {
@@ -725,21 +729,21 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             Vector.empty,
             Vector.empty,
             Vector(
-              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(34, 3, 13))),
-              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(38, 3, 17))),
-              Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(Position(55, 4, 13)))),
+              Field(None, "foo", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(34, 3, 13))),
+              Field(None, "bar", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(38, 3, 17))),
+              Field(None, "baz", Vector.empty, Vector.empty, Vector.empty, Vector.empty, Vector.empty, Some(AstLocation(55, 4, 13)))),
             Vector.empty,
             Vector.empty,
-            Some(Position(11, 2, 11)))),
+            Some(AstLocation(11, 2, 11)))),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None)
 
-      QueryParser.parse(stripCarriageReturns(query)) map (_.copy(sourceMapper = None)) should be (Success(expectedAst))
+      parseQuery(stripCarriageReturns(query)) should be (Success(expectedAst))
     }
 
     "provide useful error message (fragment `on`)" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         """
           { ...MissingOn }
           fragment MissingOn Type
@@ -752,7 +756,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "provide useful error message (braces)" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "{ field: {} }")
 
       error.formattedError should equal (
@@ -762,7 +766,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "provide useful error message (operation def)" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "notanoperation Foo { field }")
 
       error.formattedError should equal (
@@ -772,7 +776,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "provide useful error message (ellipsis)" in {
-      val Failure(error: SyntaxError) = QueryParser.parse("...")
+      val Failure(error: SyntaxError) = parseQuery("...")
 
       error.formattedError should equal (
         """Invalid input '.', expected OperationDefinition, FragmentDefinition or TypeSystemDefinition (line 1, column 1):
@@ -781,11 +785,11 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "parses constant default values" in {
-      QueryParser.parse("{ field(complex: { a: { b: [ $var ] } }) }").isSuccess should be (true)
+      parseQuery("{ field(complex: { a: { b: [ $var ] } }) }").isSuccess should be (true)
     }
 
     "parses variable inline values" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = { a: { b: [ $var ] } }) { field }")
 
       error.getMessage should equal (
@@ -795,7 +799,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `1.`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = 1.) { field }")
 
       error.formattedError should equal (
@@ -805,7 +809,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `.123`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = .123) { field }")
 
       error.formattedError should equal (
@@ -815,7 +819,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `1.0e`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = 1.0e) { field }")
 
       error.formattedError should equal (
@@ -825,7 +829,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `1.A`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = 1.A) { field }")
 
       error.formattedError should equal (
@@ -835,7 +839,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `+1`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = +1) { field }")
 
       error.formattedError should equal (
@@ -845,7 +849,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "produce parse error for `1.0eA`" in {
-      val Failure(error: SyntaxError) = QueryParser.parse(
+      val Failure(error: SyntaxError) = parseQuery(
         "query Foo($x: Complex = 1.0eA) { field }")
 
       error.formattedError should equal (
@@ -855,33 +859,33 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
     }
 
     "disallows uncommon control characters" in {
-      QueryParser.parse("{ field\u0007 }").isSuccess should be (false)
-      QueryParser.parse("{ field } \u0007").isSuccess should be (false)
+      parseQuery("{ field\u0007 }").isSuccess should be (false)
+      parseQuery("{ field } \u0007").isSuccess should be (false)
     }
 
     "accepts BOM header" in {
-      QueryParser.parse("\uFEFF{ field }").isSuccess should be (true)
+      parseQuery("\uFEFF{ field }").isSuccess should be (true)
     }
 
     "accepts new lines header" in {
-      QueryParser.parse("{ field \n another }").isSuccess should be (true)
-      QueryParser.parse("{ field \r\n another }").isSuccess should be (true)
+      parseQuery("{ field \n another }").isSuccess should be (true)
+      parseQuery("{ field \r\n another }").isSuccess should be (true)
     }
 
     "accepts escape sequences" in {
-      QueryParser.parse("{ field(id: \"\\u000A\") }").isSuccess should be (true)
-      QueryParser.parse("{ field(id: \"\\uXXXX\") }").isSuccess should be (false)
-      QueryParser.parse("{ field(id: \"\\x\") }").isSuccess should be (false)
+      parseQuery("{ field(id: \"\\u000A\") }").isSuccess should be (true)
+      parseQuery("{ field(id: \"\\uXXXX\") }").isSuccess should be (false)
+      parseQuery("{ field(id: \"\\x\") }").isSuccess should be (false)
     }
 
     "allow `null` to be the prefix of an enum value" in {
-      QueryParser.parse("query Foo($x: Complex = null111) { field }").isSuccess should be (true)
-      QueryParser.parse("query Foo($x: Complex = null_foo) { field }").isSuccess should be (true)
-      QueryParser.parse("query Foo($x: Complex = nullFoo) { field }").isSuccess should be (true)
+      parseQuery("query Foo($x: Complex = null111) { field }").isSuccess should be (true)
+      parseQuery("query Foo($x: Complex = null_foo) { field }").isSuccess should be (true)
+      parseQuery("query Foo($x: Complex = nullFoo) { field }").isSuccess should be (true)
     }
 
     "parse leading vertical bar in union types" in {
-      val Success(ast) = QueryParser.parse("union Hello = | Wo | Rld")
+      val Success(ast) = parseQuery("union Hello = | Wo | Rld")
 
       ast.withoutSourceMapper should be (
         Document(
@@ -889,28 +893,28 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             UnionTypeDefinition(
               "Hello",
               Vector(
-                NamedType("Wo", Some(Position(16, 1, 17))),
-                NamedType("Rld", Some(Position(21, 1, 22)))),
+                NamedType("Wo", Some(AstLocation(16, 1, 17))),
+                NamedType("Rld", Some(AstLocation(21, 1, 22)))),
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None))
     }
 
     "not parse invalid usage of vertical bar on union types" in {
-      QueryParser.parse("union Hello = |").isSuccess should be (false)
-      QueryParser.parse("union Hello = Wo | Rld |").isSuccess should be (false)
-      QueryParser.parse("union Hello = || Wo | Rld").isSuccess should be (false)
-      QueryParser.parse("union Hello = Wo || Rld").isSuccess should be (false)
-      QueryParser.parse("union Hello = | Wo | Rld ||").isSuccess should be (false)
+      parseQuery("union Hello = |").isSuccess should be (false)
+      parseQuery("union Hello = Wo | Rld |").isSuccess should be (false)
+      parseQuery("union Hello = || Wo | Rld").isSuccess should be (false)
+      parseQuery("union Hello = Wo || Rld").isSuccess should be (false)
+      parseQuery("union Hello = | Wo | Rld ||").isSuccess should be (false)
     }
 
     "parse leading vertical bar in directive definitions" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
         directive @include2(if: Boolean!) on
           | FIELD
@@ -924,17 +928,17 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             DirectiveDefinition(
               "include2",
               Vector(
-                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(Position(33, 2, 33))), Some(Position(33, 2, 33))), None, Vector.empty, None, Vector.empty, Some(Position(29, 2, 29)))),
+                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(AstLocation(33, 2, 33))), Some(AstLocation(33, 2, 33))), None, Vector.empty, None, Vector.empty, Some(AstLocation(29, 2, 29)))),
               Vector(
-                DirectiveLocation("FIELD", Vector.empty, Some(Position(58, 3, 13))),
-                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(Position(76, 4, 13))),
-                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(Position(104, 5, 13)))),
+                DirectiveLocation("FIELD", Vector.empty, Some(AstLocation(58, 3, 13))),
+                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(AstLocation(76, 4, 13))),
+                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(AstLocation(104, 5, 13)))),
               None,
               Vector.empty,
-              Some(Position(9, 2, 9))
+              Some(AstLocation(9, 2, 9))
             )),
           Vector.empty,
-          Some(Position(9, 2, 9)),
+          Some(AstLocation(9, 2, 9)),
           None))
     }
 
@@ -957,8 +961,8 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
       )
 
       expectedTable foreach { expected ⇒
-        findAst[BigIntValue](QueryParser.parse(s"query Foo($$x: Complex = ${expected._1}) { field }").get) should be (
-          Some(BigIntValue(expected._2, Vector.empty, Some(Position(24, 1, 25)))))
+        findAst[BigIntValue](parseQuery(s"query Foo($$x: Complex = ${expected._1}) { field }").get) should be (
+          Some(BigIntValue(expected._2, Vector.empty, Some(AstLocation(24, 1, 25)))))
       }
     }
 
@@ -977,8 +981,8 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
 
       expectedTable foreach { expected ⇒
         withClue(s"Parsing ${expected._1}.") {
-          findAst[BigDecimalValue](QueryParser.parse(s"query Foo($$x: Complex = ${expected._1}) { field }").get) should be(
-            Some(BigDecimalValue(expected._2, Vector.empty, Some(Position(24, 1, 25)))))
+          findAst[BigDecimalValue](parseQuery(s"query Foo($$x: Complex = ${expected._1}) { field }").get) should be(
+            Some(BigDecimalValue(expected._2, Vector.empty, Some(AstLocation(24, 1, 25)))))
         }
       }
     }
@@ -995,38 +999,38 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
         """
 
       QueryParser.parseInput(stripCarriageReturns(stringValue)) should be (
-        Success(StringValue("hello,\n  world", true, Some("\n            hello,\n              world\n          "), Vector.empty, Some(Position(11, 2, 11)))))
+        Success(StringValue("hello,\n  world", true, Some("\n            hello,\n              world\n          "), Vector.empty, Some(AstLocation(11, 2, 11)))))
     }
 
     "parse input values independently" in {
       val expectedTable = Vector(
-        "null" → NullValue(Vector.empty, Some(Position(0, 1, 1))),
-        "1.234" → BigDecimalValue(BigDecimal("1.234"), Vector.empty, Some(Position(0, 1, 1))),
-        "HELLO_WORLD" → EnumValue("HELLO_WORLD", Vector.empty, Some(Position(0, 1, 1))),
+        "null" → NullValue(Vector.empty, Some(AstLocation(0, 1, 1))),
+        "1.234" → BigDecimalValue(BigDecimal("1.234"), Vector.empty, Some(AstLocation(0, 1, 1))),
+        "HELLO_WORLD" → EnumValue("HELLO_WORLD", Vector.empty, Some(AstLocation(0, 1, 1))),
         "[1, 2 \"test\"]" → ListValue(
           Vector(
-            BigIntValue(1, Vector.empty, Some(Position(1, 1, 2))),
-            BigIntValue(2, Vector.empty, Some(Position(4, 1, 5))),
-            StringValue("test", false, None, Vector.empty, Some(Position(6, 1, 7)))),
+            BigIntValue(1, Vector.empty, Some(AstLocation(1, 1, 2))),
+            BigIntValue(2, Vector.empty, Some(AstLocation(4, 1, 5))),
+            StringValue("test", false, None, Vector.empty, Some(AstLocation(6, 1, 7)))),
           Vector.empty,
-          Some(Position(0, 1, 1))),
+          Some(AstLocation(0, 1, 1))),
         "{a: 1, b: \"foo\" c: {nest: true, oops: null, e: FOO_BAR}}" →
           ObjectValue(
             Vector(
-              ObjectField("a", BigIntValue(1, Vector.empty, Some(Position(4, 1, 5))), Vector.empty, Some(Position(1, 1, 2))),
-              ObjectField("b", StringValue("foo", false, None, Vector.empty, Some(Position(10, 1, 11))), Vector.empty, Some(Position(7, 1, 8))),
+              ObjectField("a", BigIntValue(1, Vector.empty, Some(AstLocation(4, 1, 5))), Vector.empty, Some(AstLocation(1, 1, 2))),
+              ObjectField("b", StringValue("foo", false, None, Vector.empty, Some(AstLocation(10, 1, 11))), Vector.empty, Some(AstLocation(7, 1, 8))),
               ObjectField("c",
                 ObjectValue(
                   Vector(
-                    ObjectField("nest", BooleanValue(true, Vector.empty, Some(Position(26, 1, 27))), Vector.empty, Some(Position(20, 1, 21))),
-                    ObjectField("oops", NullValue(Vector.empty, Some(Position(38, 1, 39))), Vector.empty, Some(Position(32, 1, 33))),
-                    ObjectField("e", EnumValue("FOO_BAR", Vector.empty, Some(Position(47, 1, 48))), Vector.empty, Some(Position(44, 1, 45)))),
+                    ObjectField("nest", BooleanValue(true, Vector.empty, Some(AstLocation(26, 1, 27))), Vector.empty, Some(AstLocation(20, 1, 21))),
+                    ObjectField("oops", NullValue(Vector.empty, Some(AstLocation(38, 1, 39))), Vector.empty, Some(AstLocation(32, 1, 33))),
+                    ObjectField("e", EnumValue("FOO_BAR", Vector.empty, Some(AstLocation(47, 1, 48))), Vector.empty, Some(AstLocation(44, 1, 45)))),
                   Vector.empty,
-                  Some(Position(19, 1, 20))),
+                  Some(AstLocation(19, 1, 20))),
                 Vector.empty,
-                Some(Position(16, 1, 17)))),
+                Some(AstLocation(16, 1, 17)))),
             Vector.empty,
-            Some(Position(0, 1, 1))),
+            Some(AstLocation(0, 1, 1))),
         """
          {
            a: 1
@@ -1037,12 +1041,12 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
         """ →
           ObjectValue(
             Vector(
-              ObjectField("a", BigIntValue(1, Vector.empty, Some(Position(26, 3, 15))), Vector.empty, Some(Position(23, 3, 12))),
-              ObjectField("b", StringValue("foo", false, None, Vector.empty, Some(Position(80, 6, 15))),
-                Vector(Comment(" This is a test comment!", Some(Position(40, 5, 12)))),
-                Some(Position(77, 6, 12)))),
+              ObjectField("a", BigIntValue(1, Vector.empty, Some(AstLocation(26, 3, 15))), Vector.empty, Some(AstLocation(23, 3, 12))),
+              ObjectField("b", StringValue("foo", false, None, Vector.empty, Some(AstLocation(80, 6, 15))),
+                Vector(Comment(" This is a test comment!", Some(AstLocation(40, 5, 12)))),
+                Some(AstLocation(77, 6, 12)))),
               Vector.empty,
-            Some(Position(10, 2, 10)))
+            Some(AstLocation(10, 2, 10)))
 
       )
 
@@ -1065,77 +1069,77 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
               Vector(
                 VariableDefinition(
                   "foo",
-                  NamedType("ComplexType", Some(Position(434, 23, 1))),
+                  NamedType("ComplexType", Some(AstLocation(434, 23, 1))),
                   None,
                   Vector(
-                    Comment(" comment 5", Some(Position(354, 15, 1))),
-                    Comment(" comment 6", Some(Position(366, 16, 1)))),
-                  Some(Position(378, 17, 1))
+                    Comment(" comment 5", Some(AstLocation(354, 15, 1))),
+                    Comment(" comment 6", Some(AstLocation(366, 16, 1)))),
+                  Some(AstLocation(378, 17, 1))
                 ),
                 VariableDefinition(
                   "site",
-                  NamedType("Site", Some(Position(565, 36, 1))),
-                  Some(EnumValue("MOBILE", Vector(Comment(" comment 16.5", Some(Position(602, 40, 1))), Comment(" comment 16.6", Some(Position(617, 41, 1)))), Some(Position(632, 42, 1)))),
+                  NamedType("Site", Some(AstLocation(565, 36, 1))),
+                  Some(EnumValue("MOBILE", Vector(Comment(" comment 16.5", Some(AstLocation(602, 40, 1))), Comment(" comment 16.6", Some(AstLocation(617, 41, 1)))), Some(AstLocation(632, 42, 1)))),
                   Vector(
-                    Comment(" comment 11", Some(Position(446, 24, 1))),
-                    Comment(" comment 12", Some(Position(459, 25, 1))),
-                    Comment(" comment 13", Some(Position(475, 28, 1))),
-                    Comment(" comment 14", Some(Position(488, 29, 1)))),
-                  Some(Position(501, 30, 1))
+                    Comment(" comment 11", Some(AstLocation(446, 24, 1))),
+                    Comment(" comment 12", Some(AstLocation(459, 25, 1))),
+                    Comment(" comment 13", Some(AstLocation(475, 28, 1))),
+                    Comment(" comment 14", Some(AstLocation(488, 29, 1)))),
+                  Some(AstLocation(501, 30, 1))
                 ),
                 VariableDefinition(
                   "foo",
-                  NamedType("ComplexType", Some(Position(703, 48, 7))),
+                  NamedType("ComplexType", Some(AstLocation(703, 48, 7))),
                   Some(ObjectValue(
                     Vector(
                       ObjectField(
                         "field1",
-                        StringValue("val", false, None, Vector(Comment(" comment 18.11", Some(Position(849, 61, 1))), Comment(" comment 18.12", Some(Position(865, 62, 1)))), Some(Position(881, 63, 1))),
+                        StringValue("val", false, None, Vector(Comment(" comment 18.11", Some(AstLocation(849, 61, 1))), Comment(" comment 18.12", Some(AstLocation(865, 62, 1)))), Some(AstLocation(881, 63, 1))),
                         Vector(
-                          Comment(" comment 18.7", Some(Position(779, 55, 1))),
-                          Comment(" comment 18.8", Some(Position(794, 56, 1)))),
-                        Some(Position(809, 57, 1))
+                          Comment(" comment 18.7", Some(AstLocation(779, 55, 1))),
+                          Comment(" comment 18.8", Some(AstLocation(794, 56, 1)))),
+                        Some(AstLocation(809, 57, 1))
                       ),
                       ObjectField(
                         "list",
                         ListValue(
                           Vector(
-                            BigIntValue(1, Vector(Comment(" comment 18.21", Some(Position(1026, 76, 1))), Comment(" comment 18.22", Some(Position(1042, 77, 1)))), Some(Position(1058, 78, 1))),
-                            BigIntValue(2, Vector(Comment(" comment 18.23", Some(Position(1061, 79, 1))), Comment(" comment 18.24", Some(Position(1077, 80, 1)))), Some(Position(1093, 81, 1))),
-                            BigIntValue(3, Vector(Comment(" comment 18.25", Some(Position(1096, 82, 1))), Comment(" comment 18.26", Some(Position(1112, 83, 1)))), Some(Position(1128, 84, 1)))),
+                            BigIntValue(1, Vector(Comment(" comment 18.21", Some(AstLocation(1026, 76, 1))), Comment(" comment 18.22", Some(AstLocation(1042, 77, 1)))), Some(AstLocation(1058, 78, 1))),
+                            BigIntValue(2, Vector(Comment(" comment 18.23", Some(AstLocation(1061, 79, 1))), Comment(" comment 18.24", Some(AstLocation(1077, 80, 1)))), Some(AstLocation(1093, 81, 1))),
+                            BigIntValue(3, Vector(Comment(" comment 18.25", Some(AstLocation(1096, 82, 1))), Comment(" comment 18.26", Some(AstLocation(1112, 83, 1)))), Some(AstLocation(1128, 84, 1)))),
                           Vector(
-                            Comment(" comment 18.19", Some(Position(992, 73, 1))),
-                            Comment(" comment 18.20", Some(Position(1008, 74, 1)))),
-                          Some(Position(1024, 75, 1))
+                            Comment(" comment 18.19", Some(AstLocation(992, 73, 1))),
+                            Comment(" comment 18.20", Some(AstLocation(1008, 74, 1)))),
+                          Some(AstLocation(1024, 75, 1))
                         ),
                         Vector(
-                          Comment(" comment 18.13", Some(Position(887, 64, 1))),
-                          Comment(" comment 18.14", Some(Position(903, 65, 1))),
-                          Comment(" comment 18.15", Some(Position(921, 67, 1))),
-                          Comment(" comment 18.16", Some(Position(937, 68, 1)))),
-                        Some(Position(953, 69, 1))
+                          Comment(" comment 18.13", Some(AstLocation(887, 64, 1))),
+                          Comment(" comment 18.14", Some(AstLocation(903, 65, 1))),
+                          Comment(" comment 18.15", Some(AstLocation(921, 67, 1))),
+                          Comment(" comment 18.16", Some(AstLocation(937, 68, 1)))),
+                        Some(AstLocation(953, 69, 1))
                       ),
                       ObjectField(
                         "field2",
-                        BooleanValue(true, Vector(Comment(" comment 18.35", Some(Position(1271, 97, 1))), Comment(" comment 18.36", Some(Position(1287, 98, 1)))), Some(Position(1303, 99, 1))),
+                        BooleanValue(true, Vector(Comment(" comment 18.35", Some(AstLocation(1271, 97, 1))), Comment(" comment 18.36", Some(AstLocation(1287, 98, 1)))), Some(AstLocation(1303, 99, 1))),
                         Vector(
-                          Comment(" comment 18.29", Some(Position(1164, 88, 1))),
-                          Comment(" comment 18.30", Some(Position(1180, 89, 1))),
-                          Comment(" comment 18.31", Some(Position(1198, 91, 1))),
-                          Comment(" comment 18.32", Some(Position(1214, 92, 1)))),
-                        Some(Position(1230, 93, 1))
+                          Comment(" comment 18.29", Some(AstLocation(1164, 88, 1))),
+                          Comment(" comment 18.30", Some(AstLocation(1180, 89, 1))),
+                          Comment(" comment 18.31", Some(AstLocation(1198, 91, 1))),
+                          Comment(" comment 18.32", Some(AstLocation(1214, 92, 1)))),
+                        Some(AstLocation(1230, 93, 1))
                       )),
                     Vector(
-                      Comment(" comment 18.5", Some(Position(747, 52, 1))),
-                      Comment(" comment 18.6", Some(Position(762, 53, 1)))),
-                    Some(Position(777, 54, 1))
+                      Comment(" comment 18.5", Some(AstLocation(747, 52, 1))),
+                      Comment(" comment 18.6", Some(AstLocation(762, 53, 1)))),
+                    Some(AstLocation(777, 54, 1))
                   )),
                   Vector(
-                    Comment(" comment 17", Some(Position(639, 43, 1))),
-                    Comment(" comment 18", Some(Position(652, 44, 1))),
-                    Comment(" comment 18.1", Some(Position(667, 46, 1))),
-                    Comment(" comment 18.2", Some(Position(682, 47, 1)))),
-                  Some(Position(697, 48, 1))
+                    Comment(" comment 17", Some(AstLocation(639, 43, 1))),
+                    Comment(" comment 18", Some(AstLocation(652, 44, 1))),
+                    Comment(" comment 18.1", Some(AstLocation(667, 46, 1))),
+                    Comment(" comment 18.2", Some(AstLocation(682, 47, 1)))),
+                  Some(AstLocation(697, 48, 1))
                 )),
               Vector.empty,
               Vector(
@@ -1147,17 +1151,17 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       "id",
                       ListValue(
                         Vector(
-                          BigIntValue(123, Vector(Comment(" comment 35", Some(Position(1660, 130, 3))), Comment(" comment 36", Some(Position(1675, 131, 3)))), Some(Position(1690, 132, 3))),
-                          BigIntValue(456, Vector(Comment(" comment 37", Some(Position(1696, 133, 3))), Comment(" comment 38", Some(Position(1711, 134, 3)))), Some(Position(1726, 135, 3)))),
+                          BigIntValue(123, Vector(Comment(" comment 35", Some(AstLocation(1660, 130, 3))), Comment(" comment 36", Some(AstLocation(1675, 131, 3)))), Some(AstLocation(1690, 132, 3))),
+                          BigIntValue(456, Vector(Comment(" comment 37", Some(AstLocation(1696, 133, 3))), Comment(" comment 38", Some(AstLocation(1711, 134, 3)))), Some(AstLocation(1726, 135, 3)))),
                         Vector(
-                          Comment(" comment 33", Some(Position(1626, 127, 3))),
-                          Comment(" comment 34", Some(Position(1641, 128, 3)))),
-                        Some(Position(1656, 129, 3))
+                          Comment(" comment 33", Some(AstLocation(1626, 127, 3))),
+                          Comment(" comment 34", Some(AstLocation(1641, 128, 3)))),
+                        Some(AstLocation(1656, 129, 3))
                       ),
                       Vector(
-                        Comment(" comment 29", Some(Position(1557, 121, 3))),
-                        Comment(" comment 30", Some(Position(1572, 122, 3)))),
-                      Some(Position(1587, 123, 3))
+                        Comment(" comment 29", Some(AstLocation(1557, 121, 3))),
+                        Comment(" comment 30", Some(AstLocation(1572, 122, 3)))),
+                      Some(AstLocation(1587, 123, 3))
                     )),
                   Vector.empty,
                   Vector(
@@ -1168,21 +1172,21 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector(
-                        Comment(" comment 44", Some(Position(1837, 145, 4))),
-                        Comment(" comment 45", Some(Position(1853, 146, 4)))),
+                        Comment(" comment 44", Some(AstLocation(1837, 145, 4))),
+                        Comment(" comment 45", Some(AstLocation(1853, 146, 4)))),
                       Vector.empty,
-                      Some(Position(1870, 147, 5))
+                      Some(AstLocation(1870, 147, 5))
                     ),
                     InlineFragment(
-                      Some(NamedType("User", Some(Position(1996, 156, 5)))),
+                      Some(NamedType("User", Some(AstLocation(1996, 156, 5)))),
                       Vector(
                         Directive(
                           "defer",
                           Vector.empty,
                           Vector(
-                            Comment(" comment 52", Some(Position(2005, 157, 5))),
-                            Comment(" comment 53", Some(Position(2022, 158, 5)))),
-                          Some(Position(2039, 159, 5))
+                            Comment(" comment 52", Some(AstLocation(2005, 157, 5))),
+                            Comment(" comment 53", Some(AstLocation(2022, 158, 5)))),
+                          Some(AstLocation(2039, 159, 5))
                         )),
                       Vector(
                         Field(
@@ -1197,19 +1201,19 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                               Vector(
                                 Argument(
                                   "first",
-                                  BigIntValue(10, Vector(Comment(" comment 70", Some(Position(2474, 185, 9))), Comment(" comment 71", Some(Position(2495, 186, 9)))), Some(Position(2516, 187, 9))),
+                                  BigIntValue(10, Vector(Comment(" comment 70", Some(AstLocation(2474, 185, 9))), Comment(" comment 71", Some(AstLocation(2495, 186, 9)))), Some(AstLocation(2516, 187, 9))),
                                   Vector(
-                                    Comment(" comment 66", Some(Position(2366, 179, 9))),
-                                    Comment(" comment 67", Some(Position(2387, 180, 9)))),
-                                  Some(Position(2408, 181, 9))
+                                    Comment(" comment 66", Some(AstLocation(2366, 179, 9))),
+                                    Comment(" comment 67", Some(AstLocation(2387, 180, 9)))),
+                                  Some(AstLocation(2408, 181, 9))
                                 ),
                                 Argument(
                                   "after",
-                                  VariableValue("foo", Vector(Comment(" comment 76", Some(Position(2636, 194, 9))), Comment(" comment 77", Some(Position(2657, 195, 9)))), Some(Position(2678, 196, 9))),
+                                  VariableValue("foo", Vector(Comment(" comment 76", Some(AstLocation(2636, 194, 9))), Comment(" comment 77", Some(AstLocation(2657, 195, 9)))), Some(AstLocation(2678, 196, 9))),
                                   Vector(
-                                    Comment(" comment 72", Some(Position(2528, 188, 9))),
-                                    Comment(" comment 73", Some(Position(2549, 189, 9)))),
-                                  Some(Position(2570, 190, 9))
+                                    Comment(" comment 72", Some(AstLocation(2528, 188, 9))),
+                                    Comment(" comment 73", Some(AstLocation(2549, 189, 9)))),
+                                  Some(AstLocation(2570, 190, 9))
                                 )),
                               Vector(
                                 Directive(
@@ -1217,16 +1221,16 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                                   Vector(
                                     Argument(
                                       "if",
-                                      VariableValue("foo", Vector(Comment(" comment 88", Some(Position(2961, 212, 10))), Comment(" comment 89", Some(Position(2983, 213, 10)))), Some(Position(3005, 214, 10))),
+                                      VariableValue("foo", Vector(Comment(" comment 88", Some(AstLocation(2961, 212, 10))), Comment(" comment 89", Some(AstLocation(2983, 213, 10)))), Some(AstLocation(3005, 214, 10))),
                                       Vector(
-                                        Comment(" comment 84", Some(Position(2855, 206, 9))),
-                                        Comment(" comment 85", Some(Position(2876, 207, 9)))),
-                                      Some(Position(2897, 208, 9))
+                                        Comment(" comment 84", Some(AstLocation(2855, 206, 9))),
+                                        Comment(" comment 85", Some(AstLocation(2876, 207, 9)))),
+                                      Some(AstLocation(2897, 208, 9))
                                     )),
                                   Vector(
-                                    Comment(" comment 80", Some(Position(2744, 200, 9))),
-                                    Comment(" comment 81", Some(Position(2765, 201, 9)))),
-                                  Some(Position(2786, 202, 9))
+                                    Comment(" comment 80", Some(AstLocation(2744, 200, 9))),
+                                    Comment(" comment 81", Some(AstLocation(2765, 201, 9)))),
+                                  Some(AstLocation(2786, 202, 9))
                                 )),
                               Vector(
                                 Field(
@@ -1236,53 +1240,53 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                                   Vector.empty,
                                   Vector.empty,
                                   Vector(
-                                    Comment(" comment 94", Some(Position(3130, 221, 11))),
-                                    Comment(" comment 95", Some(Position(3153, 222, 11)))),
+                                    Comment(" comment 94", Some(AstLocation(3130, 221, 11))),
+                                    Comment(" comment 95", Some(AstLocation(3153, 222, 11)))),
                                   Vector.empty,
-                                  Some(Position(3176, 223, 11))
+                                  Some(AstLocation(3176, 223, 11))
                                 ),
-                                FragmentSpread("frag", Vector.empty, Vector(Comment(" comment 96", Some(Position(3190, 224, 11))), Comment(" comment 97", Some(Position(3213, 225, 11)))), Some(Position(3237, 227, 11)))),
+                                FragmentSpread("frag", Vector.empty, Vector(Comment(" comment 96", Some(AstLocation(3190, 224, 11))), Comment(" comment 97", Some(AstLocation(3213, 225, 11)))), Some(AstLocation(3237, 227, 11)))),
                               Vector(
-                                Comment(" comment 58", Some(Position(2151, 167, 7))),
-                                Comment(" comment 59", Some(Position(2170, 168, 7)))),
+                                Comment(" comment 58", Some(AstLocation(2151, 167, 7))),
+                                Comment(" comment 59", Some(AstLocation(2170, 168, 7)))),
                               Vector(
-                                Comment(" comment 100", Some(Position(3312, 231, 11))),
-                                Comment(" comment 101", Some(Position(3336, 232, 11)))),
-                              Some(Position(2191, 169, 9))
+                                Comment(" comment 100", Some(AstLocation(3312, 231, 11))),
+                                Comment(" comment 101", Some(AstLocation(3336, 232, 11)))),
+                              Some(AstLocation(2191, 169, 9))
                             )),
                           Vector.empty,
                           Vector(
-                            Comment(" comment 102", Some(Position(3368, 234, 9))),
-                            Comment(" comment 103", Some(Position(3390, 235, 9)))),
-                          Some(Position(2092, 163, 7))
+                            Comment(" comment 102", Some(AstLocation(3368, 234, 9))),
+                            Comment(" comment 103", Some(AstLocation(3390, 235, 9)))),
+                          Some(AstLocation(2092, 163, 7))
                         )),
                       Vector(
-                        Comment(" comment 46", Some(Position(1879, 148, 5))),
-                        Comment(" comment 47", Some(Position(1896, 149, 5)))),
+                        Comment(" comment 46", Some(AstLocation(1879, 148, 5))),
+                        Comment(" comment 47", Some(AstLocation(1896, 149, 5)))),
                       Vector(
-                        Comment(" comment 104", Some(Position(3418, 237, 7))),
-                        Comment(" comment 105", Some(Position(3438, 238, 7)))),
-                      Some(Position(1913, 150, 5))
+                        Comment(" comment 104", Some(AstLocation(3418, 237, 7))),
+                        Comment(" comment 105", Some(AstLocation(3438, 238, 7)))),
+                      Some(AstLocation(1913, 150, 5))
                     )),
                   Vector(
-                    Comment(" comment 21", Some(Position(1408, 109, 2))),
-                    Comment(" comment 22", Some(Position(1422, 110, 2)))),
+                    Comment(" comment 21", Some(AstLocation(1408, 109, 2))),
+                    Comment(" comment 22", Some(AstLocation(1422, 110, 2)))),
                   Vector(
-                    Comment(" comment 106", Some(Position(3462, 240, 5))),
-                    Comment(" comment 107", Some(Position(3480, 241, 5)))),
-                  Some(Position(1437, 111, 3))
+                    Comment(" comment 106", Some(AstLocation(3462, 240, 5))),
+                    Comment(" comment 107", Some(AstLocation(3480, 241, 5)))),
+                  Some(AstLocation(1437, 111, 3))
                 )),
               Vector(
-                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(Position(0, 1, 1))),
-                Comment(" All rights reserved.", Some(Position(37, 2, 1))),
-                Comment("", Some(Position(60, 3, 1))),
-                Comment(" This source code is licensed under the BSD-style license found in the", Some(Position(62, 4, 1))),
-                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(Position(134, 5, 1))),
-                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(Position(212, 6, 1)))),
+                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(AstLocation(0, 1, 1))),
+                Comment(" All rights reserved.", Some(AstLocation(37, 2, 1))),
+                Comment("", Some(AstLocation(60, 3, 1))),
+                Comment(" This source code is licensed under the BSD-style license found in the", Some(AstLocation(62, 4, 1))),
+                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(AstLocation(134, 5, 1))),
+                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(AstLocation(212, 6, 1)))),
               Vector(
-                Comment(" comment 108", Some(Position(3500, 243, 3))),
-                Comment(" comment 109", Some(Position(3516, 244, 3)))),
-              Some(Position(288, 8, 1))
+                Comment(" comment 108", Some(AstLocation(3500, 243, 3))),
+                Comment(" comment 109", Some(AstLocation(3516, 244, 3)))),
+              Some(AstLocation(288, 8, 1))
             ),
             OperationDefinition(
               OperationType.Mutation,
@@ -1296,20 +1300,20 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "story",
-                      BigIntValue(123, Vector(Comment(" comment 124", Some(Position(3793, 268, 3))), Comment(" comment 125", Some(Position(3809, 269, 3)))), Some(Position(3825, 270, 3))),
+                      BigIntValue(123, Vector(Comment(" comment 124", Some(AstLocation(3793, 268, 3))), Comment(" comment 125", Some(AstLocation(3809, 269, 3)))), Some(AstLocation(3825, 270, 3))),
                       Vector(
-                        Comment(" comment 120", Some(Position(3717, 262, 3))),
-                        Comment(" comment 121", Some(Position(3733, 263, 3)))),
-                      Some(Position(3749, 264, 3))
+                        Comment(" comment 120", Some(AstLocation(3717, 262, 3))),
+                        Comment(" comment 121", Some(AstLocation(3733, 263, 3)))),
+                      Some(AstLocation(3749, 264, 3))
                     )),
                   Vector(
                     Directive(
                       "defer",
                       Vector.empty,
                       Vector(
-                        Comment(" comment 128", Some(Position(3867, 274, 3))),
-                        Comment(" comment 129", Some(Position(3883, 275, 3)))),
-                      Some(Position(3899, 276, 3))
+                        Comment(" comment 128", Some(AstLocation(3867, 274, 3))),
+                        Comment(" comment 129", Some(AstLocation(3883, 275, 3)))),
+                      Some(AstLocation(3899, 276, 3))
                     )),
                   Vector(
                     Field(
@@ -1325,40 +1329,40 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                           Vector.empty,
                           Vector.empty,
                           Vector(
-                            Comment(" comment 136", Some(Position(4030, 286, 5))),
-                            Comment(" comment 137", Some(Position(4048, 287, 5))),
-                            Comment(" comment 138", Some(Position(4067, 289, 5))),
-                            Comment(" comment 139", Some(Position(4085, 290, 5)))),
+                            Comment(" comment 136", Some(AstLocation(4030, 286, 5))),
+                            Comment(" comment 137", Some(AstLocation(4048, 287, 5))),
+                            Comment(" comment 138", Some(AstLocation(4067, 289, 5))),
+                            Comment(" comment 139", Some(AstLocation(4085, 290, 5)))),
                           Vector.empty,
-                          Some(Position(4105, 291, 7))
+                          Some(AstLocation(4105, 291, 7))
                         )),
                       Vector(
-                        Comment(" comment 132", Some(Position(3944, 280, 3))),
-                        Comment(" comment 133", Some(Position(3960, 281, 3)))),
+                        Comment(" comment 132", Some(AstLocation(3944, 280, 3))),
+                        Comment(" comment 133", Some(AstLocation(3960, 281, 3)))),
                       Vector(
-                        Comment(" comment 140", Some(Position(4114, 292, 7))),
-                        Comment(" comment 141", Some(Position(4134, 293, 7)))),
-                      Some(Position(3978, 282, 5))
+                        Comment(" comment 140", Some(AstLocation(4114, 292, 7))),
+                        Comment(" comment 141", Some(AstLocation(4134, 293, 7)))),
+                      Some(AstLocation(3978, 282, 5))
                     )),
                   Vector(
-                    Comment(" comment 116", Some(Position(3644, 256, 1))),
-                    Comment(" comment 117", Some(Position(3658, 257, 1)))),
+                    Comment(" comment 116", Some(AstLocation(3644, 256, 1))),
+                    Comment(" comment 117", Some(AstLocation(3658, 257, 1)))),
                   Vector(
-                    Comment(" comment 142", Some(Position(4158, 295, 5))),
-                    Comment(" comment 143", Some(Position(4176, 296, 5)))),
-                  Some(Position(3674, 258, 3))
+                    Comment(" comment 142", Some(AstLocation(4158, 295, 5))),
+                    Comment(" comment 143", Some(AstLocation(4176, 296, 5)))),
+                  Some(AstLocation(3674, 258, 3))
                 )),
               Vector(
-                Comment(" comment 110", Some(Position(3536, 247, 4))),
-                Comment(" comment 111", Some(Position(3553, 248, 4)))),
+                Comment(" comment 110", Some(AstLocation(3536, 247, 4))),
+                Comment(" comment 111", Some(AstLocation(3553, 248, 4)))),
               Vector(
-                Comment(" comment 144", Some(Position(4196, 298, 3))),
-                Comment(" comment 145", Some(Position(4212, 299, 3)))),
-              Some(Position(3567, 249, 1))
+                Comment(" comment 144", Some(AstLocation(4196, 298, 3))),
+                Comment(" comment 145", Some(AstLocation(4212, 299, 3)))),
+              Some(AstLocation(3567, 249, 1))
             ),
             FragmentDefinition(
               "frag",
-              NamedType("Friend", Some(Position(4358, 312, 1))),
+              NamedType("Friend", Some(AstLocation(4358, 312, 1))),
               Vector.empty,
               Vector(
                 InlineFragment(
@@ -1369,16 +1373,16 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector(
                         Argument(
                           "unless",
-                          VariableValue("foo", Vector(Comment(" comment 168", Some(Position(4613, 334, 3))), Comment(" comment 169", Some(Position(4629, 335, 3)))), Some(Position(4645, 336, 3))),
+                          VariableValue("foo", Vector(Comment(" comment 168", Some(AstLocation(4613, 334, 3))), Comment(" comment 169", Some(AstLocation(4629, 335, 3)))), Some(AstLocation(4645, 336, 3))),
                           Vector(
-                            Comment(" comment 164", Some(Position(4536, 328, 3))),
-                            Comment(" comment 165", Some(Position(4552, 329, 3)))),
-                          Some(Position(4568, 330, 3))
+                            Comment(" comment 164", Some(AstLocation(4536, 328, 3))),
+                            Comment(" comment 165", Some(AstLocation(4552, 329, 3)))),
+                          Some(AstLocation(4568, 330, 3))
                         )),
                       Vector(
-                        Comment(" comment 160", Some(Position(4460, 322, 3))),
-                        Comment(" comment 161", Some(Position(4476, 323, 3)))),
-                      Some(Position(4492, 324, 3))
+                        Comment(" comment 160", Some(AstLocation(4460, 322, 3))),
+                        Comment(" comment 161", Some(AstLocation(4476, 323, 3)))),
+                      Some(AstLocation(4492, 324, 3))
                     )),
                   Vector(
                     Field(
@@ -1388,38 +1392,38 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                       Vector.empty,
                       Vector.empty,
                       Vector(
-                        Comment(" comment 174", Some(Position(4724, 343, 3))),
-                        Comment(" comment 175", Some(Position(4740, 344, 3)))),
+                        Comment(" comment 174", Some(AstLocation(4724, 343, 3))),
+                        Comment(" comment 175", Some(AstLocation(4740, 344, 3)))),
                       Vector.empty,
-                      Some(Position(4758, 345, 5))
+                      Some(AstLocation(4758, 345, 5))
                     )),
                   Vector(
-                    Comment(" comment 156", Some(Position(4395, 316, 1))),
-                    Comment(" comment 157", Some(Position(4409, 317, 1))),
-                    Comment(" comment 158", Some(Position(4424, 319, 1))),
-                    Comment(" comment 159", Some(Position(4438, 320, 1)))),
+                    Comment(" comment 156", Some(AstLocation(4395, 316, 1))),
+                    Comment(" comment 157", Some(AstLocation(4409, 317, 1))),
+                    Comment(" comment 158", Some(AstLocation(4424, 319, 1))),
+                    Comment(" comment 159", Some(AstLocation(4438, 320, 1)))),
                   Vector(
-                    Comment(" comment 176", Some(Position(4765, 346, 5))),
-                    Comment(" comment 177", Some(Position(4783, 347, 5)))),
-                  Some(Position(4454, 321, 3))
+                    Comment(" comment 176", Some(AstLocation(4765, 346, 5))),
+                    Comment(" comment 177", Some(AstLocation(4783, 347, 5)))),
+                  Some(AstLocation(4454, 321, 3))
                 )),
               Vector.empty,
               Vector(
-                Comment(" comment 146", Some(Position(4228, 300, 3))),
-                Comment(" comment 147", Some(Position(4242, 301, 1)))),
+                Comment(" comment 146", Some(AstLocation(4228, 300, 3))),
+                Comment(" comment 147", Some(AstLocation(4242, 301, 1)))),
               Vector(
-                Comment(" comment 178", Some(Position(4803, 349, 3))),
-                Comment(" comment 179", Some(Position(4819, 350, 3)))),
-              Some(Position(4257, 303, 1))
+                Comment(" comment 178", Some(AstLocation(4803, 349, 3))),
+                Comment(" comment 179", Some(AstLocation(4819, 350, 3)))),
+              Some(AstLocation(4257, 303, 1))
             )),
           Vector(
-            Comment(" comment 180", Some(Position(4835, 352, 1))),
-            Comment(" comment 181", Some(Position(4849, 353, 1)))),
-          Some(Position(0, 1, 1)),
+            Comment(" comment 180", Some(AstLocation(4835, 352, 1))),
+            Comment(" comment 181", Some(AstLocation(4849, 353, 1)))),
+          Some(AstLocation(0, 1, 1)),
           None
         )
 
-      QueryParser.parse(query) map (_.withoutSourceMapper) should be (Success(expected))
+      QueryParser.parse(query, ParserConfig.default.withEmptySourceId.withEmptySourceMapper) should be (Success(expected))
     }
 
     "parse document with block strings" in {
@@ -1433,10 +1437,10 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
             Vector(
               VariableDefinition(
                 "someVar",
-                NamedType("String", Some(Position(40, 1, 41))),
-                Some(StringValue("hello \\\n  world", true, Some("\n    hello \\\n      world"), Vector.empty, Some(Position(53, 2, 5)))),
+                NamedType("String", Some(AstLocation(40, 1, 41))),
+                Some(StringValue("hello \\\n  world", true, Some("\n    hello \\\n      world"), Vector.empty, Some(AstLocation(53, 2, 5)))),
                 Vector.empty,
-                Some(Position(30, 1, 31))
+                Some(AstLocation(30, 1, 31))
               )),
             Vector.empty,
             Vector(
@@ -1446,42 +1450,42 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                 Vector(
                   Argument(
                     "id",
-                    StringValue("1000", false, None, Vector.empty, Some(Position(105, 3, 19))),
+                    StringValue("1000", false, None, Vector.empty, Some(AstLocation(105, 3, 19))),
                     Vector.empty,
-                    Some(Position(101, 3, 15))
+                    Some(AstLocation(101, 3, 15))
                   ),
                   Argument(
                     "bar",
-                    StringValue(" \\\"test\n123 \\u0000", true, Some(" \\\"test\n     123 \\u0000\n     "), Vector.empty, Some(Position(118, 3, 32))),
+                    StringValue(" \\\"test\n123 \\u0000", true, Some(" \\\"test\n     123 \\u0000\n     "), Vector.empty, Some(AstLocation(118, 3, 32))),
                     Vector.empty,
-                    Some(Position(113, 3, 27))
+                    Some(AstLocation(113, 3, 27))
                   )),
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
-                Some(Position(89, 3, 3))
+                Some(AstLocation(89, 3, 3))
               ),
-              FragmentSpread("Foo", Vector.empty, Vector.empty, Some(Position(158, 5, 3)))),
+              FragmentSpread("Foo", Vector.empty, Vector.empty, Some(AstLocation(158, 5, 3)))),
             Vector.empty,
             Vector.empty,
-            Some(Position(0, 1, 1))
+            Some(AstLocation(0, 1, 1))
           ),
           FragmentDefinition(
             "Foo",
-            NamedType("User", Some(Position(184, 8, 17))),
+            NamedType("User", Some(AstLocation(184, 8, 17))),
             Vector(
               Directive(
                 "foo",
                 Vector(
                   Argument(
                     "bar",
-                    BigIntValue(1, Vector.empty, Some(Position(199, 8, 32))),
+                    BigIntValue(1, Vector.empty, Some(AstLocation(199, 8, 32))),
                     Vector.empty,
-                    Some(Position(194, 8, 27))
+                    Some(AstLocation(194, 8, 27))
                   )),
                 Vector.empty,
-                Some(Position(189, 8, 22))
+                Some(AstLocation(189, 8, 22))
               )),
             Vector(
               Field(
@@ -1494,44 +1498,44 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                     Vector(
                       Argument(
                         "info",
-                        StringValue("\"\"\"\n\"\"\" this \" is \"\"\na description! \"\"\"", true, Some("\"\"\"\n    \"\"\" this \" is \"\"\n    a description! \"\"\"\n    "), Vector.empty, Some(Position(225, 10, 5))),
+                        StringValue("\"\"\"\n\"\"\" this \" is \"\"\na description! \"\"\"", true, Some("\"\"\"\n    \"\"\" this \" is \"\"\n    a description! \"\"\"\n    "), Vector.empty, Some(AstLocation(225, 10, 5))),
                         Vector.empty,
-                        Some(Position(215, 9, 13))
+                        Some(AstLocation(215, 9, 13))
                       )),
                     Vector.empty,
-                    Some(Position(209, 9, 7))
+                    Some(AstLocation(209, 9, 7))
                   )),
                 Vector.empty,
                 Vector.empty,
                 Vector.empty,
-                Some(Position(205, 9, 3))
+                Some(AstLocation(205, 9, 3))
               )),
             Vector.empty,
             Vector.empty,
             Vector.empty,
-            Some(Position(168, 8, 1))
+            Some(AstLocation(168, 8, 1))
           )),
         Vector.empty,
-        Some(Position(0, 1, 1)),
+        Some(AstLocation(0, 1, 1)),
         None
       )
 
-      QueryParser.parse(query) map (_.withoutSourceMapper) should be (Success(expected))
+      parseQuery(query) should be (Success(expected))
     }
     
     "Experimental: allows parsing fragment defined variables" in {
       val queryStr = "fragment a($v: Boolean = false) on t { f(v: $v) }"
 
-      QueryParser.parse(queryStr).isFailure should be (true)
+      parseQuery(queryStr).isFailure should be (true)
 
-      val Success(query) = QueryParser.parse(queryStr, experimentalFragmentVariables = true)
+      val Success(query) = QueryParser.parse(queryStr, ParserConfig.default.withEmptySourceId.withEmptySourceMapper.withExperimentalFragmentVariables)
 
-      query.withoutSourceMapper should be (
+      query should be (
         Document(
           Vector(
             FragmentDefinition(
               "a",
-              NamedType("t", Some(Position(35, 1, 36))),
+              NamedType("t", Some(AstLocation(35, 1, 36))),
               Vector.empty,
               Vector(
                 Field(
@@ -1540,30 +1544,30 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
                   Vector(
                     Argument(
                       "v",
-                      VariableValue("v", Vector.empty, Some(Position(44, 1, 45))),
+                      VariableValue("v", Vector.empty, Some(AstLocation(44, 1, 45))),
                       Vector.empty,
-                      Some(Position(41, 1, 42))
+                      Some(AstLocation(41, 1, 42))
                     )),
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(39, 1, 40))
+                  Some(AstLocation(39, 1, 40))
                 )),
               Vector(
                 VariableDefinition(
                   "v",
-                  NamedType("Boolean", Some(Position(15, 1, 16))),
-                  Some(BooleanValue(false, Vector.empty, Some(Position(25, 1, 26)))),
+                  NamedType("Boolean", Some(AstLocation(15, 1, 16))),
+                  Some(BooleanValue(false, Vector.empty, Some(AstLocation(25, 1, 26)))),
                   Vector.empty,
-                  Some(Position(11, 1, 12))
+                  Some(AstLocation(11, 1, 12))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
@@ -1582,7 +1586,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
           }
         """
 
-      (QueryParser.parse(query) == QueryParser.parse(query)) should be (true)
+      (parseQuery(query) == parseQuery(query)) should be (true)
     }
 
     "not be equal for the same queries with different AST node positions" in {
@@ -1606,7 +1610,7 @@ class QueryParserSpec extends WordSpec with Matchers with StringMatchers {
           }
         """
 
-      (QueryParser.parse(query1) == QueryParser.parse(query2)) should be (false)
+      (parseQuery(query1) == parseQuery(query2)) should be (false)
     }
   }
 }

--- a/src/test/scala/sangria/parser/SchemaParserSpec.scala
+++ b/src/test/scala/sangria/parser/SchemaParserSpec.scala
@@ -1,13 +1,17 @@
 package sangria.parser
 
-import org.parboiled2.Position
+import sangria.ast.AstLocation
 import org.scalatest.{Matchers, WordSpec}
+import sangria.ast
 import sangria.ast._
 import sangria.util.{DebugUtil, FileUtil, StringMatchers}
 
 import scala.util.Success
 
 class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
+
+  def parseQuery(query: String)(implicit scheme: DeliveryScheme[ast.Document]): scheme.Result =
+    QueryParser.parse(query, ParserConfig.default.withEmptySourceId.withEmptySourceMapper)(scheme)
 
   "QueryParser" should {
     "parse schema kitchen sink" in {
@@ -18,156 +22,156 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
           Vector(
             SchemaDefinition(
               Vector(
-                OperationTypeDefinition(OperationType.Query, NamedType("QueryType", Some(Position(306, 9, 10))), Vector.empty, Some(Position(299, 9, 3))),
-                OperationTypeDefinition(OperationType.Mutation, NamedType("MutationType", Some(Position(328, 10, 13))), Vector.empty, Some(Position(318, 10, 3)))),
+                OperationTypeDefinition(OperationType.Query, NamedType("QueryType", Some(AstLocation(306, 9, 10))), Vector.empty, Some(AstLocation(299, 9, 3))),
+                OperationTypeDefinition(OperationType.Mutation, NamedType("MutationType", Some(AstLocation(328, 10, 13))), Vector.empty, Some(AstLocation(318, 10, 3)))),
               Vector.empty,
               Vector(
-                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(Position(0, 1, 1))),
-                Comment(" All rights reserved.", Some(Position(37, 2, 1))),
-                Comment("", Some(Position(60, 3, 1))),
-                Comment(" This source code is licensed under the BSD-style license found in the", Some(Position(62, 4, 1))),
-                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(Position(134, 5, 1))),
-                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(Position(212, 6, 1)))),
+                Comment(" Copyright (c) 2015, Facebook, Inc.", Some(AstLocation(0, 1, 1))),
+                Comment(" All rights reserved.", Some(AstLocation(37, 2, 1))),
+                Comment("", Some(AstLocation(60, 3, 1))),
+                Comment(" This source code is licensed under the BSD-style license found in the", Some(AstLocation(62, 4, 1))),
+                Comment(" LICENSE file in the root directory of this source tree. An additional grant", Some(AstLocation(134, 5, 1))),
+                Comment(" of patent rights can be found in the PATENTS file in the same directory.", Some(AstLocation(212, 6, 1)))),
               Vector.empty,
-              Some(Position(288, 8, 1))
+              Some(AstLocation(288, 8, 1))
             ),
             ObjectTypeDefinition(
               "Foo",
               Vector(
-                NamedType("Bar", Some(Position(390, 14, 21)))),
+                NamedType("Bar", Some(AstLocation(390, 14, 21)))),
               Vector(
-                FieldDefinition("one", NamedType("Type", Some(Position(403, 15, 8))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(398, 15, 3))),
-                FieldDefinition("two", NamedType("Type", Some(Position(437, 16, 30))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(Position(424, 16, 17))), Some(Position(424, 16, 17))), None, Vector.empty, None, Vector.empty, Some(Position(414, 16, 7)))), Vector.empty, None, Vector.empty, Some(Position(410, 16, 3))),
-                FieldDefinition("three", NamedType("Int", Some(Position(487, 17, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(460, 17, 19))), None, Vector.empty, None, Vector.empty, Some(Position(450, 17, 9))), InputValueDefinition("other", NamedType("String", Some(Position(478, 17, 37))), None, Vector.empty, None, Vector.empty, Some(Position(471, 17, 30)))), Vector.empty, None, Vector.empty, Some(Position(444, 17, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(528, 18, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(508, 18, 18))), Some(StringValue("string", false, None, Vector.empty, Some(Position(517, 18, 27)))), Vector.empty, None, Vector.empty, Some(Position(498, 18, 8)))), Vector.empty, None, Vector.empty, Some(Position(493, 18, 3))),
-                FieldDefinition("five", NamedType("String", Some(Position(586, 19, 52))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(553, 19, 19))), Some(Position(552, 19, 18))), Some(ListValue(
+                FieldDefinition("one", NamedType("Type", Some(AstLocation(403, 15, 8))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(398, 15, 3))),
+                FieldDefinition("two", NamedType("Type", Some(AstLocation(437, 16, 30))), Vector(InputValueDefinition("argument", NotNullType(NamedType("InputType", Some(AstLocation(424, 16, 17))), Some(AstLocation(424, 16, 17))), None, Vector.empty, None, Vector.empty, Some(AstLocation(414, 16, 7)))), Vector.empty, None, Vector.empty, Some(AstLocation(410, 16, 3))),
+                FieldDefinition("three", NamedType("Int", Some(AstLocation(487, 17, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(AstLocation(460, 17, 19))), None, Vector.empty, None, Vector.empty, Some(AstLocation(450, 17, 9))), InputValueDefinition("other", NamedType("String", Some(AstLocation(478, 17, 37))), None, Vector.empty, None, Vector.empty, Some(AstLocation(471, 17, 30)))), Vector.empty, None, Vector.empty, Some(AstLocation(444, 17, 3))),
+                FieldDefinition("four", NamedType("String", Some(AstLocation(528, 18, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(AstLocation(508, 18, 18))), Some(StringValue("string", false, None, Vector.empty, Some(AstLocation(517, 18, 27)))), Vector.empty, None, Vector.empty, Some(AstLocation(498, 18, 8)))), Vector.empty, None, Vector.empty, Some(AstLocation(493, 18, 3))),
+                FieldDefinition("five", NamedType("String", Some(AstLocation(586, 19, 52))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(AstLocation(553, 19, 19))), Some(AstLocation(552, 19, 18))), Some(ListValue(
                   Vector(
-                    StringValue("string", false, None, Vector.empty, Some(Position(564, 19, 30))),
-                    StringValue("string", false, None, Vector.empty, Some(Position(574, 19, 40)))),
+                    StringValue("string", false, None, Vector.empty, Some(AstLocation(564, 19, 30))),
+                    StringValue("string", false, None, Vector.empty, Some(AstLocation(574, 19, 40)))),
                   Vector.empty,
-                  Some(Position(563, 19, 29))
-                )), Vector.empty, None, Vector.empty, Some(Position(542, 19, 8)))), Vector.empty, None, Vector.empty, Some(Position(537, 19, 3))),
-                FieldDefinition("six", NamedType("Type", Some(Position(678, 22, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(Position(649, 22, 17))), Some(ObjectValue(
+                  Some(AstLocation(563, 19, 29))
+                )), Vector.empty, None, Vector.empty, Some(AstLocation(542, 19, 8)))), Vector.empty, None, Vector.empty, Some(AstLocation(537, 19, 3))),
+                FieldDefinition("six", NamedType("Type", Some(AstLocation(678, 22, 46))), Vector(InputValueDefinition("argument", NamedType("InputType", Some(AstLocation(649, 22, 17))), Some(ObjectValue(
                   Vector(
                     ObjectField(
                       "key",
-                      StringValue("value", false, None, Vector.empty, Some(Position(667, 22, 35))),
+                      StringValue("value", false, None, Vector.empty, Some(AstLocation(667, 22, 35))),
                       Vector.empty,
-                      Some(Position(662, 22, 30))
+                      Some(AstLocation(662, 22, 30))
                     )),
                   Vector.empty,
-                  Some(Position(661, 22, 29))
-                )), Vector.empty, None, Vector.empty, Some(Position(639, 22, 7)))), Vector.empty, Some(StringValue("More \"\"\" descriptions \\", true, Some("\n  More \"\"\" descriptions \\\n  "), Vector.empty, Some(Position(596, 21, 3)))), Vector.empty, Some(Position(635, 22, 3)))),
+                  Some(AstLocation(661, 22, 29))
+                )), Vector.empty, None, Vector.empty, Some(AstLocation(639, 22, 7)))), Vector.empty, Some(StringValue("More \"\"\" descriptions \\", true, Some("\n  More \"\"\" descriptions \\\n  "), Vector.empty, Some(AstLocation(596, 21, 3)))), Vector.empty, Some(AstLocation(635, 22, 3)))),
               Vector.empty,
-              Some(StringValue("type description!", true, Some("\ntype description!\n"), Vector.empty, Some(Position(344, 13, 1)))),
+              Some(StringValue("type description!", true, Some("\ntype description!\n"), Vector.empty, Some(AstLocation(344, 13, 1)))),
               Vector.empty,
               Vector.empty,
-              Some(Position(370, 14, 1))
+              Some(AstLocation(370, 14, 1))
             ),
             ObjectTypeDefinition(
               "AnnotatedObject",
               Vector.empty,
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(781, 26, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(755, 26, 23))), Some(StringValue("default", false, None, Vector.empty, Some(Position(762, 26, 30)))), Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(AstLocation(781, 26, 49))), Vector(InputValueDefinition("arg", NamedType("Type", Some(AstLocation(755, 26, 23))), Some(StringValue("default", false, None, Vector.empty, Some(AstLocation(762, 26, 30)))), Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(772, 26, 40))
-                )), None, Vector.empty, Some(Position(750, 26, 18)))), Vector(Directive(
+                  Some(AstLocation(772, 26, 40))
+                )), None, Vector.empty, Some(AstLocation(750, 26, 18)))), Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(786, 26, 54))
-                )), None, Vector.empty, Some(Position(735, 26, 3)))),
+                  Some(AstLocation(786, 26, 54))
+                )), None, Vector.empty, Some(AstLocation(735, 26, 3)))),
               Vector(
                 Directive(
                   "onObject",
                   Vector(
                     Argument(
                       "arg",
-                      StringValue("value", false, None, Vector.empty, Some(Position(722, 25, 37))),
+                      StringValue("value", false, None, Vector.empty, Some(AstLocation(722, 25, 37))),
                       Vector.empty,
-                      Some(Position(717, 25, 32))
+                      Some(AstLocation(717, 25, 32))
                     )),
                   Vector.empty,
-                  Some(Position(707, 25, 22))
+                  Some(AstLocation(707, 25, 22))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(686, 25, 1))
+              Some(AstLocation(686, 25, 1))
             ),
             InterfaceTypeDefinition(
               "Bar",
               Vector(
-                FieldDefinition("one", NamedType("Type", Some(Position(875, 33, 8))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(870, 33, 3))),
-                FieldDefinition("four", NamedType("String", Some(Position(917, 34, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(Position(897, 34, 18))), Some(StringValue("string", false, None, Vector.empty, Some(Position(906, 34, 27)))), Vector.empty, None, Vector.empty, Some(Position(887, 34, 8)))), Vector.empty, None, Vector.empty, Some(Position(882, 34, 3)))),
+                FieldDefinition("one", NamedType("Type", Some(AstLocation(875, 33, 8))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(870, 33, 3))),
+                FieldDefinition("four", NamedType("String", Some(AstLocation(917, 34, 38))), Vector(InputValueDefinition("argument", NamedType("String", Some(AstLocation(897, 34, 18))), Some(StringValue("string", false, None, Vector.empty, Some(AstLocation(906, 34, 27)))), Vector.empty, None, Vector.empty, Some(AstLocation(887, 34, 8)))), Vector.empty, None, Vector.empty, Some(AstLocation(882, 34, 3)))),
               Vector.empty,
-              Some(StringValue(" It's an interface!", false, None, Vector(Comment(" comment above", Some(Position(798, 29, 1)))), Some(Position(814, 30, 1)))),
+              Some(StringValue(" It's an interface!", false, None, Vector(Comment(" comment above", Some(AstLocation(798, 29, 1)))), Some(AstLocation(814, 30, 1)))),
               Vector(
-                Comment(" comment below", Some(Position(836, 31, 1)))),
+                Comment(" comment below", Some(AstLocation(836, 31, 1)))),
               Vector.empty,
-              Some(Position(852, 32, 1))
+              Some(AstLocation(852, 32, 1))
             ),
             InterfaceTypeDefinition(
               "AnnotatedInterface",
               Vector(
-                FieldDefinition("annotatedField", NamedType("Type", Some(Position(1007, 38, 37))), Vector(InputValueDefinition("arg", NamedType("Type", Some(Position(993, 38, 23))), None, Vector(Directive(
+                FieldDefinition("annotatedField", NamedType("Type", Some(AstLocation(1007, 38, 37))), Vector(InputValueDefinition("arg", NamedType("Type", Some(AstLocation(993, 38, 23))), None, Vector(Directive(
                   "onArg",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(998, 38, 28))
-                )), None, Vector.empty, Some(Position(988, 38, 18)))), Vector(Directive(
+                  Some(AstLocation(998, 38, 28))
+                )), None, Vector.empty, Some(AstLocation(988, 38, 18)))), Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1012, 38, 42))
-                )), None, Vector.empty, Some(Position(973, 38, 3)))),
+                  Some(AstLocation(1012, 38, 42))
+                )), None, Vector.empty, Some(AstLocation(973, 38, 3)))),
               Vector(
                 Directive(
                   "onInterface",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(956, 37, 30))
+                  Some(AstLocation(956, 37, 30))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(927, 37, 1))
+              Some(AstLocation(927, 37, 1))
             ),
             UnionTypeDefinition(
               "Feed",
               Vector(
-                NamedType("Story", Some(Position(1037, 41, 14))),
-                NamedType("Article", Some(Position(1045, 41, 22))),
-                NamedType("Advert", Some(Position(1055, 41, 32)))),
+                NamedType("Story", Some(AstLocation(1037, 41, 14))),
+                NamedType("Article", Some(AstLocation(1045, 41, 22))),
+                NamedType("Advert", Some(AstLocation(1055, 41, 32)))),
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(1024, 41, 1))
+              Some(AstLocation(1024, 41, 1))
             ),
             UnionTypeDefinition(
               "AnnotatedUnion",
               Vector(
-                NamedType("A", Some(Position(1095, 43, 33))),
-                NamedType("B", Some(Position(1099, 43, 37)))),
+                NamedType("A", Some(AstLocation(1095, 43, 33))),
+                NamedType("B", Some(AstLocation(1099, 43, 37)))),
               Vector(
                 Directive(
                   "onUnion",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1084, 43, 22))
+                  Some(AstLocation(1084, 43, 22))
                 )),
               None,
               Vector.empty,
-              Some(Position(1063, 43, 1))
+              Some(AstLocation(1063, 43, 1))
             ),
             ScalarTypeDefinition(
               "CustomScalar",
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(1102, 45, 1))
+              Some(AstLocation(1102, 45, 1))
             ),
             ScalarTypeDefinition(
               "AnnotatedScalar",
@@ -176,22 +180,22 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "onScalar",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1146, 47, 24))
+                  Some(AstLocation(1146, 47, 24))
                 )),
               None,
               Vector.empty,
-              Some(Position(1123, 47, 1))
+              Some(AstLocation(1123, 47, 1))
             ),
             EnumTypeDefinition(
               "Site",
               Vector(
-                EnumValueDefinition("DESKTOP", Vector.empty, Some(StringValue("description 1", false, None, Vector.empty, Some(Position(1171, 50, 3)))), Vector.empty, Some(Position(1189, 51, 3))),
-                EnumValueDefinition("MOBILE", Vector.empty, Some(StringValue("description 2", true, Some("\n  description 2\n  "), Vector.empty, Some(Position(1199, 52, 3)))), Vector.empty, Some(Position(1227, 53, 3)))),
+                EnumValueDefinition("DESKTOP", Vector.empty, Some(StringValue("description 1", false, None, Vector.empty, Some(AstLocation(1171, 50, 3)))), Vector.empty, Some(AstLocation(1189, 51, 3))),
+                EnumValueDefinition("MOBILE", Vector.empty, Some(StringValue("description 2", true, Some("\n  description 2\n  "), Vector.empty, Some(AstLocation(1199, 52, 3)))), Vector.empty, Some(AstLocation(1227, 53, 3)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1157, 49, 1))
+              Some(AstLocation(1157, 49, 1))
             ),
             EnumTypeDefinition(
               "AnnotatedEnum",
@@ -200,62 +204,62 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "onEnumValue",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1284, 57, 19))
-                )), None, Vector.empty, Some(Position(1268, 57, 3))),
-                EnumValueDefinition("OTHER_VALUE", Vector.empty, None, Vector.empty, Some(Position(1299, 58, 3)))),
+                  Some(AstLocation(1284, 57, 19))
+                )), None, Vector.empty, Some(AstLocation(1268, 57, 3))),
+                EnumValueDefinition("OTHER_VALUE", Vector.empty, None, Vector.empty, Some(AstLocation(1299, 58, 3)))),
               Vector(
                 Directive(
                   "onEnum",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1256, 56, 20))
+                  Some(AstLocation(1256, 56, 20))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1237, 56, 1))
+              Some(AstLocation(1237, 56, 1))
             ),
             InputObjectTypeDefinition(
               "InputType",
               Vector(
-                InputValueDefinition("key", NotNullType(NamedType("String", Some(Position(1339, 62, 8))), Some(Position(1339, 62, 8))), None, Vector.empty, None, Vector.empty, Some(Position(1334, 62, 3))),
-                InputValueDefinition("answer", NamedType("Int", Some(Position(1357, 63, 11))), Some(BigIntValue(42, Vector.empty, Some(Position(1363, 63, 17)))), Vector.empty, None, Vector.empty, Some(Position(1349, 63, 3)))),
+                InputValueDefinition("key", NotNullType(NamedType("String", Some(AstLocation(1339, 62, 8))), Some(AstLocation(1339, 62, 8))), None, Vector.empty, None, Vector.empty, Some(AstLocation(1334, 62, 3))),
+                InputValueDefinition("answer", NamedType("Int", Some(AstLocation(1357, 63, 11))), Some(BigIntValue(42, Vector.empty, Some(AstLocation(1363, 63, 17)))), Vector.empty, None, Vector.empty, Some(AstLocation(1349, 63, 3)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1314, 61, 1))
+              Some(AstLocation(1314, 61, 1))
             ),
             InputObjectTypeDefinition(
               "AnnotatedInput",
               Vector(
-                InputValueDefinition("annotatedField", NamedType("Type", Some(Position(1447, 68, 19))), None, Vector(Directive(
+                InputValueDefinition("annotatedField", NamedType("Type", Some(AstLocation(1447, 68, 19))), None, Vector(Directive(
                   "onField",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1452, 68, 24))
-                )), None, Vector(Comment(" field comment", Some(Position(1413, 67, 3)))), Some(Position(1431, 68, 3)))),
+                  Some(AstLocation(1452, 68, 24))
+                )), None, Vector(Comment(" field comment", Some(AstLocation(1413, 67, 3)))), Some(AstLocation(1431, 68, 3)))),
               Vector(
                 Directive(
                   "onInputObjectType",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1390, 66, 22))
+                  Some(AstLocation(1390, 66, 22))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(1369, 66, 1))
+              Some(AstLocation(1369, 66, 1))
             ),
             ObjectTypeExtensionDefinition(
               "Foo",
               Vector.empty,
               Vector(
-                FieldDefinition("seven", NamedType("Type", Some(Position(1511, 72, 30))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(Position(1501, 72, 20))), Some(Position(1500, 72, 19))), None, Vector.empty, None, Vector.empty, Some(Position(1490, 72, 9)))), Vector.empty, None, Vector.empty, Some(Position(1484, 72, 3)))),
+                FieldDefinition("seven", NamedType("Type", Some(AstLocation(1511, 72, 30))), Vector(InputValueDefinition("argument", ListType(NamedType("String", Some(AstLocation(1501, 72, 20))), Some(AstLocation(1500, 72, 19))), None, Vector.empty, None, Vector.empty, Some(AstLocation(1490, 72, 9)))), Vector.empty, None, Vector.empty, Some(AstLocation(1484, 72, 3)))),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(1464, 71, 1))
+              Some(AstLocation(1464, 71, 1))
             ),
             ObjectTypeExtensionDefinition(
               "Foo",
@@ -266,46 +270,46 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "onType",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(1535, 75, 17))
+                  Some(AstLocation(1535, 75, 17))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(1519, 75, 1))
+              Some(AstLocation(1519, 75, 1))
             ),
             DirectiveDefinition(
               "skip",
               Vector(
-                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(Position(1577, 78, 21))), Some(Position(1577, 78, 21))), None, Vector.empty, None, Vector.empty, Some(Position(1573, 78, 17)))),
+                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(AstLocation(1577, 78, 21))), Some(AstLocation(1577, 78, 21))), None, Vector.empty, None, Vector.empty, Some(AstLocation(1573, 78, 17)))),
               Vector(
-                DirectiveLocation("FIELD", Vector.empty, Some(Position(1590, 78, 34))),
-                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(Position(1598, 78, 42))),
-                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(Position(1616, 78, 60)))),
-              Some(StringValue("cool skip", false, None, Vector.empty, Some(Position(1545, 77, 1)))),
+                DirectiveLocation("FIELD", Vector.empty, Some(AstLocation(1590, 78, 34))),
+                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(AstLocation(1598, 78, 42))),
+                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(AstLocation(1616, 78, 60)))),
+              Some(StringValue("cool skip", false, None, Vector.empty, Some(AstLocation(1545, 77, 1)))),
               Vector.empty,
-              Some(Position(1557, 78, 1))
+              Some(AstLocation(1557, 78, 1))
             ),
             DirectiveDefinition(
               "include",
               Vector(
-                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(Position(1656, 80, 24))), Some(Position(1656, 80, 24))), None, Vector.empty, None, Vector.empty, Some(Position(1652, 80, 20)))),
+                InputValueDefinition("if", NotNullType(NamedType("Boolean", Some(AstLocation(1656, 80, 24))), Some(AstLocation(1656, 80, 24))), None, Vector.empty, None, Vector.empty, Some(AstLocation(1652, 80, 20)))),
               Vector(
-                DirectiveLocation("FIELD", Vector.empty, Some(Position(1671, 81, 6))),
-                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(Position(1682, 82, 6))),
-                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(Position(1703, 83, 6)))),
+                DirectiveLocation("FIELD", Vector.empty, Some(AstLocation(1671, 81, 6))),
+                DirectiveLocation("FRAGMENT_SPREAD", Vector.empty, Some(AstLocation(1682, 82, 6))),
+                DirectiveLocation("INLINE_FRAGMENT", Vector.empty, Some(AstLocation(1703, 83, 6)))),
               None,
               Vector.empty,
-              Some(Position(1633, 80, 1))
+              Some(AstLocation(1633, 80, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         )
 
-      QueryParser.parse(query) map (_.withoutSourceMapper) should be(Success(expectedAst))
+      parseQuery(query) should be(Success(expectedAst))
     }
 
     "Simple type" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           # my type
           # comment
@@ -322,23 +326,23 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(123, 6, 20))), Vector.empty, Vector.empty, None, Vector(Comment(" and field comment as well", Some(Position(76, 5, 13)))), Some(Position(116, 6, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(123, 6, 20))), Vector.empty, Vector.empty, None, Vector(Comment(" and field comment as well", Some(AstLocation(76, 5, 13)))), Some(AstLocation(116, 6, 13)))),
               Vector.empty,
               None,
               Vector(
-                Comment(" my type", Some(Position(11, 2, 11))),
-                Comment(" comment", Some(Position(31, 3, 11)))),
+                Comment(" my type", Some(AstLocation(11, 2, 11))),
+                Comment(" comment", Some(AstLocation(31, 3, 11)))),
               Vector.empty,
-              Some(Position(51, 4, 11))
+              Some(AstLocation(51, 4, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple extension" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           # my type
           # comment
@@ -354,101 +358,101 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(90, 5, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(83, 5, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(90, 5, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(83, 5, 13)))),
               Vector.empty,
               Vector(
-                Comment(" my type", Some(Position(11, 2, 11))),
-                Comment(" comment", Some(Position(31, 3, 11)))),
+                Comment(" my type", Some(AstLocation(11, 2, 11))),
+                Comment(" comment", Some(AstLocation(31, 3, 11)))),
               Vector.empty,
-              Some(Position(51, 4, 11))
+              Some(AstLocation(51, 4, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple non-null type" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Hello {
             world: String!
           }
         """)
       
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NotNullType(NamedType("String", Some(Position(43, 3, 20))), Some(Position(43, 3, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(36, 3, 13)))),
+                FieldDefinition("world", NotNullType(NamedType("String", Some(AstLocation(43, 3, 20))), Some(AstLocation(43, 3, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(36, 3, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple type inheriting interface" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "type Hello implements World { foo: Bar }")
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector(
-                NamedType("World", Some(Position(22, 1, 23)))),
+                NamedType("World", Some(AstLocation(22, 1, 23)))),
               Vector(
-                FieldDefinition("foo", NamedType("Bar", Some(Position(35, 1, 36))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(30, 1, 31)))),
+                FieldDefinition("foo", NamedType("Bar", Some(AstLocation(35, 1, 36))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(30, 1, 31)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Simple type inheriting multiple interfaces" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "type Hello implements Wo & rld { foo: Bar }")
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector(
-                NamedType("Wo", Some(Position(22, 1, 23))),
-                NamedType("rld", Some(Position(27, 1, 28)))),
+                NamedType("Wo", Some(AstLocation(22, 1, 23))),
+                NamedType("rld", Some(AstLocation(27, 1, 28)))),
               Vector(
-                FieldDefinition("foo", NamedType("Bar", Some(Position(38, 1, 39))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(33, 1, 34)))),
+                FieldDefinition("foo", NamedType("Bar", Some(AstLocation(38, 1, 39))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(33, 1, 34)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Simple type inheriting multiple interfaces (allow separator at the beginning)" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Hello implements
             & Foo
@@ -457,80 +461,80 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
             foo: Bar
           }
         """)
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector(
-                NamedType("Foo", Some(Position(47, 3, 15))),
-                NamedType("Baz", Some(Position(65, 4, 15)))),
+                NamedType("Foo", Some(AstLocation(47, 3, 15))),
+                NamedType("Baz", Some(AstLocation(65, 4, 15)))),
               Vector(
-                FieldDefinition("foo", NamedType("Bar", Some(Position(98, 6, 18))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(93, 6, 13)))),
+                FieldDefinition("foo", NamedType("Bar", Some(AstLocation(98, 6, 18))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(93, 6, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple type inheriting multiple interfaces (legacy syntax)" in {
       val Success(ast) = QueryParser.parse(
-        "type Hello implements Wo, rld { foo: Bar }", legacyImplementsInterface = true)
+        "type Hello implements Wo, rld { foo: Bar }", ParserConfig.default.withEmptySourceId.withEmptySourceMapper.withLegacyImplementsInterface)
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector(
-                NamedType("Wo", Some(Position(22, 1, 23))),
-                NamedType("rld", Some(Position(26, 1, 27)))),
+                NamedType("Wo", Some(AstLocation(22, 1, 23))),
+                NamedType("rld", Some(AstLocation(26, 1, 27)))),
               Vector(
-                FieldDefinition("foo", NamedType("Bar", Some(Position(37, 1, 38))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(32, 1, 33)))),
+                FieldDefinition("foo", NamedType("Bar", Some(AstLocation(37, 1, 38))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(32, 1, 33)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Double value enum" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "enum Hello { WO, RLD }")
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             EnumTypeDefinition(
               "Hello",
               Vector(
-                EnumValueDefinition("WO", Vector.empty, None, Vector.empty, Some(Position(13, 1, 14))),
-                EnumValueDefinition("RLD", Vector.empty, None, Vector.empty, Some(Position(17, 1, 18)))),
+                EnumValueDefinition("WO", Vector.empty, None, Vector.empty, Some(AstLocation(13, 1, 14))),
+                EnumValueDefinition("RLD", Vector.empty, None, Vector.empty, Some(AstLocation(17, 1, 18)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Simple interface" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           #foo
           interface Hello {
@@ -538,28 +542,28 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
           }
         """)
       
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             InterfaceTypeDefinition(
               "Hello",
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(63, 4, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(56, 4, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(63, 4, 20))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(56, 4, 13)))),
               Vector.empty,
               None,
               Vector(
-                Comment("foo", Some(Position(11, 2, 11)))),
+                Comment("foo", Some(AstLocation(11, 2, 11)))),
               Vector.empty,
-              Some(Position(26, 3, 11))
+              Some(AstLocation(26, 3, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple field with arg" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           #c1
           type Hello {
@@ -579,22 +583,22 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(140, 9, 31))), Vector(InputValueDefinition("flag", NamedType("Boolean", Some(Position(130, 9, 21))), None, Vector.empty, None, Vector(Comment("c3", Some(Position(87, 6, 15))), Comment("c4", Some(Position(106, 8, 15)))), Some(Position(124, 9, 15)))), Vector.empty, None, Vector(Comment("c2", Some(Position(50, 4, 13)))), Some(Position(66, 5, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(140, 9, 31))), Vector(InputValueDefinition("flag", NamedType("Boolean", Some(AstLocation(130, 9, 21))), None, Vector.empty, None, Vector(Comment("c3", Some(AstLocation(87, 6, 15))), Comment("c4", Some(AstLocation(106, 8, 15)))), Some(AstLocation(124, 9, 15)))), Vector.empty, None, Vector(Comment("c2", Some(AstLocation(50, 4, 13)))), Some(AstLocation(66, 5, 13)))),
               Vector.empty,
               None,
               Vector(
-                Comment("c1", Some(Position(11, 2, 11)))),
+                Comment("c1", Some(AstLocation(11, 2, 11)))),
               Vector.empty,
-              Some(Position(25, 3, 11))
+              Some(AstLocation(25, 3, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple field with arg with default value" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Hello {
             world(flag: Boolean =
@@ -603,132 +607,132 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
           }
         """)
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(109, 5, 22))), Vector(InputValueDefinition("flag", NamedType("Boolean", Some(Position(48, 3, 25))), Some(BooleanValue(true, Vector(Comment(" value comment", Some(Position(72, 4, 15)))), Some(Position(102, 5, 15)))), Vector.empty, None, Vector.empty, Some(Position(42, 3, 19)))), Vector.empty, None, Vector.empty, Some(Position(36, 3, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(109, 5, 22))), Vector(InputValueDefinition("flag", NamedType("Boolean", Some(AstLocation(48, 3, 25))), Some(BooleanValue(true, Vector(Comment(" value comment", Some(AstLocation(72, 4, 15)))), Some(AstLocation(102, 5, 15)))), Vector.empty, None, Vector.empty, Some(AstLocation(42, 3, 19)))), Vector.empty, None, Vector.empty, Some(AstLocation(36, 3, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple field with list arg" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Hello {
             world(things: [String]): String
           }
         """)
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(61, 3, 38))), Vector(InputValueDefinition("things", ListType(NamedType("String", Some(Position(51, 3, 28))), Some(Position(50, 3, 27))), None, Vector.empty, None, Vector.empty, Some(Position(42, 3, 19)))), Vector.empty, None, Vector.empty, Some(Position(36, 3, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(61, 3, 38))), Vector(InputValueDefinition("things", ListType(NamedType("String", Some(AstLocation(51, 3, 28))), Some(AstLocation(50, 3, 27))), None, Vector.empty, None, Vector.empty, Some(AstLocation(42, 3, 19)))), Vector.empty, None, Vector.empty, Some(AstLocation(36, 3, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple field with two args" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Hello {
             world(argOne: Boolean, argTwo: Int): String
           }
         """)
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ObjectTypeDefinition(
               "Hello",
               Vector.empty,
               Vector(
-                FieldDefinition("world", NamedType("String", Some(Position(73, 3, 50))), Vector(InputValueDefinition("argOne", NamedType("Boolean", Some(Position(50, 3, 27))), None, Vector.empty, None, Vector.empty, Some(Position(42, 3, 19))), InputValueDefinition("argTwo", NamedType("Int", Some(Position(67, 3, 44))), None, Vector.empty, None, Vector.empty, Some(Position(59, 3, 36)))), Vector.empty, None, Vector.empty, Some(Position(36, 3, 13)))),
+                FieldDefinition("world", NamedType("String", Some(AstLocation(73, 3, 50))), Vector(InputValueDefinition("argOne", NamedType("Boolean", Some(AstLocation(50, 3, 27))), None, Vector.empty, None, Vector.empty, Some(AstLocation(42, 3, 19))), InputValueDefinition("argTwo", NamedType("Int", Some(AstLocation(67, 3, 44))), None, Vector.empty, None, Vector.empty, Some(AstLocation(59, 3, 36)))), Vector.empty, None, Vector.empty, Some(AstLocation(36, 3, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Simple union" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "union Hello = World")
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             UnionTypeDefinition(
               "Hello",
               Vector(
-                NamedType("World", Some(Position(14, 1, 15)))),
+                NamedType("World", Some(AstLocation(14, 1, 15)))),
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Union with two types" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "union Hello = Wo | Rld")
 
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             UnionTypeDefinition(
               "Hello",
               Vector(
-                NamedType("Wo", Some(Position(14, 1, 15))),
-                NamedType("Rld", Some(Position(19, 1, 20)))),
+                NamedType("Wo", Some(AstLocation(14, 1, 15))),
+                NamedType("Rld", Some(AstLocation(19, 1, 20)))),
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Scalar" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         "scalar Hello")
       
-      ast.copy(sourceMapper = None) should be (
+      ast.withoutSourceMapper should be (
         Document(
           Vector(
             ScalarTypeDefinition(
@@ -736,16 +740,16 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               Vector.empty,
               None,
               Vector.empty,
-              Some(Position(0, 1, 1))
+              Some(AstLocation(0, 1, 1))
             )),
           Vector.empty,
-          Some(Position(0, 1, 1)),
+          Some(AstLocation(0, 1, 1)),
           None
         ))
     }
 
     "Simple input object" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           input Hello {
             world: String
@@ -758,15 +762,15 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
             InputObjectTypeDefinition(
               "Hello",
               Vector(
-                InputValueDefinition("world", NamedType("String", Some(Position(44, 3, 20))), None, Vector.empty, None, Vector.empty, Some(Position(37, 3, 13)))),
+                InputValueDefinition("world", NamedType("String", Some(AstLocation(44, 3, 20))), None, Vector.empty, None, Vector.empty, Some(AstLocation(37, 3, 13)))),
               Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
@@ -774,7 +778,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
     "Simple input object with args should fail" in {
       import sangria.parser.DeliveryScheme.Throw
 
-      an [SyntaxError] should be thrownBy QueryParser.parse(
+      an [SyntaxError] should be thrownBy parseQuery(
         """
           input Hello {
             world(foo: Int): String
@@ -788,7 +792,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
           type Foo @hello {}
           interface Bar {}
           input Baz {}
-        """, legacyEmptyFields = true)
+        """, ParserConfig.default.withEmptySourceId.withEmptySourceMapper.withLegacyEmptyFields)
 
       ast.withoutSourceMapper should be(
         Document(
@@ -802,12 +806,12 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "hello",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(20, 2, 20))
+                  Some(AstLocation(20, 2, 20))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             ),
             InterfaceTypeDefinition(
               "Bar",
@@ -816,7 +820,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(40, 3, 11))
+              Some(AstLocation(40, 3, 11))
             ),
             InputObjectTypeDefinition(
               "Baz",
@@ -825,16 +829,16 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(67, 4, 11))
+              Some(AstLocation(67, 4, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
     
     "Allow empty fields and values" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           type Foo @hello
           interface Bar
@@ -855,12 +859,12 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "hello",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(20, 2, 20))
+                  Some(AstLocation(20, 2, 20))
                 )),
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             ),
             InterfaceTypeDefinition(
               "Bar",
@@ -869,7 +873,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(37, 3, 11))
+              Some(AstLocation(37, 3, 11))
             ),
             InputObjectTypeDefinition(
               "Baz",
@@ -878,7 +882,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(61, 4, 11))
+              Some(AstLocation(61, 4, 11))
             ),
             EnumTypeDefinition(
               "Test",
@@ -887,7 +891,7 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
               None,
               Vector.empty,
               Vector.empty,
-              Some(Position(81, 5, 11))
+              Some(AstLocation(81, 5, 11))
             ),
             UnionTypeDefinition(
               "Test",
@@ -897,20 +901,20 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "bar",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(112, 6, 22))
+                  Some(AstLocation(112, 6, 22))
                 )),
               None,
               Vector.empty,
-              Some(Position(101, 6, 11))
+              Some(AstLocation(101, 6, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }
 
     "Allow extensions on various types" in {
-      val Success(ast) = QueryParser.parse(
+      val Success(ast) = parseQuery(
         """
           extend type Foo implements Hello & World @hello(ids: [1, 2]) {
            f1: Int
@@ -944,10 +948,10 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
             ObjectTypeExtensionDefinition(
               "Foo",
               Vector(
-                NamedType("Hello", Some(Position(38, 2, 38))),
-                NamedType("World", Some(Position(46, 2, 46)))),
+                NamedType("Hello", Some(AstLocation(38, 2, 38))),
+                NamedType("World", Some(AstLocation(46, 2, 46)))),
               Vector(
-                FieldDefinition("f1", NamedType("Int", Some(Position(89, 3, 16))), Vector.empty, Vector.empty, None, Vector.empty, Some(Position(85, 3, 12)))),
+                FieldDefinition("f1", NamedType("Int", Some(AstLocation(89, 3, 16))), Vector.empty, Vector.empty, None, Vector.empty, Some(AstLocation(85, 3, 12)))),
               Vector(
                 Directive(
                   "hello",
@@ -956,74 +960,74 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                       "ids",
                       ListValue(
                         Vector(
-                          BigIntValue(1, Vector.empty, Some(Position(65, 2, 65))),
-                          BigIntValue(2, Vector.empty, Some(Position(68, 2, 68)))),
+                          BigIntValue(1, Vector.empty, Some(AstLocation(65, 2, 65))),
+                          BigIntValue(2, Vector.empty, Some(AstLocation(68, 2, 68)))),
                         Vector.empty,
-                        Some(Position(64, 2, 64))
+                        Some(AstLocation(64, 2, 64))
                       ),
                       Vector.empty,
-                      Some(Position(59, 2, 59))
+                      Some(AstLocation(59, 2, 59))
                     )),
                   Vector.empty,
-                  Some(Position(52, 2, 52))
+                  Some(AstLocation(52, 2, 52))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(11, 2, 11))
+              Some(AstLocation(11, 2, 11))
             ),
             InterfaceTypeExtensionDefinition(
               "Bar",
               Vector(
-                FieldDefinition("f2", ListType(NotNullType(NamedType("String", Some(Position(186, 8, 18))), Some(Position(186, 8, 18))), Some(Position(185, 8, 17))), Vector.empty, Vector.empty, Some(StringValue("test field", false, None, Vector.empty, Some(Position(156, 7, 13)))), Vector.empty, Some(Position(181, 8, 13)))),
+                FieldDefinition("f2", ListType(NotNullType(NamedType("String", Some(AstLocation(186, 8, 18))), Some(AstLocation(186, 8, 18))), Some(AstLocation(185, 8, 17))), Vector.empty, Vector.empty, Some(StringValue("test field", false, None, Vector.empty, Some(AstLocation(156, 7, 13)))), Vector.empty, Some(AstLocation(181, 8, 13)))),
               Vector(
                 Directive(
                   "dir",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(137, 6, 32))
+                  Some(AstLocation(137, 6, 32))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(116, 6, 11))
+              Some(AstLocation(116, 6, 11))
             ),
             InputObjectTypeExtensionDefinition(
               "Baz",
               Vector(
-                InputValueDefinition("inp", NamedType("Int", Some(Position(253, 12, 17))), Some(BigIntValue(1, Vector.empty, Some(Position(259, 12, 23)))), Vector.empty, None, Vector.empty, Some(Position(248, 12, 12)))),
+                InputValueDefinition("inp", NamedType("Int", Some(AstLocation(253, 12, 17))), Some(BigIntValue(1, Vector.empty, Some(AstLocation(259, 12, 23)))), Vector.empty, None, Vector.empty, Some(AstLocation(248, 12, 12)))),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(218, 11, 11))
+              Some(AstLocation(218, 11, 11))
             ),
             EnumTypeExtensionDefinition(
               "Color",
               Vector(
-                EnumValueDefinition("MAGENTA", Vector.empty, None, Vector.empty, Some(Position(316, 16, 13)))),
+                EnumValueDefinition("MAGENTA", Vector.empty, None, Vector.empty, Some(AstLocation(316, 16, 13)))),
               Vector.empty,
               Vector.empty,
               Vector.empty,
-              Some(Position(284, 15, 11))
+              Some(AstLocation(284, 15, 11))
             ),
             UnionTypeExtensionDefinition(
               "Test",
               Vector(
-                NamedType("More", Some(Position(372, 19, 36))),
-                NamedType("Types", Some(Position(379, 19, 43)))),
+                NamedType("More", Some(AstLocation(372, 19, 36))),
+                NamedType("Types", Some(AstLocation(379, 19, 43)))),
               Vector(
                 Directive(
                   "bar",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(365, 19, 29))
+                  Some(AstLocation(365, 19, 29))
                 )),
               Vector.empty,
-              Some(Position(347, 19, 11))
+              Some(AstLocation(347, 19, 11))
             ),
             ObjectTypeExtensionDefinition(
               "EmptyFoo",
               Vector(
-                NamedType("Hello1", Some(Position(428, 21, 43))),
-                NamedType("World1", Some(Position(437, 21, 52)))),
+                NamedType("Hello1", Some(AstLocation(428, 21, 43))),
+                NamedType("World1", Some(AstLocation(437, 21, 52)))),
               Vector.empty,
               Vector(
                 Directive(
@@ -1033,20 +1037,20 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                       "ids",
                       ListValue(
                         Vector(
-                          BigIntValue(1, Vector.empty, Some(Position(458, 21, 73))),
-                          BigIntValue(2, Vector.empty, Some(Position(461, 21, 76)))),
+                          BigIntValue(1, Vector.empty, Some(AstLocation(458, 21, 73))),
+                          BigIntValue(2, Vector.empty, Some(AstLocation(461, 21, 76)))),
                         Vector.empty,
-                        Some(Position(457, 21, 72))
+                        Some(AstLocation(457, 21, 72))
                       ),
                       Vector.empty,
-                      Some(Position(452, 21, 67))
+                      Some(AstLocation(452, 21, 67))
                     )),
                   Vector.empty,
-                  Some(Position(444, 21, 59))
+                  Some(AstLocation(444, 21, 59))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(396, 21, 11))
+              Some(AstLocation(396, 21, 11))
             ),
             InterfaceTypeExtensionDefinition(
               "EmptyBar",
@@ -1056,11 +1060,11 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "dir1",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(501, 22, 37))
+                  Some(AstLocation(501, 22, 37))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(475, 22, 11))
+              Some(AstLocation(475, 22, 11))
             ),
             InputObjectTypeExtensionDefinition(
               "EmptyBaz",
@@ -1070,11 +1074,11 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "extraDir",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(539, 23, 33))
+                  Some(AstLocation(539, 23, 33))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(517, 23, 11))
+              Some(AstLocation(517, 23, 11))
             ),
             EnumTypeExtensionDefinition(
               "EmptyColor",
@@ -1084,11 +1088,11 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "beautiful",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(582, 24, 34))
+                  Some(AstLocation(582, 24, 34))
                 )),
               Vector.empty,
               Vector.empty,
-              Some(Position(559, 24, 11))
+              Some(AstLocation(559, 24, 11))
             ),
             UnionTypeExtensionDefinition(
               "EmptyTest",
@@ -1098,13 +1102,13 @@ class SchemaParserSpec extends WordSpec with Matchers with StringMatchers {
                   "bar",
                   Vector.empty,
                   Vector.empty,
-                  Some(Position(626, 25, 34))
+                  Some(AstLocation(626, 25, 34))
                 )),
               Vector.empty,
-              Some(Position(603, 25, 11))
+              Some(AstLocation(603, 25, 11))
             )),
           Vector.empty,
-          Some(Position(11, 2, 11)),
+          Some(AstLocation(11, 2, 11)),
           None
         ))
     }

--- a/src/test/scala/sangria/renderer/QueryRendererSpec.scala
+++ b/src/test/scala/sangria/renderer/QueryRendererSpec.scala
@@ -2,7 +2,7 @@ package sangria.renderer
 
 import org.scalatest.{Matchers, WordSpec}
 import sangria.ast._
-import sangria.parser.QueryParser
+import sangria.parser.{ParserConfig, QueryParser}
 import sangria.util.{DebugUtil, FileUtil, StringMatchers}
 import sangria.ast
 import sangria.macros._
@@ -24,9 +24,9 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
         val Success(prettyParsed) = QueryParser.parse(prettyRendered)
         val Success(compactParsed) = QueryParser.parse(compactRendered)
 
-        AstNode.withoutPosition(ast) should be (AstNode.withoutPosition(prettyParsed))
-        AstNode.withoutPosition(ast, stripComments = true) should be (
-          AstNode.withoutPosition(compactParsed, stripComments = true))
+        AstNode.withoutAstLocations(ast) should be (AstNode.withoutAstLocations(prettyParsed))
+        AstNode.withoutAstLocations(ast, stripComments = true) should be (
+          AstNode.withoutAstLocations(compactParsed, stripComments = true))
 
         compactRendered should be (
           "query queryName($foo:ComplexType,$site:Site=MOBILE){whoever123is:node(id:[123,456]){" +
@@ -575,9 +575,9 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
         val Success(prettyParsed) = QueryParser.parse(prettyRendered)
         val Success(compactParsed) = QueryParser.parse(compactRendered)
 
-        AstNode.withoutPosition(ast) should be (AstNode.withoutPosition(prettyParsed))
-        AstNode.withoutPosition(ast, stripComments = true) should be (
-          AstNode.withoutPosition(compactParsed, stripComments = true))
+        AstNode.withoutAstLocations(ast) should be (AstNode.withoutAstLocations(prettyParsed))
+        AstNode.withoutAstLocations(ast, stripComments = true) should be (
+          AstNode.withoutAstLocations(compactParsed, stripComments = true))
 
         compactRendered should be (
           "query FetchLukeAndLeiaAliased($someVar:String=\"hello \\\\\\n  world\"" +
@@ -609,9 +609,9 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
         val Success(prettyParsed) = QueryParser.parse(prettyRendered)
         val Success(compactParsed) = QueryParser.parse(compactRendered)
 
-        AstNode.withoutPosition(withoutRaw(ast)) should be (AstNode.withoutPosition(withoutRaw(prettyParsed)))
-        AstNode.withoutPosition(withoutRaw(ast, block = false), stripComments = true) should be (
-          AstNode.withoutPosition(withoutRaw(compactParsed, block = false), stripComments = true))
+        AstNode.withoutAstLocations(withoutRaw(ast)) should be (AstNode.withoutAstLocations(withoutRaw(prettyParsed)))
+        AstNode.withoutAstLocations(withoutRaw(ast, block = false), stripComments = true) should be (
+          AstNode.withoutAstLocations(withoutRaw(compactParsed, block = false), stripComments = true))
 
         compactRendered should be (
           "query FetchLukeAndLeiaAliased($someVar:String=\"hello \\\\\\n  world\"" +
@@ -632,7 +632,7 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
 
         QueryParser.parse(query).isFailure should be (true)
 
-        val Success(ast) = QueryParser.parse(query, experimentalFragmentVariables = true)
+        val Success(ast) = QueryParser.parse(query, ParserConfig.default.withExperimentalFragmentVariables)
 
         ast.renderPretty should equal (
           """fragment Foo($a: ComplexType, $b: Boolean = false) on TestType {
@@ -673,11 +673,11 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
         val Success(prettyParsed) = QueryParser.parse(prettyRendered)
         val Success(compactParsed) = QueryParser.parse(compactRendered)
 
-        AstNode.withoutPosition(ast, stripComments = true) should be (
-          AstNode.withoutPosition(prettyParsed, stripComments = true))
+        AstNode.withoutAstLocations(ast, stripComments = true) should be (
+          AstNode.withoutAstLocations(prettyParsed, stripComments = true))
 
-        AstNode.withoutPosition(noBlock(ast), stripComments = true) should be (
-          AstNode.withoutPosition(noBlock(compactParsed), stripComments = true))
+        AstNode.withoutAstLocations(noBlock(ast), stripComments = true) should be (
+          AstNode.withoutAstLocations(noBlock(compactParsed), stripComments = true))
 
         compactRendered should equal (
           """schema{query:QueryType mutation:MutationType}
@@ -818,11 +818,11 @@ class QueryRendererSpec extends WordSpec with Matchers with StringMatchers {
         val Success(prettyParsed) = QueryParser.parse(prettyRendered)
         val Success(compactParsed) = QueryParser.parse(compactRendered)
 
-        AstNode.withoutPosition(ast, stripComments = true) should be (
-          AstNode.withoutPosition(prettyParsed, stripComments = true))
+        AstNode.withoutAstLocations(ast, stripComments = true) should be (
+          AstNode.withoutAstLocations(prettyParsed, stripComments = true))
 
-        AstNode.withoutPosition(ast, stripComments = true) should be (
-            AstNode.withoutPosition(compactParsed, stripComments = true))
+        AstNode.withoutAstLocations(ast, stripComments = true) should be (
+            AstNode.withoutAstLocations(compactParsed, stripComments = true))
 
         compactRendered should equal (
           """type Foo implements Bar@dfdsfsdf(aaa:1)@qqq(aaa:[1,2]){one:Type two(argument:InputType!):Type three(argument:InputType@aaa(c:b),other:String@ddd(aa:1)@xxx(ttt:"sdfdsf")):Int four(argument:String="string"):String five(argument:[String]=["string","string"]):String@aaaa(if:true) six(argument:InputType={key:"value"}):Type another(argument:InputType={key:"value"},mylist:[String]=["string","string"]):Type}

--- a/src/test/scala/sangria/util/CatsSupport.scala
+++ b/src/test/scala/sangria/util/CatsSupport.scala
@@ -318,10 +318,10 @@ trait CatsSupport extends FutureResultSupport { this: WordSpec with Matchers ⇒
     val withLoc = violation.asInstanceOf[AstNodeLocation]
 
     withClue(s"Violation does not have all positions: ${violation.errorMessage}") {
-      withLoc.positions should have size locations.size
+      withLoc.locations should have size locations.size
     }
 
-    withLoc.positions.zipWithIndex foreach { case (pos, idx) ⇒
+    withLoc.locations.zipWithIndex foreach { case (pos, idx) ⇒
       withClue(s"Violation position mismatch (line: ${locations(idx).line}, column: ${locations(idx).column}): ${violation.errorMessage}") {
         ErrorLocation(pos.line, pos.column) should be(locations(idx))
       }

--- a/src/test/scala/sangria/util/GraphQlSupport.scala
+++ b/src/test/scala/sangria/util/GraphQlSupport.scala
@@ -110,7 +110,7 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
 
           message.contains(expected) && {
             error match {
-              case n: AstNodeLocation ⇒ n.positions.map(p ⇒ Pos(p.line, p.column)) == pos
+              case n: AstNodeLocation ⇒ n.locations.map(p ⇒ Pos(p.line, p.column)) == pos
               case _ ⇒ false
             }
           }

--- a/src/test/scala/sangria/util/ValidationSupport.scala
+++ b/src/test/scala/sangria/util/ValidationSupport.scala
@@ -212,7 +212,7 @@ trait ValidationSupport extends Matchers {
       withClue(s"Expected error not found: $expected${pos map (p ⇒ s" (line ${p.line}, column ${p.col})") mkString "; "}. Actual:\n${errors map (_.errorMessage) mkString "\n"}") {
         errors exists { error ⇒
           error.errorMessage.contains(expected) && {
-            val errorPositions = error.asInstanceOf[AstNodeViolation].positions
+            val errorPositions = error.asInstanceOf[AstNodeViolation].locations
 
             errorPositions should have size pos.size
 


### PR DESCRIPTION
Improvements include:

* Different schema elements retain the information about SDL `AstNode`s that were used to create them (in addition to the directives).
* `AstLocation` now replaces the `Position` and holds additional field: `sourceId`.
* Introduced `AggregateSourceMapper` and improved `Document` merge. It is now possible to show proper error messages and source locations even for AST that was parsed from different sources (files, URLs, etc.). 

These improvements might also be quite helpful for recently discussed "import" functionality where the schema SDL is defined in multiple files.