### PR TITLE
Support Args in ProjectedNames

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ import sbt.Keys.{
   scmInfo,
   startYear
 }
+import com.typesafe.tools.mima.core.{ProblemFilters, Problem}
 
 // sbt-github-actions needs configuration in `ThisBuild`
 ThisBuild / crossScalaVersions := Seq("2.12.13", "2.13.4")
@@ -15,6 +16,12 @@ ThisBuild / githubWorkflowPublishTargetBranches := List()
 ThisBuild / githubWorkflowBuildPreamble ++= List(
   WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check binary compatibility")),
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check formatting"))
+)
+
+// Binary Incompatible Changes, we'll document.
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[Problem]("sangria.schema.ProjectedName*"),
+  ProblemFilters.exclude[Problem]("sangria.schema.Args*")
 )
 
 lazy val root = project

--- a/modules/core/src/main/scala/sangria/execution/Resolver.scala
+++ b/modules/core/src/main/scala/sangria/execution/Resolver.scala
@@ -1655,7 +1655,8 @@ class Resolver[Ctx](
                     projectedName.map(name =>
                       ProjectedName(
                         name,
-                        loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1)))
+                        loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1),
+                        Args(field, astField, variables)))
                 }.flatten
               case Failure(_) => Vector.empty
             }

--- a/modules/core/src/main/scala/sangria/schema/Context.scala
+++ b/modules/core/src/main/scala/sangria/schema/Context.scala
@@ -200,7 +200,10 @@ object Projector {
     }
 }
 
-case class ProjectedName(name: String, children: Vector[ProjectedName] = Vector.empty) {
+case class ProjectedName(
+    name: String,
+    children: Vector[ProjectedName] = Vector.empty,
+    args: Args = Args.empty) {
   lazy val asVector = {
     def loop(name: ProjectedName): Vector[Vector[String]] =
       Vector(name.name) +: (name.children.flatMap(loop).map(name.name +: _))
@@ -518,7 +521,10 @@ object Args {
   def apply(definitions: List[Argument[_]], values: Map[String, Any]): Args =
     apply(definitions, input = ScalaInput.scalaInput(values))
 
-  def apply[In: InputUnmarshaller](definitions: List[Argument[_]], input: In): Args = {
+  def apply[In: InputUnmarshaller](
+      definitions: List[Argument[_]],
+      input: In,
+      variables: Option[Map[String, VariableValue]] = None): Args = {
     import sangria.marshalling.queryAst._
 
     val iu = implicitly[InputUnmarshaller[In]]
@@ -530,7 +536,7 @@ object Args {
         iu.getMapKeys(input).flatMap(key => definitions.find(_.name == key)).map { arg =>
           val astValue = iu
             .getRootMapValue(input, arg.name)
-            .flatMap(x => this.convert[In, ast.Value](x, arg.argumentType))
+            .flatMap(x => this.convert[In, ast.Value](x, arg.argumentType, variables))
 
           ast.Argument(name = arg.name, value = astValue.getOrElse(ast.NullValue()))
         }
@@ -556,9 +562,23 @@ object Args {
         astElem.arguments.map(arg => ast.ObjectField(arg.name, arg.value))): ast.Value)
   }
 
+  def apply(
+      schemaElem: HasArguments,
+      astElem: ast.WithArguments,
+      variables: Map[String, VariableValue]): Args = {
+    import sangria.marshalling.queryAst._
+
+    apply(
+      schemaElem.arguments,
+      ast.ObjectValue(astElem.arguments.map(arg ⇒ ast.ObjectField(arg.name, arg.value))): ast.Value,
+      Some(variables)
+    )
+  }
+
   private def convert[In: InputUnmarshaller, Out: ResultMarshallerForType](
       value: In,
-      tpe: InputType[_]): Option[Out] = {
+      tpe: InputType[_],
+      variables: Option[Map[String, VariableValue]] = None): Option[Out] = {
     val rm = implicitly[ResultMarshallerForType[Out]]
 
     ValueCoercionHelper.default.coerceInputValue(
@@ -566,7 +586,7 @@ object Args {
       List("stub"),
       value,
       None,
-      None,
+      variables,
       rm.marshaller,
       rm.marshaller,
       isArgument = false) match {


### PR DESCRIPTION
After a little digging, thanks to @kirach's fork, I saw that the fix for the problem @yanns ran into https://github.com/sangria-graphql-org/sangria/pull/10#issuecomment-571471876 was a trivial fix.

I also updated the test cases to ensure queries with variables are a tested case.

Closing #468 in favor of this due to nasty rebasing from a long out of date branch :)