### PR TITLE
[WIP] Add filterFields to Schema

### DIFF
--- a/src/main/scala/sangria/schema/Schema.scala
+++ b/src/main/scala/sangria/schema/Schema.scala
@@ -11,6 +11,7 @@ import sangria.{ast, introspection}
 import sangria.validation._
 import sangria.introspection._
 import sangria.renderer.{SchemaFilter, SchemaRenderer}
+import sangria.schema.transformations.TransformSchema
 import sangria.streaming.SubscriptionStreamLike
 
 import scala.annotation.implicitNotFound
@@ -904,6 +905,10 @@ case class Schema[Ctx, Val](
     case ast.NamedType(name, _) ⇒ outputTypes get name map (ot ⇒ if (topLevel) ot else OptionType(ot))
     case ast.NotNullType(ofType, _) ⇒ getOutputType(ofType) collect {case OptionType(ot) ⇒ ot}
     case ast.ListType(ofType, _) ⇒ getOutputType(ofType) map (ListType(_))
+  }
+
+  def filterFields(filter: TransformSchema.FieldFilter[Ctx]): Schema[Ctx, Val] = {
+    TransformSchema.filterFields[Ctx, Val](this, filter)
   }
 
   lazy val directImplementations: Map[String, Vector[ObjectLikeType[_, _]]] = {

--- a/src/main/scala/sangria/schema/transformations/FieldFilteredAstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/transformations/FieldFilteredAstSchemaBuilder.scala
@@ -1,0 +1,26 @@
+package sangria.schema.transformations
+
+import sangria.ast
+import sangria.schema.transformations.TransformSchema.FieldFilter
+import sangria.schema.{AstSchemaMaterializer, DefaultAstSchemaBuilder, Field, InterfaceType, MatOrigin, ObjectType}
+
+
+class FieldFilteredAstSchemaBuilder[Ctx](filter: FieldFilter[Ctx]) extends DefaultAstSchemaBuilder[Ctx] {
+  override def extendObjectType(
+                        origin: MatOrigin,
+                        existing: ObjectType[Ctx, _],
+                        extensions: List[ast.ObjectTypeExtensionDefinition],
+                        fields: () ⇒ List[Field[Ctx, Any]],
+                        interfaces: List[InterfaceType[Ctx, Any]],
+                        mat: AstSchemaMaterializer[Ctx]): ObjectType[Ctx, Any] = {
+    super.extendObjectType(
+      origin = origin,
+      existing = existing,
+      extensions = extensions,
+      fields = () => filter(fields()),
+      interfaces = interfaces,
+      mat = mat
+    )
+  }
+}
+

--- a/src/main/scala/sangria/schema/transformations/TransformSchema.scala
+++ b/src/main/scala/sangria/schema/transformations/TransformSchema.scala
@@ -1,0 +1,22 @@
+package sangria.schema.transformations
+
+import sangria.ast.{Document, ObjectTypeExtensionDefinition}
+import sangria.schema.{AstSchemaMaterializer, Field, Schema}
+
+object TransformSchema {
+  type FieldFilter[Ctx] = List[Field[Ctx, Any]] => List[Field[Ctx, Any]]
+
+  def filterFields[Ctx, Val](schema: Schema[Ctx, Val], filter: FieldFilter[Ctx]): Schema[Ctx, Val] = {
+    AstSchemaMaterializer.extendSchema(
+      schema,
+      emptyExtensionDocument(schema.query.name),
+      new FieldFilteredAstSchemaBuilder[Ctx](filter)
+    )
+  }
+
+  private def emptyExtensionDocument(queryName: String): Document = {
+    Document(Vector(
+      ObjectTypeExtensionDefinition(queryName, Vector.empty, Vector.empty)
+    ))
+  }
+}


### PR DESCRIPTION
This is an adapted version of the example provided on https://github.com/sangria-graphql/sangria/issues/418#issuecomment-439870854 

This approach extends an existent schema and apply a filter defined by the user to the defined fields.

### Usage

There are two ways of using it, the first one is calling `TransformSchema.filterFields` and provide a schema and a filter. 

``` scala
  TransformSchema.filterFields(aSchema, _.filterNot(_.tags.contains(Preview)))
```

The second one is a syntactic sugar, it consists  on calling `filterFields` directly on an existent schema.

``` scala
  aSchema.filterFields(_.filterNot(_.tags.contains(Preview)))
```



## Tasks
- [ ] Add tests
- [ ] Update documentation

