### PR TITLE
Don't allow ObjectTypes derived from case classes to overwrite each other

### DIFF
--- a/src/main/scala/sangria/validation/Violation.scala
+++ b/src/main/scala/sangria/validation/Violation.scala
@@ -444,6 +444,11 @@ case class ConflictingTypeDefinitionViolation(typeName: String, conflictingTypes
   lazy val errorMessage = s"Type name '$typeName' is used for several conflicting GraphQL type kinds: ${conflictingTypes mkString ", "}. Conflict found in $parentInfo."
 }
 
+case class ConflictingObjectTypeCaseClassViolation(typeName: String, parentInfo: String) extends Violation {
+  // Ideally this error message should include the conflicting classes canonical names but due to https://issues.scala-lang.org/browse/SI-2034 that's not possible
+  lazy val errorMessage = s"""Type name '$typeName' is used for several conflicting GraphQL ObjectTypes based on different classes. Conflict found in $parentInfo. One possible fix is to use ObjectTypeName like this: deriveObjectType[Foo, Bar](ObjectTypeName("OtherBar")) to avoid that two ObjectTypes have the same name."""
+}
+
 case class ReservedTypeNameViolation(typeName: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Type name '$typeName' must not begin with '__', which is reserved by GraphQL introspection."
 }

--- a/src/test/scala/sangria/schema/bar/Baz.scala
+++ b/src/test/scala/sangria/schema/bar/Baz.scala
@@ -1,0 +1,3 @@
+package sangria.schema.bar
+
+case class Baz(y: String, z: Double)

--- a/src/test/scala/sangria/schema/foo/Baz.scala
+++ b/src/test/scala/sangria/schema/foo/Baz.scala
@@ -1,0 +1,3 @@
+package sangria.schema.foo
+
+case class Baz(x: Int)


### PR DESCRIPTION
If two or more case classes with the same name in different packages are used to derive `ObjectType`s Sangria will silently choose one of them and ignore the others. This PR makes it so that an exception is thrown if two `ObjectType`s are found with the same name but derived from different case classes.