### PR TITLE
emit jvm 8 bytecode for scala >= 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ lazy val scalaSettings = Seq(
     if (scalaVersion.value startsWith "2.11")
       Seq("-target:jvm-1.7")
     else
-      Seq.empty
+      Seq("-target:jvm-1.8")
   }
 )
 


### PR DESCRIPTION
instead of using the JVM version of the locally used JVM, control the target version