### PR TITLE
Extract extension methods from AstSchemaBuilder 

### DIFF
--- a/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -1,15 +1,15 @@
 package sangria.schema
 
 import language.existentials
-
 import sangria.ast
 import sangria.execution.FieldTag
 import sangria.marshalling.{FromInput, MarshallerCapability, ScalarValueInfo, ToInput}
+import sangria.schema.extension.AstSchemaExtender
 import sangria.validation.Violation
 
 import scala.reflect.ClassTag
 
-trait AstSchemaBuilder[Ctx] {
+trait AstSchemaBuilder[Ctx] extends AstSchemaExtender[Ctx] {
   def additionalTypeExtensionDefs: List[ast.TypeExtensionDefinition]
   def additionalTypes: List[MaterializedType]
   def additionalDirectiveDefs: List[ast.DirectiveDefinition]
@@ -26,16 +26,6 @@ trait AstSchemaBuilder[Ctx] {
     directives: List[Directive],
     mat: AstSchemaMaterializer[Ctx]): Schema[Ctx, Any]
 
-  def extendSchema[Val](
-    originalSchema: Schema[Ctx, Val],
-    extensions: List[ast.SchemaExtensionDefinition],
-    queryType: ObjectType[Ctx, Val],
-    mutationType: Option[ObjectType[Ctx, Val]],
-    subscriptionType: Option[ObjectType[Ctx, Val]],
-    additionalTypes: List[Type with Named],
-    directives: List[Directive],
-    mat: AstSchemaMaterializer[Ctx]): Schema[Ctx, Val]
-
   def buildObjectType(
     origin: MatOrigin,
     definition: ast.ObjectTypeDefinition,
@@ -44,13 +34,6 @@ trait AstSchemaBuilder[Ctx] {
     interfaces: List[InterfaceType[Ctx, Any]],
     mat: AstSchemaMaterializer[Ctx]): Option[ObjectType[Ctx, Any]]
 
-  def extendObjectType(
-    origin: MatOrigin,
-    existing: ObjectType[Ctx, _],
-    extensions: List[ast.ObjectTypeExtensionDefinition],
-    fields: () ⇒ List[Field[Ctx, Any]],
-    interfaces: List[InterfaceType[Ctx, Any]],
-    mat: AstSchemaMaterializer[Ctx]): ObjectType[Ctx, Any]
 
   def buildInputObjectType(
     origin: MatOrigin,
@@ -73,33 +56,12 @@ trait AstSchemaBuilder[Ctx] {
     fields: () ⇒ List[Field[Ctx, Any]],
     mat: AstSchemaMaterializer[Ctx]): Option[InterfaceType[Ctx, Any]]
 
-  def extendInterfaceType(
-    origin: MatOrigin,
-    existing: InterfaceType[Ctx, _],
-    extensions: List[ast.InterfaceTypeExtensionDefinition],
-    fields: () ⇒ List[Field[Ctx, Any]],
-    mat: AstSchemaMaterializer[Ctx]): InterfaceType[Ctx, Any]
-
   def buildUnionType(
     origin: MatOrigin,
     extensions: Vector[ast.UnionTypeExtensionDefinition],
     definition: ast.UnionTypeDefinition,
     types: List[ObjectType[Ctx, _]],
     mat: AstSchemaMaterializer[Ctx]): Option[UnionType[Ctx]]
-
-  def extendUnionType(
-    origin: MatOrigin,
-    extensions: Vector[ast.UnionTypeExtensionDefinition],
-    existing: UnionType[Ctx],
-    types: List[ObjectType[Ctx, _]],
-    mat: AstSchemaMaterializer[Ctx]): UnionType[Ctx]
-
-  def extendScalarAlias[T, ST](
-    origin: MatOrigin,
-    extensions: Vector[ast.ScalarTypeExtensionDefinition],
-    existing: ScalarAlias[T, ST],
-    aliasFor: ScalarType[ST],
-    mat: AstSchemaMaterializer[Ctx]): ScalarAlias[T, ST]
 
   def buildScalarType(
     origin: MatOrigin,
@@ -148,48 +110,6 @@ trait AstSchemaBuilder[Ctx] {
     definition: ast.FieldDefinition,
     arguments: List[Argument[_]],
     mat: AstSchemaMaterializer[Ctx]): OutputType[Any]
-
-  def extendField(
-    origin: MatOrigin,
-    typeDefinition: Option[ObjectLikeType[Ctx, _]],
-    existing: Field[Ctx, Any],
-    fieldType: OutputType[_],
-    arguments: List[Argument[_]],
-    mat: AstSchemaMaterializer[Ctx]): Field[Ctx, Any]
-
-  def extendArgument(
-    origin: MatOrigin,
-    typeDefinition: Option[ObjectLikeType[Ctx, _]],
-    field: Field[Ctx, Any],
-    argument: Argument[Any],
-    argumentType: InputType[_],
-    mat: AstSchemaMaterializer[Ctx]): Argument[Any]
-
-  def extendInputField(
-    origin: MatOrigin,
-    typeDefinition: InputObjectType[_],
-    existing: InputField[Any],
-    fieldType: InputType[_],
-    mat: AstSchemaMaterializer[Ctx]): InputField[Any]
-
-  def extendFieldType(
-    origin: MatOrigin,
-    typeDefinition: Option[ObjectLikeType[Ctx, _]],
-    existing: Field[Ctx, Any],
-    mat: AstSchemaMaterializer[Ctx]): OutputType[Any]
-
-  def extendArgumentType(
-    origin: MatOrigin,
-    typeDefinition: Option[ObjectLikeType[Ctx, _]],
-    field: Field[Ctx, Any],
-    existing: Argument[Any],
-    mat: AstSchemaMaterializer[Ctx]): InputType[Any]
-
-  def extendInputFieldType(
-    origin: MatOrigin,
-    typeDefinition: InputObjectType[_],
-    existing: InputField[Any],
-    mat: AstSchemaMaterializer[Ctx]): InputType[Any]
 
   def buildInputField(
     origin: MatOrigin,

--- a/src/main/scala/sangria/schema/extension/AstSchemaExtender.scala
+++ b/src/main/scala/sangria/schema/extension/AstSchemaExtender.scala
@@ -1,0 +1,88 @@
+package sangria.schema.extension
+
+import sangria.ast
+import sangria.schema.{Argument, AstSchemaMaterializer, Directive, Field, InputField, InputObjectType, InputType, InterfaceType, MatOrigin, Named, ObjectLikeType, ObjectType, OutputType, ScalarAlias, ScalarType, Schema, Type, UnionType}
+
+trait AstSchemaExtender[Ctx] {
+
+  def extendArgument(
+                      origin: MatOrigin,
+                      typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                      field: Field[Ctx, Any],
+                      argument: Argument[Any],
+                      argumentType: InputType[_],
+                      mat: AstSchemaMaterializer[Ctx]): Argument[Any]
+
+  def extendArgumentType(
+                          origin: MatOrigin,
+                          typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                          field: Field[Ctx, Any],
+                          existing: Argument[Any],
+                          mat: AstSchemaMaterializer[Ctx]): InputType[Any]
+
+  def extendField(
+                   origin: MatOrigin,
+                   typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                   existing: Field[Ctx, Any],
+                   fieldType: OutputType[_],
+                   arguments: List[Argument[_]],
+                   mat: AstSchemaMaterializer[Ctx]): Field[Ctx, Any]
+
+  def extendFieldType(
+                       origin: MatOrigin,
+                       typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                       existing: Field[Ctx, Any],
+                       mat: AstSchemaMaterializer[Ctx]): OutputType[Any]
+
+  def extendInputField(
+                        origin: MatOrigin,
+                        typeDefinition: InputObjectType[_],
+                        existing: InputField[Any],
+                        fieldType: InputType[_],
+                        mat: AstSchemaMaterializer[Ctx]): InputField[Any]
+
+  def extendInputFieldType(
+                            origin: MatOrigin,
+                            typeDefinition: InputObjectType[_],
+                            existing: InputField[Any],
+                            mat: AstSchemaMaterializer[Ctx]): InputType[Any]
+
+  def extendInterfaceType(
+                           origin: MatOrigin,
+                           existing: InterfaceType[Ctx, _],
+                           extensions: List[ast.InterfaceTypeExtensionDefinition],
+                           fields: () ⇒ List[Field[Ctx, Any]],
+                           mat: AstSchemaMaterializer[Ctx]): InterfaceType[Ctx, Any]
+
+  def extendObjectType(
+                        origin: MatOrigin,
+                        existing: ObjectType[Ctx, _],
+                        extensions: List[ast.ObjectTypeExtensionDefinition],
+                        fields: () ⇒ List[Field[Ctx, Any]],
+                        interfaces: List[InterfaceType[Ctx, Any]],
+                        mat: AstSchemaMaterializer[Ctx]): ObjectType[Ctx, Any]
+
+  def extendScalarAlias[T, ST](
+                                origin: MatOrigin,
+                                extensions: Vector[ast.ScalarTypeExtensionDefinition],
+                                existing: ScalarAlias[T, ST],
+                                aliasFor: ScalarType[ST],
+                                mat: AstSchemaMaterializer[Ctx]): ScalarAlias[T, ST]
+
+  def extendSchema[Val](
+                         originalSchema: Schema[Ctx, Val],
+                         extensions: List[ast.SchemaExtensionDefinition],
+                         queryType: ObjectType[Ctx, Val],
+                         mutationType: Option[ObjectType[Ctx, Val]],
+                         subscriptionType: Option[ObjectType[Ctx, Val]],
+                         additionalTypes: List[Type with Named],
+                         directives: List[Directive],
+                         mat: AstSchemaMaterializer[Ctx]): Schema[Ctx, Val]
+
+  def extendUnionType(
+                       origin: MatOrigin,
+                       extensions: Vector[ast.UnionTypeExtensionDefinition],
+                       existing: UnionType[Ctx],
+                       types: List[ObjectType[Ctx, _]],
+                       mat: AstSchemaMaterializer[Ctx]): UnionType[Ctx]
+}

--- a/src/main/scala/sangria/schema/extension/DefaultAstSchemaExtender.scala
+++ b/src/main/scala/sangria/schema/extension/DefaultAstSchemaExtender.scala
@@ -7,31 +7,31 @@ import scala.reflect.ClassTag
 
 class DefaultAstSchemaExtender[Ctx] extends AstSchemaExtender[Ctx] {
 
-  def extendArgument(
-                      origin: MatOrigin,
-                      typeDefinition: Option[ObjectLikeType[Ctx, _]],
-                      field: Field[Ctx, Any],
-                      argument: Argument[Any],
-                      argumentType: InputType[_],
-                      mat: AstSchemaMaterializer[Ctx]): Argument[Any] =
+  override def extendArgument(
+                               origin: MatOrigin,
+                               typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                               field: Field[Ctx, Any],
+                               argument: Argument[Any],
+                               argumentType: InputType[_],
+                               mat: AstSchemaMaterializer[Ctx]): Argument[Any] =
     argument.copy(argumentType = argumentType)
 
 
-  def extendArgumentType(
-                          origin: MatOrigin,
-                          typeDefinition: Option[ObjectLikeType[Ctx, _]],
-                          field: Field[Ctx, Any],
-                          existing: Argument[Any],
-                          mat: AstSchemaMaterializer[Ctx]): InputType[Any] =
+  override def extendArgumentType(
+                                   origin: MatOrigin,
+                                   typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                                   field: Field[Ctx, Any],
+                                   existing: Argument[Any],
+                                   mat: AstSchemaMaterializer[Ctx]): InputType[Any] =
     mat.getInputTypeFromExistingType(origin, existing.argumentType)
 
-  def extendField(
-                   origin: MatOrigin,
-                   typeDefinition: Option[ObjectLikeType[Ctx, _]],
-                   existing: Field[Ctx, Any],
-                   fieldType: OutputType[_],
-                   arguments: List[Argument[_]],
-                   mat: AstSchemaMaterializer[Ctx]) =
+  override def extendField(
+                            origin: MatOrigin,
+                            typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                            existing: Field[Ctx, Any],
+                            fieldType: OutputType[_],
+                            arguments: List[Argument[_]],
+                            mat: AstSchemaMaterializer[Ctx]): Field[Ctx, Any] =
     existing.copy(
       fieldType = fieldType,
       arguments = arguments,
@@ -45,45 +45,45 @@ class DefaultAstSchemaExtender[Ctx] extends AstSchemaExtender[Ctx] {
                            fieldType: OutputType[_],
                            mat: AstSchemaMaterializer[Ctx]): Context[Ctx, Any] ⇒ Action[Ctx, _] = existing.resolve
 
-  def extendFieldType(
-                       origin: MatOrigin,
-                       typeDefinition: Option[ObjectLikeType[Ctx, _]],
-                       existing: Field[Ctx, Any],
-                       mat: AstSchemaMaterializer[Ctx]): OutputType[Any] =
+  override def extendFieldType(
+                                origin: MatOrigin,
+                                typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                                existing: Field[Ctx, Any],
+                                mat: AstSchemaMaterializer[Ctx]): OutputType[Any] =
     mat.getTypeFromExistingType(origin, existing.fieldType)
 
-  def extendInputField(
-                        origin: MatOrigin,
-                        typeDefinition: InputObjectType[_],
-                        existing: InputField[Any],
-                        fieldType: InputType[_],
-                        mat: AstSchemaMaterializer[Ctx]) =
+  override def extendInputField(
+                                 origin: MatOrigin,
+                                 typeDefinition: InputObjectType[_],
+                                 existing: InputField[Any],
+                                 fieldType: InputType[_],
+                                 mat: AstSchemaMaterializer[Ctx]): InputField[Any] =
     existing.copy(fieldType = fieldType)
 
-  def extendInputFieldType(
-                            origin: MatOrigin,
-                            typeDefinition: InputObjectType[_],
-                            existing: InputField[Any],
-                            mat: AstSchemaMaterializer[Ctx]) =
+  override def extendInputFieldType(
+                                     origin: MatOrigin,
+                                     typeDefinition: InputObjectType[_],
+                                     existing: InputField[Any],
+                                     mat: AstSchemaMaterializer[Ctx]): InputType[Any] =
     mat.getInputTypeFromExistingType(origin, existing.fieldType)
 
-  def extendInterfaceType(
-                           origin: MatOrigin,
-                           existing: InterfaceType[Ctx, _],
-                           extensions: List[ast.InterfaceTypeExtensionDefinition],
-                           fields: () ⇒ List[Field[Ctx, Any]],
-                           mat: AstSchemaMaterializer[Ctx]) =
+  override def extendInterfaceType(
+                                    origin: MatOrigin,
+                                    existing: InterfaceType[Ctx, _],
+                                    extensions: List[ast.InterfaceTypeExtensionDefinition],
+                                    fields: () ⇒ List[Field[Ctx, Any]],
+                                    mat: AstSchemaMaterializer[Ctx]) =
     existing.copy(fieldsFn = fields, manualPossibleTypes = () ⇒ Nil, interfaces = Nil,
       astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
       astNodes = existing.astNodes ++ extensions)
 
-  def extendObjectType(
-                        origin: MatOrigin,
-                        existing: ObjectType[Ctx, _],
-                        extensions: List[ast.ObjectTypeExtensionDefinition],
-                        fields: () ⇒ List[Field[Ctx, Any]],
-                        interfaces: List[InterfaceType[Ctx, Any]],
-                        mat: AstSchemaMaterializer[Ctx]) =
+  override def extendObjectType(
+                                 origin: MatOrigin,
+                                 existing: ObjectType[Ctx, _],
+                                 extensions: List[ast.ObjectTypeExtensionDefinition],
+                                 fields: () ⇒ List[Field[Ctx, Any]],
+                                 interfaces: List[InterfaceType[Ctx, Any]],
+                                 mat: AstSchemaMaterializer[Ctx]): ObjectType[Ctx, Any] =
     extendedObjectTypeInstanceCheck(origin, existing, extensions) match {
       case Some(fn) ⇒
         existing.copy(
@@ -104,23 +104,23 @@ class DefaultAstSchemaExtender[Ctx] extends AstSchemaExtender[Ctx] {
   def extendedObjectTypeInstanceCheck(origin: MatOrigin, tpe: ObjectType[Ctx, _], extensions: List[ast.ObjectTypeExtensionDefinition]): Option[(Any, Class[_]) ⇒ Boolean] =
     None
 
-  def extendScalarAlias[T, ST](
-                                origin: MatOrigin,
-                                extensions: Vector[ast.ScalarTypeExtensionDefinition],
-                                existing: ScalarAlias[T, ST],
-                                aliasFor: ScalarType[ST],
-                                mat: AstSchemaMaterializer[Ctx]) =
+  override def extendScalarAlias[T, ST](
+                                         origin: MatOrigin,
+                                         extensions: Vector[ast.ScalarTypeExtensionDefinition],
+                                         existing: ScalarAlias[T, ST],
+                                         aliasFor: ScalarType[ST],
+                                         mat: AstSchemaMaterializer[Ctx]): ScalarAlias[T, ST] =
     existing.copy(aliasFor = aliasFor)
 
-  def extendSchema[Val](
-                         originalSchema: Schema[Ctx, Val],
-                         extensions: List[ast.SchemaExtensionDefinition],
-                         queryType: ObjectType[Ctx, Val],
-                         mutationType: Option[ObjectType[Ctx, Val]],
-                         subscriptionType: Option[ObjectType[Ctx, Val]],
-                         additionalTypes: List[Type with Named],
-                         directives: List[Directive],
-                         mat: AstSchemaMaterializer[Ctx]) =
+  override def extendSchema[Val](
+                                  originalSchema: Schema[Ctx, Val],
+                                  extensions: List[ast.SchemaExtensionDefinition],
+                                  queryType: ObjectType[Ctx, Val],
+                                  mutationType: Option[ObjectType[Ctx, Val]],
+                                  subscriptionType: Option[ObjectType[Ctx, Val]],
+                                  additionalTypes: List[Type with Named],
+                                  directives: List[Directive],
+                                  mat: AstSchemaMaterializer[Ctx]): Schema[Ctx, Val] =
     Schema[Ctx, Val](
       query = queryType,
       mutation = mutationType,
@@ -137,12 +137,12 @@ class DefaultAstSchemaExtender[Ctx] extends AstSchemaExtender[Ctx] {
         (newDoc +: other) ++ extensions
       })
 
-  def extendUnionType(
-                       origin: MatOrigin,
-                       extensions: Vector[ast.UnionTypeExtensionDefinition],
-                       existing: UnionType[Ctx],
-                       types: List[ObjectType[Ctx, _]],
-                       mat: AstSchemaMaterializer[Ctx]) =
+  override def extendUnionType(
+                                origin: MatOrigin,
+                                extensions: Vector[ast.UnionTypeExtensionDefinition],
+                                existing: UnionType[Ctx],
+                                types: List[ObjectType[Ctx, _]],
+                                mat: AstSchemaMaterializer[Ctx]): UnionType[Ctx] =
     existing.copy(types = types,
       astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
       astNodes = existing.astNodes ++ extensions)

--- a/src/main/scala/sangria/schema/extension/DefaultAstSchemaExtender.scala
+++ b/src/main/scala/sangria/schema/extension/DefaultAstSchemaExtender.scala
@@ -1,0 +1,149 @@
+package sangria.schema.extension
+
+import sangria.ast
+import sangria.schema.{Action, Argument, AstSchemaMaterializer, Context, Directive, Field, InputField, InputObjectType, InputType, InterfaceType, MatOrigin, Named, ObjectLikeType, ObjectType, OutputType, ScalarAlias, ScalarType, Schema, Type, UnionType}
+
+import scala.reflect.ClassTag
+
+class DefaultAstSchemaExtender[Ctx] extends AstSchemaExtender[Ctx] {
+
+  def extendArgument(
+                      origin: MatOrigin,
+                      typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                      field: Field[Ctx, Any],
+                      argument: Argument[Any],
+                      argumentType: InputType[_],
+                      mat: AstSchemaMaterializer[Ctx]): Argument[Any] =
+    argument.copy(argumentType = argumentType)
+
+
+  def extendArgumentType(
+                          origin: MatOrigin,
+                          typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                          field: Field[Ctx, Any],
+                          existing: Argument[Any],
+                          mat: AstSchemaMaterializer[Ctx]): InputType[Any] =
+    mat.getInputTypeFromExistingType(origin, existing.argumentType)
+
+  def extendField(
+                   origin: MatOrigin,
+                   typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                   existing: Field[Ctx, Any],
+                   fieldType: OutputType[_],
+                   arguments: List[Argument[_]],
+                   mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(
+      fieldType = fieldType,
+      arguments = arguments,
+      resolve = extendFieldResolver(origin, typeDefinition, existing, fieldType, mat),
+      manualPossibleTypes = () ⇒ Nil)
+
+  def extendFieldResolver(
+                           origin: MatOrigin,
+                           typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                           existing: Field[Ctx, Any],
+                           fieldType: OutputType[_],
+                           mat: AstSchemaMaterializer[Ctx]): Context[Ctx, Any] ⇒ Action[Ctx, _] = existing.resolve
+
+  def extendFieldType(
+                       origin: MatOrigin,
+                       typeDefinition: Option[ObjectLikeType[Ctx, _]],
+                       existing: Field[Ctx, Any],
+                       mat: AstSchemaMaterializer[Ctx]): OutputType[Any] =
+    mat.getTypeFromExistingType(origin, existing.fieldType)
+
+  def extendInputField(
+                        origin: MatOrigin,
+                        typeDefinition: InputObjectType[_],
+                        existing: InputField[Any],
+                        fieldType: InputType[_],
+                        mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(fieldType = fieldType)
+
+  def extendInputFieldType(
+                            origin: MatOrigin,
+                            typeDefinition: InputObjectType[_],
+                            existing: InputField[Any],
+                            mat: AstSchemaMaterializer[Ctx]) =
+    mat.getInputTypeFromExistingType(origin, existing.fieldType)
+
+  def extendInterfaceType(
+                           origin: MatOrigin,
+                           existing: InterfaceType[Ctx, _],
+                           extensions: List[ast.InterfaceTypeExtensionDefinition],
+                           fields: () ⇒ List[Field[Ctx, Any]],
+                           mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(fieldsFn = fields, manualPossibleTypes = () ⇒ Nil, interfaces = Nil,
+      astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
+      astNodes = existing.astNodes ++ extensions)
+
+  def extendObjectType(
+                        origin: MatOrigin,
+                        existing: ObjectType[Ctx, _],
+                        extensions: List[ast.ObjectTypeExtensionDefinition],
+                        fields: () ⇒ List[Field[Ctx, Any]],
+                        interfaces: List[InterfaceType[Ctx, Any]],
+                        mat: AstSchemaMaterializer[Ctx]) =
+    extendedObjectTypeInstanceCheck(origin, existing, extensions) match {
+      case Some(fn) ⇒
+        existing.copy(
+          fieldsFn = fields,
+          interfaces = interfaces,
+          astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
+          astNodes = existing.astNodes ++ extensions,
+          instanceCheck = (value: Any, clazz: Class[_], _: ObjectType[Ctx, Any]) ⇒ fn(value, clazz))(ClassTag(existing.valClass))
+      case None ⇒
+        existing.copy(
+          fieldsFn = fields,
+          interfaces = interfaces,
+          astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
+          astNodes = existing.astNodes ++ extensions,
+          instanceCheck = existing.instanceCheck.asInstanceOf[(Any, Class[_], ObjectType[Ctx, _]) ⇒ Boolean])(ClassTag(existing.valClass))
+    }
+
+  def extendedObjectTypeInstanceCheck(origin: MatOrigin, tpe: ObjectType[Ctx, _], extensions: List[ast.ObjectTypeExtensionDefinition]): Option[(Any, Class[_]) ⇒ Boolean] =
+    None
+
+  def extendScalarAlias[T, ST](
+                                origin: MatOrigin,
+                                extensions: Vector[ast.ScalarTypeExtensionDefinition],
+                                existing: ScalarAlias[T, ST],
+                                aliasFor: ScalarType[ST],
+                                mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(aliasFor = aliasFor)
+
+  def extendSchema[Val](
+                         originalSchema: Schema[Ctx, Val],
+                         extensions: List[ast.SchemaExtensionDefinition],
+                         queryType: ObjectType[Ctx, Val],
+                         mutationType: Option[ObjectType[Ctx, Val]],
+                         subscriptionType: Option[ObjectType[Ctx, Val]],
+                         additionalTypes: List[Type with Named],
+                         directives: List[Directive],
+                         mat: AstSchemaMaterializer[Ctx]) =
+    Schema[Ctx, Val](
+      query = queryType,
+      mutation = mutationType,
+      subscription = subscriptionType,
+      additionalTypes = additionalTypes,
+      directives = directives,
+      description = originalSchema.description,
+      validationRules = originalSchema.validationRules,
+      astDirectives = originalSchema.astDirectives ++ extensions.flatMap(_.directives),
+      astNodes = {
+        val (docs, other) = originalSchema.astNodes.partition(_.isInstanceOf[ast.Document])
+        val newDoc = ast.Document.merge(docs.asInstanceOf[Vector[ast.Document]] :+ mat.document)
+
+        (newDoc +: other) ++ extensions
+      })
+
+  def extendUnionType(
+                       origin: MatOrigin,
+                       extensions: Vector[ast.UnionTypeExtensionDefinition],
+                       existing: UnionType[Ctx],
+                       types: List[ObjectType[Ctx, _]],
+                       mat: AstSchemaMaterializer[Ctx]) =
+    existing.copy(types = types,
+      astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
+      astNodes = existing.astNodes ++ extensions)
+}


### PR DESCRIPTION
As discussed https://github.com/sangria-graphql/sangria/issues/418#issuecomment-440458452 this PR aims to settle the ground for decoupling schema extension from  materialization.


Creates a new trait `AstSchemaExtender` which contains all schema extension methods definition as originally defined in `AstSchemaBuilder`.

Furthermore, it creates a new default `AstSchemaExtender` implementation moving the implementation from `DefaultAstSchemaBuilder` to `DefaultAstSchemaExtender`

In order to keep backwards compatibility  `AstSchemaBuilder` signature remains unchanged  with the following tradeoffs
- `AstSchemaBuilder` extends  `AstSchemaExtender`
- `DefaultAstSchemaBuilder` extends `DefaultAstSchemaExtender`