### PR TITLE
Lazy Union Types

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -469,7 +469,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
       existing: UnionType[Ctx],
       types: List[ObjectType[Ctx, _]],
       mat: AstSchemaMaterializer[Ctx]) =
-    existing.copy(types = types,
+    existing.copy(typesFn = () => types,
       astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
       astNodes = existing.astNodes ++ extensions)
 

--- a/modules/core/src/test/scala/sangria/schema/IntrospectionSchemaMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/IntrospectionSchemaMaterializerSpec.scala
@@ -60,6 +60,8 @@ class IntrospectionSchemaMaterializerSpec extends AnyWordSpec with Matchers with
 
   lazy val FriendlyUnionType = UnionType("Friendly", types = DogUnionType :: HumanUnionType :: Nil)
 
+  lazy val LazilyInitializedUnionType = UnionType("FriendlyButLazy", typesFn = () => DogUnionType :: HumanUnionType :: Nil)
+
   val CustomScalar = ScalarType[Int]("Custom",
     description = Some("Some custom"),
     coerceOutput = (i, _) => ast.IntValue(i),


### PR DESCRIPTION
Moves `types` for `UnionType` to be defined as a no-arg method à la `fieldsFn` on `Field`.