### PR TITLE
Support implicit output type lookups for interface types.

### DIFF
--- a/modules/core/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
@@ -17,6 +17,11 @@ object GraphQLOutputTypeLookup extends GraphQLOutputTypeLookupLowPrio {
       override val graphqlType: OutputType[T] = out
     }
 
+  implicit def interfaceLookup[T](implicit interfaceType: InterfaceType[_, T]): GraphQLOutputTypeLookup[T] =
+    new GraphQLOutputTypeLookup[T] {
+      override def graphqlType: OutputType[T] = interfaceType
+    }
+
   implicit def optionLookup[T: GraphQLOutputTypeLookup]: GraphQLOutputTypeLookup[Option[T]] =
     new GraphQLOutputTypeLookup[Option[T]] {
       override val graphqlType: OptionType[T] = OptionType(

--- a/modules/core/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/GraphQLOutputTypeLookup.scala
@@ -17,7 +17,8 @@ object GraphQLOutputTypeLookup extends GraphQLOutputTypeLookupLowPrio {
       override val graphqlType: OutputType[T] = out
     }
 
-  implicit def interfaceLookup[T](implicit interfaceType: InterfaceType[_, T]): GraphQLOutputTypeLookup[T] =
+  implicit def interfaceLookup[T](implicit
+      interfaceType: InterfaceType[_, T]): GraphQLOutputTypeLookup[T] =
     new GraphQLOutputTypeLookup[T] {
       override def graphqlType: OutputType[T] = interfaceType
     }

--- a/modules/core/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/modules/core/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -778,12 +778,21 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
     }
 
     "derive a context object type with an implicit interface type and an implicit object type implementing the interface" in {
-      implicit val Parent1ObjectType = Parent1Type
-      implicit val TestSubjectType = deriveObjectType[Unit, TestSubject](Interfaces(Parent1Type))
+      trait Parent3 {
+        def id: String
+      }
+
+      case class TestSubject1(id: String, list: List[String] = Nil, excluded: Int) extends Parent3
+
+      implicit val Parent3Type = InterfaceType(
+        "Parent3",
+        fields[Unit, Parent3](Field("id", StringType, resolve = _.value.id)))
+
+      implicit val TestSubject1Type = deriveObjectType[Unit, TestSubject1](Interfaces(Parent3Type))
 
       class Query {
         @GraphQLField
-        def myMethod: Parent1 = TestSubject("123", List("1", "2", "3"), 123)
+        def myMethod: Parent3 = TestSubject1("123", List("1", "2", "3"), 123)
       }
 
       "deriveContextObjectType[Unit, Query, Unit](_ => new Query)" should compile

--- a/modules/core/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/modules/core/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -776,5 +776,17 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
 
       "deriveObjectType[Unit, TestContainer[TestSubject]]()" should compile
     }
+
+    "derive a context object type with an implicit interface type and an implicit object type implementing the interface" in {
+      implicit val Parent1ObjectType = Parent1Type
+      implicit val TestSubjectType = deriveObjectType[Unit, TestSubject](Interfaces(Parent1Type))
+
+      class Query {
+        @GraphQLField
+        def myMethod: Parent1 = TestSubject("123", List("1", "2", "3"), 123)
+      }
+
+      "deriveContextObjectType[Unit, Query, Unit](_ => new Query)" should compile
+    }
   }
 }


### PR DESCRIPTION
This is a new version of https://github.com/sangria-graphql/sangria/pull/306. I hope it maybe can be merged or perhaps it leads to another idea to solve the problem with Interface-Types that cannot be found. All context is in the original pull request so I keep it short here. :)