### PR TITLE
Add support for interfaces implementing interfaces

### DIFF
--- a/modules/core/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/core/src/main/scala/sangria/ast/QueryAst.scala
@@ -451,6 +451,7 @@ case class ObjectTypeDefinition(
 
 case class InterfaceTypeDefinition(
     name: String,
+    interfaces: Vector[NamedType],
     fields: Vector[FieldDefinition],
     directives: Vector[Directive] = Vector.empty,
     description: Option[StringValue] = None,
@@ -528,6 +529,7 @@ case class ObjectTypeExtensionDefinition(
 
 case class InterfaceTypeExtensionDefinition(
     name: String,
+    interfaces: Vector[NamedType],
     fields: Vector[FieldDefinition],
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
@@ -670,6 +672,7 @@ sealed trait TypeExtensionDefinition extends TypeSystemExtensionDefinition with 
 
 sealed trait ObjectLikeTypeExtensionDefinition extends TypeExtensionDefinition {
   def fields: Vector[FieldDefinition]
+  def interfaces: Vector[NamedType]
 }
 
 object AstNode {
@@ -993,6 +996,7 @@ object AstVisitor {
           }
         case n @ InterfaceTypeDefinition(
               _,
+              interfaces,
               fields,
               dirs,
               description,
@@ -1000,6 +1004,7 @@ object AstVisitor {
               trailingComments,
               _) =>
           if (breakOrSkip(onEnter(n))) {
+            interfaces.foreach(d => loop(d))
             fields.foreach(d => loop(d))
             dirs.foreach(d => loop(d))
             description.foreach(s => loop(s))
@@ -1055,8 +1060,9 @@ object AstVisitor {
             tc.foreach(s => loop(s))
             breakOrSkip(onLeave(n))
           }
-        case n @ InterfaceTypeExtensionDefinition(_, fields, dirs, comment, tc, _) =>
+        case n @ InterfaceTypeExtensionDefinition(_, interfaces, fields, dirs, comment, tc, _) =>
           if (breakOrSkip(onEnter(n))) {
+            interfaces.foreach(d => loop(d))
             fields.foreach(d => loop(d))
             dirs.foreach(d => loop(d))
             comment.foreach(s => loop(s))

--- a/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
+++ b/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
@@ -48,10 +48,7 @@ object IntrospectionParser {
         .map(um.getListValue)
         .getOrElse(Vector.empty)
         .map(field => parseField(field, path :+ "fields")),
-      interfaces = mapFieldOpt(tpe, "interfaces")
-        .map(um.getListValue)
-        .getOrElse(Vector.empty)
-        .map(i => parseNamedTypeRef(i, path :+ "interfaces"))
+      interfaces = parseNamedInterfacesTypeRef(tpe, path),
     )
 
   private def parseInterface[In: InputUnmarshaller](tpe: In, path: Vector[String]) =
@@ -62,6 +59,7 @@ object IntrospectionParser {
         .map(um.getListValue)
         .getOrElse(Vector.empty)
         .map(field => parseField(field, path :+ "fields")),
+      interfaces = parseNamedInterfacesTypeRef(tpe, path),
       possibleTypes = mapFieldOpt(tpe, "possibleTypes")
         .map(um.getListValue)
         .getOrElse(Vector.empty)
@@ -165,6 +163,12 @@ object IntrospectionParser {
         IntrospectionNonNullTypeRef(parseTypeRef(mapField(in, "ofType", path), path :+ "ofType"))
       case _ => parseNamedTypeRef(in, path)
     }
+
+  private def parseNamedInterfacesTypeRef[In: InputUnmarshaller](in: In, path: Vector[String]): Seq[IntrospectionNamedTypeRef] =
+    mapFieldOpt(in, "interfaces")
+      .map(um.getListValue)
+      .getOrElse(Vector.empty)
+      .map(i => parseNamedTypeRef(i, path :+ "interfaces"))
 
   private def required[T](obj: Option[T], path: Vector[String]) = obj match {
     case Some(o) => o

--- a/modules/core/src/main/scala/sangria/introspection/model.scala
+++ b/modules/core/src/main/scala/sangria/introspection/model.scala
@@ -59,6 +59,7 @@ case class IntrospectionInterfaceType(
     name: String,
     description: Option[String],
     fields: Seq[IntrospectionField],
+    interfaces: Seq[IntrospectionNamedTypeRef],
     possibleTypes: Seq[IntrospectionNamedTypeRef])
     extends IntrospectionType {
   val kind = TypeKind.Interface

--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -267,7 +267,7 @@ package object introspection {
           "interfaces",
           OptionType(ListType(__Type)),
           resolve = _.value._2 match {
-            case t: ObjectType[_, _] =>
+            case t: ObjectLikeType[_, _] =>
               Some(t.allInterfaces.asInstanceOf[Vector[Type]].map(true -> _))
             case _ => None
           }

--- a/modules/core/src/main/scala/sangria/macros/AstLiftable.scala
+++ b/modules/core/src/main/scala/sangria/macros/AstLiftable.scala
@@ -81,8 +81,8 @@ trait AstLiftable {
 
     case ObjectTypeExtensionDefinition(n, i, f, d, c, tc, p) =>
       q"_root_.sangria.ast.ObjectTypeExtensionDefinition($n, $i, $f, $d, $c, $tc, $p)"
-    case InterfaceTypeExtensionDefinition(n, f, d, c, tc, p) =>
-      q"_root_.sangria.ast.InterfaceTypeExtensionDefinition($n, $f, $d, $c, $tc, $p)"
+    case InterfaceTypeExtensionDefinition(n, i, f, d, c, tc, p) =>
+      q"_root_.sangria.ast.InterfaceTypeExtensionDefinition($n, $i, $f, $d, $c, $tc, $p)"
     case InputObjectTypeExtensionDefinition(n, f, d, c, tc, p) =>
       q"_root_.sangria.ast.InputObjectTypeExtensionDefinition($n, $f, $d, $c, $tc, $p)"
     case UnionTypeExtensionDefinition(n, t, d, c, p) =>
@@ -98,8 +98,8 @@ trait AstLiftable {
       q"_root_.sangria.ast.EnumTypeDefinition($n, $v, $d, $desc, $c, $tc, $p)"
     case InputObjectTypeDefinition(n, f, d, desc, c, tc, p) =>
       q"_root_.sangria.ast.InputObjectTypeDefinition($n, $f, $d, $desc, $c, $tc, $p)"
-    case InterfaceTypeDefinition(n, f, d, desc, c, tc, p) =>
-      q"_root_.sangria.ast.InterfaceTypeDefinition($n, $f, $d, $desc, $c, $tc, $p)"
+    case InterfaceTypeDefinition(n, i, f, d, desc, c, tc, p) =>
+      q"_root_.sangria.ast.InterfaceTypeDefinition($n, $i, $f, $d, $desc, $c, $tc, $p)"
     case ObjectTypeDefinition(n, i, f, d, desc, c, tc, p) =>
       q"_root_.sangria.ast.ObjectTypeDefinition($n, $i, $f, $d, $desc, $c, $tc, $p)"
     case ScalarTypeDefinition(n, d, desc, c, p) =>

--- a/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -659,12 +659,14 @@ object QueryRenderer {
           renderDirs(dirs, config, indent, frontSep = true) +
           renderInputFieldDefinitions(fields, itd, indent, config, frontSep = true)
 
-      case itd @ InterfaceTypeDefinition(name, fields, dirs, description, _, _, _) =>
+      case itd @ InterfaceTypeDefinition(name, interfaces, fields, dirs, description, _, _, _) =>
         renderDescription(itd, prev, indent, config) +
           renderComment(itd, description.orElse(prev), indent, config) +
           indent.str + "interface" + config.mandatorySeparator + name +
-          renderDirs(dirs, config, indent, frontSep = true) +
-          renderFieldDefinitions(fields, itd, indent, config, frontSep = true)
+          config.mandatorySeparator +
+          renderInterfaces(interfaces, config, indent) +
+          renderDirs(dirs, config, indent, withSep = fields.nonEmpty) +
+          renderFieldDefinitions(fields, itd, indent, config)
 
       case utd @ UnionTypeDefinition(name, types, dirs, description, _, _) =>
         val typesString =
@@ -719,11 +721,13 @@ object QueryRenderer {
           renderDirs(dirs, config, indent, withSep = fields.nonEmpty) +
           renderFieldDefinitions(fields, ted, indent, config)
 
-      case ext @ InterfaceTypeExtensionDefinition(name, fields, dirs, _, _, _) =>
+      case ext @ InterfaceTypeExtensionDefinition(name, interfaces, fields, dirs, _, _, _) =>
         renderComment(ext, prev, indent, config) +
           indent.str + "extend" + config.mandatorySeparator + "interface" + config.mandatorySeparator + name +
-          renderDirs(dirs, config, indent, frontSep = true) +
-          renderFieldDefinitions(fields, ext, indent, config, frontSep = true)
+          config.mandatorySeparator +
+          renderInterfaces(interfaces, config, indent) +
+          renderDirs(dirs, config, indent, withSep = fields.nonEmpty) +
+          renderFieldDefinitions(fields, ext, indent, config)
 
       case ext @ UnionTypeExtensionDefinition(name, types, dirs, _, _) =>
         val typesString =

--- a/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -48,6 +48,9 @@ object SchemaRenderer {
   def renderImplementedInterfaces(tpe: IntrospectionObjectType) =
     tpe.interfaces.map(t => ast.NamedType(t.name)).toVector
 
+  def renderImplementedInterfaces(tpe: IntrospectionInterfaceType) =
+    tpe.interfaces.map(t => ast.NamedType(t.name)).toVector
+
   def renderImplementedInterfaces(tpe: ObjectLikeType[_, _]) =
     tpe.allInterfaces.map(t => ast.NamedType(t.name))
 
@@ -219,12 +222,14 @@ object SchemaRenderer {
   def renderInterface(tpe: IntrospectionInterfaceType) =
     ast.InterfaceTypeDefinition(
       tpe.name,
+      renderImplementedInterfaces(tpe),
       renderFieldsI(tpe.fields),
       description = renderDescription(tpe.description))
 
   def renderInterface(tpe: InterfaceType[_, _]) =
     ast.InterfaceTypeDefinition(
       tpe.name,
+      renderImplementedInterfaces(tpe),
       renderFields(tpe.uniqueFields),
       tpe.astDirectives,
       renderDescription(tpe.description))

--- a/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -69,6 +69,7 @@ trait AstSchemaBuilder[Ctx] {
       definition: ast.InterfaceTypeDefinition,
       extensions: List[ast.InterfaceTypeExtensionDefinition],
       fields: () => List[Field[Ctx, Any]],
+      interfaces: List[InterfaceType[Ctx, Any]],
       mat: AstSchemaMaterializer[Ctx]): Option[InterfaceType[Ctx, Any]]
 
   def extendInterfaceType(
@@ -443,6 +444,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
       definition: ast.InterfaceTypeDefinition,
       extensions: List[ast.InterfaceTypeExtensionDefinition],
       fields: () => List[Field[Ctx, Any]],
+      interfaces: List[InterfaceType[Ctx, Any]],
       mat: AstSchemaMaterializer[Ctx]) = {
     val directives = definition.directives ++ extensions.flatMap(_.directives)
 

--- a/modules/core/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
+++ b/modules/core/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
@@ -642,7 +642,7 @@ class AstSchemaMaterializer[Ctx] private (
       tpe,
       extensions.toList,
       () => buildFields(origin, tpe, tpe.fields, extensions).toList,
-      buildInterfaces(origin, tpe, tpe.interfaces, extensions).toList,
+      buildInterfaces(origin, tpe.interfaces, extensions).toList,
       this
     )
   }
@@ -667,6 +667,7 @@ class AstSchemaMaterializer[Ctx] private (
       tpe,
       extensions.toList,
       () => buildFields(origin, tpe, tpe.fields, extensions).toList,
+      buildInterfaces(origin, tpe.interfaces, extensions).toList,
       this)
   }
 
@@ -712,9 +713,8 @@ class AstSchemaMaterializer[Ctx] private (
 
   def buildInterfaces(
       origin: MatOrigin,
-      tpe: ast.ObjectTypeDefinition,
       interfaces: Vector[ast.NamedType],
-      extensions: Vector[ast.ObjectTypeExtensionDefinition]) = {
+      extensions: Vector[ast.ObjectLikeTypeExtensionDefinition]) = {
     val extraInts = extensions.flatMap(_.interfaces)
     val allInts = interfaces ++ extraInts
 

--- a/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
@@ -36,6 +36,7 @@ trait IntrospectionSchemaBuilder[Ctx] {
   def buildInterfaceType(
       definition: IntrospectionInterfaceType,
       fields: () => List[Field[Ctx, Any]],
+      interfaces: List[InterfaceType[Ctx, Any]],
       mat: IntrospectionSchemaMaterializer[Ctx, _]): Option[InterfaceType[Ctx, Any]]
 
   def buildUnionType(
@@ -157,13 +158,14 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
   def buildInterfaceType(
       definition: IntrospectionInterfaceType,
       fields: () => List[Field[Ctx, Any]],
+      interfaces: List[InterfaceType[Ctx, Any]],
       mat: IntrospectionSchemaMaterializer[Ctx, _]) =
     Some(
       InterfaceType[Ctx, Any](
         name = typeName(definition),
         description = typeDescription(definition),
         fieldsFn = fields,
-        interfaces = Nil,
+        interfaces = interfaces,
         manualPossibleTypes = () => Nil,
         astDirectives = Vector.empty,
         astNodes = Vector.empty

--- a/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaMaterializer.scala
+++ b/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaMaterializer.scala
@@ -140,7 +140,7 @@ class IntrospectionSchemaMaterializer[Ctx, T: InputUnmarshaller](
       this)
 
   def buildInterfaceDef(tpe: IntrospectionInterfaceType) =
-    builder.buildInterfaceType(tpe, () => tpe.fields.toList.flatMap(buildField(tpe, _)), this)
+    builder.buildInterfaceType(tpe, () => tpe.fields.toList.flatMap(buildField(tpe, _)), tpe.interfaces.toList.map(getInterfaceType), this)
 
   def buildUnionDef(tpe: IntrospectionUnionType) =
     builder.buildUnionType(tpe, tpe.possibleTypes.toList.map(getObjectType), this)

--- a/modules/core/src/test/resources/queries/schema-kitchen-sink.graphql
+++ b/modules/core/src/test/resources/queries/schema-kitchen-sink.graphql
@@ -38,7 +38,9 @@ interface Bar {
   four(argument: String = "string"): String
 }
 
-interface AnnotatedInterface @onInterface {
+interface AnnotatedInterface implements Bar @onInterface {
+  one: Type
+  four(argument: String = "string"): String
   annotatedField(arg: Type @onArg): Type @onField
 }
 

--- a/modules/core/src/test/scala/sangria/macros/LiteralMacroSpec.scala
+++ b/modules/core/src/test/scala/sangria/macros/LiteralMacroSpec.scala
@@ -977,6 +977,7 @@ class LiteralMacroSpec extends AnyWordSpec with Matchers {
             ),
             InterfaceTypeDefinition(
               "Bar",
+              Vector.empty,
               Vector(
                 FieldDefinition(
                   "one",
@@ -1012,6 +1013,7 @@ class LiteralMacroSpec extends AnyWordSpec with Matchers {
             ),
             InterfaceTypeDefinition(
               "AnnotatedInterface",
+              Vector.empty,
               Vector(FieldDefinition(
                 "annotatedField",
                 NamedType("Type", None),

--- a/modules/core/src/test/scala/sangria/parser/SchemaParserSpec.scala
+++ b/modules/core/src/test/scala/sangria/parser/SchemaParserSpec.scala
@@ -276,6 +276,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeDefinition(
               "Bar",
+              Vector.empty,
               Vector(
                 FieldDefinition(
                   "one",
@@ -323,7 +324,39 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeDefinition(
               "AnnotatedInterface",
+              Vector.empty,
               Vector(
+                FieldDefinition(
+                  "one",
+                  NamedType("Type", Some(AstLocation(875, 37, 8))),
+                  Vector.empty,
+                  Vector.empty,
+                  None,
+                  Vector.empty,
+                  Some(AstLocation(870, 37, 3))),
+                FieldDefinition(
+                  "four",
+                  NamedType("String", Some(AstLocation(917, 38, 38))),
+                  Vector(InputValueDefinition(
+                    "argument",
+                    NamedType("String", Some(AstLocation(897, 38, 18))),
+                    Some(
+                      StringValue(
+                        "string",
+                        false,
+                        None,
+                        Vector.empty,
+                        Some(AstLocation(906, 38, 27)))),
+                    Vector.empty,
+                    None,
+                    Vector.empty,
+                    Some(AstLocation(887, 38, 8))
+                  )),
+                  Vector.empty,
+                  None,
+                  Vector.empty,
+                  Some(AstLocation(882, 38, 3))
+                ),
                 FieldDefinition(
                   "annotatedField",
                   NamedType("Type", Some(AstLocation(1007, 42, 37))),
@@ -931,6 +964,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
         Document(
           Vector(InterfaceTypeDefinition(
             "Hello",
+            Vector.empty,
             Vector(
               FieldDefinition(
                 "world",
@@ -1275,6 +1309,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
               "Bar",
               Vector.empty,
               Vector.empty,
+              Vector.empty,
               None,
               Vector.empty,
               Vector.empty,
@@ -1326,6 +1361,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeDefinition(
               "Bar",
+              Vector.empty,
               Vector.empty,
               Vector.empty,
               None,
@@ -1440,6 +1476,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeExtensionDefinition(
               "Bar",
+              Vector.empty,
               Vector(FieldDefinition(
                 "f2",
                 ListType(
@@ -1544,6 +1581,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeExtensionDefinition(
               "EmptyBar",
+              Vector.empty,
               Vector.empty,
               Vector(
                 Directive(

--- a/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -378,7 +378,7 @@ class SchemaRenderSpec
         |  query: Root
         |}
         |
-        |interface Baaz {
+        |interface Baaz implements Foo {
         |  int: Int
         |  str: String
         |}


### PR DESCRIPTION
Add support for interfaces implementing interfaces

This is per the RFC 373 found here: https://github.com/graphql/graphql-spec/pull/373

TODO:
- [ ] Validate that there are no cycles
- [ ] Validate that transitively implemented interfaces (interfaces implemented by the interface that is being implemented) must also be defined on an implementing type or interface.
- [ ] Validate that the implementing interface must define each field that is specified by the implemented interface. 
- [ ] Add more tests