### PR TITLE
Introspection: Return interfaces implemented for interfaces

### DIFF
--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -2,7 +2,7 @@ package sangria
 
 import sangria.parser.QueryParser
 import sangria.parser.DeliveryScheme.Throw
-import sangria.schema._
+import sangria.schema.{ObjectLikeType, _}
 
 package object introspection {
   object TypeKind extends Enumeration {
@@ -267,7 +267,7 @@ package object introspection {
           "interfaces",
           OptionType(ListType(__Type)),
           resolve = _.value._2 match {
-            case t: ObjectType[_, _] =>
+            case t: ObjectLikeType[_, _] =>
               Some(t.allInterfaces.asInstanceOf[Vector[Type]].map(true -> _))
             case _ => None
           }


### PR DESCRIPTION
We should return interfaces implemented for interfaces even though it will be empty for now, since there is a bug in the GraphQL JS implementation which expects null or empty array: https://github.com/graphql/graphql-js/pull/2949

Currently Sangria doesn't handle interfaces implementing interfaces (RFC 373). Though I've made a quick take on it https://github.com/cognitedata/sangria/tree/add-rfc-373 but I've some failing tests which I've to figure out.