### PR TITLE
extend ProjectionNames to include Args

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria"
 organization := "org.sangria-graphql"
-version := "1.4.3-SNAPSHOT"
+version := "1.4.4-SNAPSHOT"
 
 description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/src/main/scala/sangria/execution/Resolver.scala
+++ b/src/main/scala/sangria/execution/Resolver.scala
@@ -1165,7 +1165,7 @@ class Resolver[Ctx](
                       else Vector(field.name)
 
                     projectedName.map (name ⇒
-                      ProjectedName(name, loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1)))
+                      ProjectedName(name, loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1), Args(field, astField)))
                 }
                 .flatten
             case Failure(_) ⇒ Vector.empty

--- a/src/main/scala/sangria/schema/Context.scala
+++ b/src/main/scala/sangria/schema/Context.scala
@@ -158,7 +158,7 @@ object Projector {
     }
 }
 
-case class ProjectedName(name: String, children: Vector[ProjectedName] = Vector.empty) {
+case class ProjectedName(name: String, children: Vector[ProjectedName] = Vector.empty, args: Args = Args.empty) {
   lazy val asVector = {
     def loop(name: ProjectedName): Vector[Vector[String]] =
       Vector(name.name) +: (name.children flatMap loop map (name.name +: _))


### PR DESCRIPTION
This PR extends the Projector facility with access to the Args present at each projection node. This enables use cases for n+1 query mitigation that require access to arguments in order to properly formulate the query.

I bumped the version by one patch increment, but this change may in fact require a minor version bump because anyone relying on case comprehension on the `ProjectedName` class will have their code broken if they pick up this build. 

Addresses https://github.com/sangria-graphql/sangria/issues/427