### PR TITLE
can disable expensive suggestions

### DIFF
--- a/modules/core/src/main/scala/sangria/validation/rules/KnownTypeNames.scala
+++ b/modules/core/src/main/scala/sangria/validation/rules/KnownTypeNames.scala
@@ -4,6 +4,7 @@ import sangria.ast
 import sangria.ast.AstVisitorCommand
 import sangria.util.StringUtil
 import sangria.validation._
+import sangria.validation.rules.KnownTypeNames.SuggestionFunction
 
 /**
  * Known type names
@@ -11,7 +12,7 @@ import sangria.validation._
  * A GraphQL document is only valid if referenced types (specifically
  * variable definitions and fragment conditions) are defined by the type schema.
  */
-class KnownTypeNames extends ValidationRule {
+class KnownTypeNames(suggestion: SuggestionFunction = SuggestionFunction.Default) extends ValidationRule {
   override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
     override val onEnter: ValidationVisit = {
       case _: ast.ObjectTypeDefinition | _: ast.InterfaceTypeDefinition | _: ast.UnionTypeDefinition | _: ast.InputObjectTypeDefinition | _: ast.TypeSystemExtensionDefinition | _: ast.SchemaDefinition =>
@@ -22,11 +23,26 @@ class KnownTypeNames extends ValidationRule {
         if (!ctx.schema.allTypes.contains(name))
           Left(Vector(UnknownTypeViolation(
             name,
-            StringUtil.suggestionList(name, ctx.schema.availableTypeNames),
+            suggestion(name, ctx.schema.availableTypeNames),
             ctx.sourceMapper,
             pos.toList)))
         else
           AstVisitorCommand.RightContinue
+    }
+  }
+}
+
+object KnownTypeNames {
+  trait SuggestionFunction {
+    def apply(input: String, availableTypeNames: Vector[String]): Seq[String]
+  }
+  object SuggestionFunction {
+    object Default extends SuggestionFunction {
+      override def apply(input: String, availableTypeNames: Vector[String]): Seq[String] =
+        StringUtil.suggestionList(input, availableTypeNames)
+    }
+    object Disabled extends SuggestionFunction {
+      override def apply(input: String, availableTypeNames: Vector[String]): Seq[String] = Nil
     }
   }
 }

--- a/modules/core/src/test/scala/sangria/validation/rules/KnownTypeNamesDisabledSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/rules/KnownTypeNamesDisabledSpec.scala
@@ -1,0 +1,42 @@
+package sangria.validation.rules
+
+import sangria.util.{Pos, ValidationSupport}
+import org.scalatest.wordspec.AnyWordSpec
+import sangria.validation.rules.KnownTypeNames.SuggestionFunction
+
+class KnownTypeNamesDisabledSpec extends AnyWordSpec with ValidationSupport {
+
+  override val defaultRule = Some(new KnownTypeNames(suggestion = SuggestionFunction.Disabled))
+
+  "Validate: Known type names" should {
+    "known type names are valid" in expectPasses(
+      """
+        query Foo($var: String, $required: [String!]!) {
+          user(id: 4) {
+            pets { ... on Pet { name }, ...PetFields, ... { name }}
+          }
+        }
+        fragment PetFields on Pet {
+          name
+        }
+      """)
+
+    "unknown type names are invalid" in expectFails(
+      """
+        query Foo($var: JumbledUpLetters) {
+          user(id: 4) {
+            name
+            pets { ... on Badger { name }, ...PetFields }
+          }
+        }
+        fragment PetFields on Peettt {
+          name
+        }
+      """,
+      List(
+        "Unknown type 'JumbledUpLetters'." -> Some(Pos(2, 25)),
+        "Unknown type 'Badger'." -> Some(Pos(5, 27)),
+        "Unknown type 'Peettt'." -> Some(Pos(8, 31))
+      ))
+  }
+}


### PR DESCRIPTION
By overriding the default QueryValidator, one can disable or add a cache for the suggested fields.
Fixes https://github.com/sangria-graphql/sangria/issues/497