### PR TITLE
Transform enum values' names with a macro setting

### DIFF
--- a/src/main/scala/sangria/macros/derive/DeriveEnumSetting.scala
+++ b/src/main/scala/sangria/macros/derive/DeriveEnumSetting.scala
@@ -13,3 +13,5 @@ case class RenameValue(value: String, graphqlName: String) extends DeriveEnumSet
 
 case class IncludeValues(values: String*) extends DeriveEnumSetting
 case class ExcludeValues(fieldNames: String*) extends DeriveEnumSetting
+
+case class TransformValueNames(transformer: String ⇒ String) extends DeriveEnumSetting

--- a/src/test/scala/sangria/macros/derive/DeriveEnumTypeMacroSpec.scala
+++ b/src/test/scala/sangria/macros/derive/DeriveEnumTypeMacroSpec.scala
@@ -153,6 +153,18 @@ class DeriveEnumTypeMacroSpec extends WordSpec with Matchers {
       enum.values.map(_.name).sorted should be ("DARK1_BLUE_FOO_STUFF" :: "DARK_BLUE" :: "NORMAL_RED" :: Nil)
     }
 
+    "allow transformation of GraphQL enum values' names" in {
+      val singletonEnum = deriveEnumType[Difficulty](TransformValueNames("Difficulty" + _))
+      val singletonEnumUpperCase = deriveEnumType[Difficulty](TransformValueNames("Difficulty" + _), UppercaseValues)
+      val enum = deriveEnumType[ColorAnnotated.Value](TransformValueNames("Color" + _))
+      val enumUpperCase = deriveEnumType[ColorAnnotated.Value](TransformValueNames("Color" + _), UppercaseValues)
+
+      singletonEnum.values.map(_.name).sorted should be ("DifficultyEasy" :: "DifficultyHard" :: "DifficultyMedium" :: Nil)
+      singletonEnumUpperCase.values.map(_.name).sorted should be ("DIFFICULTY_EASY" :: "DIFFICULTY_HARD" :: "DIFFICULTY_MEDIUM" :: Nil)
+      enum.values.map(_.name).sorted should be ("ColorDark1Blue_FooStuff" :: "ColorDarkBlue" :: "ColorNormalRed" :: Nil)
+      enumUpperCase.values.map(_.name).sorted should be ("COLOR_DARK1_BLUE_FOO_STUFF" :: "COLOR_DARK_BLUE" :: "COLOR_NORMAL_RED" :: Nil)
+    }
+
     "allow to set name, description and deprecationReason with config" in {
       val singletonEnum = deriveEnumType[Fruit](
         DocumentValue("RedApple", "apple!", deprecationReason = Some("foo")),


### PR DESCRIPTION
Added a derivation setting for transforming GraphQL enum values, similar to `TransformFieldNames`.
#### Use case
Since graphql has no definition scopes, the following scala enums will cause collision:
```scala
sealed trait Color
object Color {
  case object Red extends Color
  case object Blue extends Color
  case object Green extends Color
  // etc
}

sealed trait TrafficLight
object TrafficLight {
  case object Red extends TrafficLight
  case object Yellow extends TrafficLight
  case object Green extends TrafficLight
}
```

The solution might be adding a prefix to graphql enum values, renaming, for example, traffic light colors to `TrafficLightRed`, `TrafficLightYellow` and `TrafficLightGreen`.

------------------------

The proposed setting should allow to do it in bulk.