### PR TITLE
Fix BeforeFieldResult field name

### DIFF
--- a/src/main/scala/sangria/execution/middleware.scala
+++ b/src/main/scala/sangria/execution/middleware.scala
@@ -120,7 +120,7 @@ case class MiddlewareQueryContext[+Ctx, RootVal, Input](
   queryReducerTiming: TimeMeasurement)
 
 case class BeforeFieldResult[Ctx, FieldVal](
-  fileVal: FieldVal = (),
+  fieldVal: FieldVal = (),
   actionOverride: Option[Action[Ctx, _]] = None,
   attachment: Option[MiddlewareAttachment] = None)
 


### PR DESCRIPTION
Did a code search and found no use for this field. So this should be a safe fix.