### PR TITLE
support for configuring max concurrent batches in fetcher

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,6 +9,12 @@ align.preset = none
 
 danglingParentheses.preset = false
 
+rewriteTokens {
+  "⇒":"=>"
+  "←":"<-"
+  "→":"->"
+}
+
 rewrite.rules = [
   AvoidInfix
   RedundantBraces

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ ThisBuild / githubWorkflowBuildPreamble ++= List(
 // Binary Incompatible Changes, we'll document.
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[Problem]("sangria.schema.ProjectedName*"),
-  ProblemFilters.exclude[Problem]("sangria.schema.Args*")
+  ProblemFilters.exclude[Problem]("sangria.schema.Args*"),
+  ProblemFilters.exclude[Problem]("sangria.execution.deferred.FetcherConfig*")
 )
 
 lazy val root = project

--- a/modules/core/src/main/scala/sangria/execution/deferred/Fetcher.scala
+++ b/modules/core/src/main/scala/sangria/execution/deferred/Fetcher.scala
@@ -201,11 +201,13 @@ object Fetcher {
 
 case class FetcherConfig(
     cacheConfig: Option[() => FetcherCache] = None,
-    maxBatchSizeConfig: Option[Int] = None) {
+    maxBatchSizeConfig: Option[Int] = None,
+    maxConcurrentBatchesConfig: Option[Int] = None) {
   def caching = copy(cacheConfig = Some(() => FetcherCache.simple))
   def caching(cache: FetcherCache) = copy(cacheConfig = Some(() => cache))
 
   def maxBatchSize(size: Int) = copy(maxBatchSizeConfig = Some(size))
+  def maxConcurrentBatches(numBatches: Int) = copy(maxConcurrentBatchesConfig = Some(numBatches))
 }
 
 object FetcherConfig {
@@ -215,6 +217,7 @@ object FetcherConfig {
   def caching(cache: FetcherCache) = empty.caching(cache)
 
   def maxBatchSize(size: Int) = empty.maxBatchSize(size)
+  def maxConcurrentBatches(numBatches: Int) = empty.maxConcurrentBatches(numBatches)
 }
 
 trait DeferredOne[+T, Id] extends Deferred[T] {

--- a/modules/core/src/main/scala/sangria/schema/Context.scala
+++ b/modules/core/src/main/scala/sangria/schema/Context.scala
@@ -570,7 +570,7 @@ object Args {
 
     apply(
       schemaElem.arguments,
-      ast.ObjectValue(astElem.arguments.map(arg ⇒ ast.ObjectField(arg.name, arg.value))): ast.Value,
+      ast.ObjectValue(astElem.arguments.map(arg => ast.ObjectField(arg.name, arg.value))): ast.Value,
       Some(variables)
     )
   }

--- a/modules/core/src/main/scala/sangria/schema/Context.scala
+++ b/modules/core/src/main/scala/sangria/schema/Context.scala
@@ -570,7 +570,8 @@ object Args {
 
     apply(
       schemaElem.arguments,
-      ast.ObjectValue(astElem.arguments.map(arg => ast.ObjectField(arg.name, arg.value))): ast.Value,
+      ast.ObjectValue(
+        astElem.arguments.map(arg => ast.ObjectField(arg.name, arg.value))): ast.Value,
       Some(variables)
     )
   }


### PR DESCRIPTION
added a new config param maxConcurrentBatches to configure
the max number of batched IDs that can be fetched concurrently by fetcher.
not specifying any value for this param will fallback to the existing
behaviour of running all batches concurrently.