### PR TITLE
parboiled 2.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val core = project
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(
       // AST Parser
-      "org.parboiled" %% "parboiled" % "2.1.8",
+      "org.parboiled" %% "parboiled" % "2.2.1",
 
       // AST Visitor
       "org.sangria-graphql" %% "macro-visit" % "0.1.2",


### PR DESCRIPTION
I have noticed that Sangria is running on a pretty ancient version of parboiled.

Upgrading also removes a fair amount of  warnings like:
```Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_!```

For some reason scala-steward did not create a PR for it.