### PR TITLE
Remove Scala 2.11 Support 🔥

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ classes
 *.iml
 *.sc
 *.swp
+
+# Metals!
+.metals/
+.bloop/
+.vscode/
+metals.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: scala
 scala:
-  - 2.11.12
   - 2.12.10
-  - 2.13.3
+  - 2.13.4
 jdk:
   - openjdk8
   - openjdk11
-
-matrix:
-  exclude:
-    - scala: 2.11.12
-      jdk: openjdk11
 
 script: |
   sbt ++$TRAVIS_SCALA_VERSION clean coverage test

--- a/build.sbt
+++ b/build.sbt
@@ -85,24 +85,14 @@ lazy val projectInfo = Seq(
 )
 
 lazy val scalaSettings = Seq(
-  scalaVersion := "2.13.3",
-  crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value),
+  scalaVersion := "2.13.4",
+  crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   scalacOptions ++= Seq(
     "-deprecation",
     "-feature",
     "-Xlint:-missing-interpolator,_"),
-  scalacOptions ++= {
-    if (scalaVersion.value startsWith "2.11")
-      Seq("-target:jvm-1.7")
-    else
-      Seq("-target:jvm-1.8")
-  },
-  javacOptions ++= {
-    if (scalaVersion.value startsWith "2.11")
-      Seq("-source", "7", "-target", "7")
-    else
-      Seq("-source", "8", "-target", "8")
-  }
+  scalacOptions += "-target:jvm-1.8",
+  javacOptions ++= Seq("-source", "8", "-target", "8")
 )
 
 lazy val shellSettings = Seq(


### PR DESCRIPTION
2.11 targets JVM 7 which is old and stinky, this moves us into the future of Long Term support!