### PR TITLE
support for configuring max concurrent batches in fetcher

### DIFF
--- a/src/main/scala/sangria/execution/deferred/Fetcher.scala
+++ b/src/main/scala/sangria/execution/deferred/Fetcher.scala
@@ -134,11 +134,12 @@ object Fetcher {
     new Fetcher[Ctx, Res, RelRes, Id](i ⇒ id.id(i), relationOnlySupported, fetchRel, config)
 }
 
-case class FetcherConfig(cacheConfig: Option[() ⇒ FetcherCache] = None, maxBatchSizeConfig: Option[Int] = None) {
+case class FetcherConfig(cacheConfig: Option[() ⇒ FetcherCache] = None, maxBatchSizeConfig: Option[Int] = None, maxConcurrentBatchesConfig: Option[Int] = None) {
   def caching = copy(cacheConfig = Some(() ⇒ FetcherCache.simple))
   def caching(cache: FetcherCache) = copy(cacheConfig = Some(() ⇒ cache))
 
   def maxBatchSize(size: Int) = copy(maxBatchSizeConfig = Some(size))
+  def maxConcurrentBatches(size: Int) = copy(maxConcurrentBatchesConfig = Some(size))
 }
 
 object FetcherConfig {
@@ -148,6 +149,7 @@ object FetcherConfig {
   def caching(cache: FetcherCache) = empty.caching(cache)
 
   def maxBatchSize(size: Int) = empty.maxBatchSize(size)
+  def maxConcurrentBatches(size: Int) = empty.maxConcurrentBatches(size)
 }
 
 trait DeferredOne[+T, Id] extends Deferred[T] {

--- a/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
+++ b/src/main/scala/sangria/execution/deferred/FetcherBasedDeferredResolver.scala
@@ -150,6 +150,34 @@ class FetcherBasedDeferredResolver[-Ctx](fetchers: Vector[Fetcher[Ctx, _, _, _]]
     }
   }
 
+  private def resolveConcurrentBatches(
+    ctx: FetcherContext[Ctx] @uncheckedVariance,
+    f: Fetcher[Ctx, Any, Any, Any] @uncheckedVariance,
+    nonCachedIds: Vector[Any]
+  )(implicit ec: ExecutionContext): Iterator[Future[(Vector[Any], Try[Seq[Any]])]] = {
+    val groupedIds: Iterator[Vector[Any]] = ctx.fetcher.config.maxBatchSizeConfig match {
+      case Some(size) ⇒ nonCachedIds.grouped(size)
+      case None ⇒ Iterator(nonCachedIds)
+    }
+
+    val groupedBatches: Iterator[TraversableOnce[Vector[Any]]] = ctx.fetcher.config.maxConcurrentBatchesConfig match {
+      case Some(size) ⇒ groupedIds.grouped(size)
+      case None ⇒ Iterator(groupedIds)
+    }
+
+    groupedBatches
+      .foldLeft(Iterator.empty[Future[(Vector[Any], Try[Seq[Any]])]]) {
+        (accumFutureSeq, groupedIds) =>
+          val results: Iterator[Future[(Vector[Any], Try[Seq[Any]])]] = groupedIds.toIterator map { group ⇒
+            if (group.nonEmpty)
+              f.fetch(ctx, group).map(r ⇒ group → Success(r): (Vector[Any], Try[Seq[Any]])).recover {case e ⇒ group → Failure(e)}
+            else
+              Future.successful(group → Success(Seq.empty))
+          }
+          accumFutureSeq ++ results
+      }
+  }
+
   private def resolveEntities(
     ctx: FetcherContext[Ctx] @uncheckedVariance,
     deferredToResolve: Vector[Deferred[Any]],
@@ -159,17 +187,7 @@ class FetcherBasedDeferredResolver[-Ctx](fetchers: Vector[Fetcher[Ctx, _, _, _]]
     val ids = ctx.fetcher.ids(deferredToResolve)
     val (nonCachedIds, cachedResults) = partitionCached(ctx.cache, ids)
 
-    val groupedIds = ctx.fetcher.config.maxBatchSizeConfig match {
-      case Some(size) ⇒ nonCachedIds.grouped(size)
-      case None ⇒ Iterator(nonCachedIds)
-    }
-
-    val results = groupedIds map { group ⇒
-      if (group.nonEmpty)
-        f.fetch(ctx, group).map(r ⇒ group → Success(r): (Vector[Any], Try[Seq[Any]])).recover {case e ⇒ group → Failure(e)}
-      else
-        Future.successful(group → Success(Seq.empty))
-    }
+    val results = resolveConcurrentBatches(ctx, f, nonCachedIds)
 
     val futureRes = Future.sequence(results).map { allResults ⇒
       val byId = MutableMap[Any, Any]() // can contain either exception or actual value! (using `Any` to avoid unnecessary boxing)


### PR DESCRIPTION
- added a new config param maxConcurrentBatches to configure
the max number of batched IDs that can be fetched concurrently by fetcher.
- not specifying any value for this param will fallback to the existing
behaviour of running all batches concurrently.