### PR TITLE
Minor performance optimization to ValueCoercionHelper.valuePosition

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/ValueCoercionHelper.scala
+++ b/modules/core/src/main/scala/sangria/execution/ValueCoercionHelper.scala
@@ -568,16 +568,15 @@ class ValueCoercionHelper[Ctx](
   }
 
   private def valuePosition[T](forNode: Option[ast.AstNode], value: T*): List[AstLocation] = {
-    val values = value.view.collect {
-      case node: ast.AstNode if node.location.isDefined => node.location.toList
+    val firstValue = value.collectFirst {
+      case node: ast.AstNode if node.location.isDefined => node.location.get
     }
 
-    val nodeLocations: List[AstLocation] = forNode match {
-      case Some(n) if n.location.isDefined => List(n.location.get)
-      case _ => Nil
+    val nodeLocation: Option[AstLocation] = forNode.collect {
+      case n if n.location.isDefined => n.location.get
     }
 
-    values.headOption.fold(nodeLocations)(nodeLocations ++ _)
+    nodeLocation.toList ++ firstValue.toList
   }
 
   def isValidValue[In](tpe: InputType[_], input: Option[In])(implicit


### PR DESCRIPTION
This function shows up while profiling mostly due to the creation of the `View` which is not strictly necessary.

The proposed implementation only relies on `collectFirst` which should be significantly faster than `view.collect.headOption`