### PR TITLE
document some of the AST & parser packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[Problem]("sangria.execution.deferred.FetcherConfig*"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.ast.FragmentDefinition.typeConditionOpt"),
   ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.ast.ObjectValue.fieldsByName"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.marshalling.QueryAstInputUnmarshaller.getMapKeys"),
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,6 @@
 import sbt.Developer
-import sbt.Keys.{
-  crossScalaVersions,
-  developers,
-  organizationHomepage,
-  scalacOptions,
-  scmInfo,
-  startYear
-}
-import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+import sbt.Keys.{crossScalaVersions, developers, organizationHomepage, scalacOptions, scmInfo, startYear}
+import com.typesafe.tools.mima.core.{DirectMissingMethodProblem, IncompatibleResultTypeProblem, Problem, ProblemFilters}
 
 // sbt-github-actions needs configuration in `ThisBuild`
 ThisBuild / crossScalaVersions := Seq("2.12.14", "2.13.6")
@@ -38,7 +31,9 @@ ThisBuild / githubWorkflowPublish := Seq(
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[Problem]("sangria.schema.ProjectedName*"),
   ProblemFilters.exclude[Problem]("sangria.schema.Args*"),
-  ProblemFilters.exclude[Problem]("sangria.execution.deferred.FetcherConfig*")
+  ProblemFilters.exclude[Problem]("sangria.execution.deferred.FetcherConfig*"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.ast.FragmentDefinition.typeConditionOpt"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.ast.ObjectValue.fieldsByName"),
 )
 
 lazy val root = project
@@ -127,6 +122,9 @@ lazy val scalacSettings = Seq(
     if (scalaVersion.value.startsWith("2.12")) Seq("-language:higherKinds") else List.empty[String]
   },
   scalacOptions += "-target:jvm-1.8",
+  Compile / doc / scalacOptions ++= Seq(  // scaladoc options
+    "-groups"
+  ),
   javacOptions ++= Seq("-source", "8", "-target", "8")
 )
 

--- a/modules/core/src/main/scala/sangria/ast/AstLocation.scala
+++ b/modules/core/src/main/scala/sangria/ast/AstLocation.scala
@@ -2,10 +2,14 @@ package sangria.ast
 
 /** A location within a GraphQL source code string.
   *
-  * @param sourceId The ID of the source code.
-  * @param index The offset of the location as characters from the start of the source code.
-  * @param line The line number of the location within the source code.
-  * @param column The column number of the location within the source code.
+  * @param sourceId
+  *   The ID of the source code.
+  * @param index
+  *   The offset of the location as characters from the start of the source code.
+  * @param line
+  *   The line number of the location within the source code.
+  * @param column
+  *   The column number of the location within the source code.
   */
 case class AstLocation(sourceId: String, index: Int, line: Int, column: Int)
 

--- a/modules/core/src/main/scala/sangria/ast/AstLocation.scala
+++ b/modules/core/src/main/scala/sangria/ast/AstLocation.scala
@@ -1,0 +1,15 @@
+package sangria.ast
+
+/** A location within a GraphQL source code string.
+  *
+  * @param sourceId The ID of the source code.
+  * @param index The offset of the location as characters from the start of the source code.
+  * @param line The line number of the location within the source code.
+  * @param column The column number of the location within the source code.
+  */
+case class AstLocation(sourceId: String, index: Int, line: Int, column: Int)
+
+object AstLocation {
+  def apply(index: Int, line: Int, column: Int): AstLocation =
+    AstLocation("", index, line, column)
+}

--- a/modules/core/src/main/scala/sangria/ast/AstVisitorCommand.scala
+++ b/modules/core/src/main/scala/sangria/ast/AstVisitorCommand.scala
@@ -1,0 +1,11 @@
+package sangria.ast
+
+import sangria.validation.Violation
+
+object AstVisitorCommand extends Enumeration {
+  val Skip, Continue, Break = Value
+
+  val RightContinue: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Continue)
+  val RightSkip: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Skip)
+  val RightBreak: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Break)
+}

--- a/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
+++ b/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
@@ -1,0 +1,12 @@
+package sangria.ast
+
+import sangria.visitor.VisitorCommand
+
+case class DefaultAstVisitor(
+  override val onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ =>
+    VisitorCommand.Continue
+  },
+  override val onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ =>
+    VisitorCommand.Continue
+  }
+) extends AstVisitor

--- a/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
+++ b/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
@@ -3,10 +3,10 @@ package sangria.ast
 import sangria.visitor.VisitorCommand
 
 case class DefaultAstVisitor(
-  override val onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-    VisitorCommand.Continue
-  },
-  override val onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-    VisitorCommand.Continue
-  }
+    override val onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ =>
+      VisitorCommand.Continue
+    },
+    override val onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ =>
+      VisitorCommand.Continue
+    }
 ) extends AstVisitor

--- a/modules/core/src/main/scala/sangria/ast/OperationType.scala
+++ b/modules/core/src/main/scala/sangria/ast/OperationType.scala
@@ -1,0 +1,9 @@
+package sangria.ast
+
+sealed trait OperationType
+
+object OperationType {
+  case object Query extends OperationType
+  case object Mutation extends OperationType
+  case object Subscription extends OperationType
+}

--- a/modules/core/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/core/src/main/scala/sangria/ast/QueryAst.scala
@@ -362,33 +362,56 @@ case class Argument(
   * [[ObjectValue objects]], or [[NullValue null values]].
   *
   * @see [[https://spec.graphql.org/June2018/#Value]]
+  * @group value
   */
 sealed trait Value extends AstNode with WithComments {
   override def renderPretty: String = QueryRenderer.render(this, QueryRenderer.PrettyInput)
 }
 
+/**
+  * @group scalar
+  */
 sealed trait ScalarValue extends Value
 
+/**
+  * @group scalar
+  */
 case class IntValue(
     value: Int,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group scalar
+  */
 case class BigIntValue(
     value: BigInt,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group scalar
+  */
 case class FloatValue(
     value: Double,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group scalar
+  */
 case class BigDecimalValue(
     value: BigDecimal,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group scalar
+  */
 case class StringValue(
     value: String,
     block: Boolean = false,
@@ -396,28 +419,52 @@ case class StringValue(
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group scalar
+  */
 case class BooleanValue(
     value: Boolean,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends ScalarValue
+
+/**
+  * @group value
+  */
 case class EnumValue(
     value: String,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends Value
+
+/**
+  * @group value
+  */
 case class ListValue(
     values: Vector[Value],
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends Value
+
+/**
+  * @group value
+  */
 case class VariableValue(
     name: String,
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends Value
+
+/**
+  * @group value
+  */
 case class NullValue(comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None)
     extends Value
+
+/**
+  * @group value
+  */
 case class ObjectValue(
     fields: Vector[ObjectField],
     comments: Vector[Comment] = Vector.empty,
@@ -429,6 +476,9 @@ case class ObjectValue(
     }
 }
 
+/**
+  * @group value
+  */
 object ObjectValue {
   def apply(fields: (String, Value)*): ObjectValue = ObjectValue(
     fields.toVector.map(f => ObjectField(f._1, f._2)))

--- a/modules/core/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/core/src/main/scala/sangria/ast/QueryAst.scala
@@ -14,10 +14,12 @@ import scala.collection.immutable.ListMap
 
 /** A complete GraphQL request operated on by a GraphQL service.
   *
-  * @param definitions The definitions, which primarily constitute the document.
+  * @param definitions
+  *   The definitions, which primarily constitute the document.
   * @param sourceMapper
   *
-  * @see [[https://spec.graphql.org/June2018/#Document]]
+  * @see
+  *   [[https://spec.graphql.org/June2018/#Document]]
   */
 case class Document(
     definitions: Vector[Definition],
@@ -26,14 +28,17 @@ case class Document(
     sourceMapper: Option[SourceMapper] = None)
     extends AstNode
     with WithTrailingComments {
+
   /** Map of operation name to its definition. */
-  lazy val operations: Map[Option[String], OperationDefinition] = Map(definitions.collect { case op: OperationDefinition =>
-    op.name -> op
+  lazy val operations: Map[Option[String], OperationDefinition] = Map(definitions.collect {
+    case op: OperationDefinition =>
+      op.name -> op
   }: _*)
 
   /** Map of fragment name to its definition. */
-  lazy val fragments: Map[String, FragmentDefinition] = Map(definitions.collect { case fragment: FragmentDefinition =>
-    fragment.name -> fragment
+  lazy val fragments: Map[String, FragmentDefinition] = Map(definitions.collect {
+    case fragment: FragmentDefinition =>
+      fragment.name -> fragment
   }: _*)
 
   lazy val source: Option[String] = sourceMapper.map(_.source)
@@ -43,7 +48,8 @@ case class Document(
 
   /** Return the operation for the given name.
     *
-    * @return `None`, if no operations are defined or if the given name is ambiguous
+    * @return
+    *   `None`, if no operations are defined or if the given name is ambiguous
     */
   def operation(operationName: Option[String] = None): Option[OperationDefinition] =
     if (operationName.isEmpty && operations.size != 1)
@@ -53,7 +59,9 @@ case class Document(
     else
       operationName
         .flatMap(opName => operations.get(Some(opName)))
-        .orElse(operations.values.headOption)  //FIXME This appears to return the first operation if the named one doesn't exist?
+        .orElse(
+          operations.values.headOption
+        ) //FIXME This appears to return the first operation if the named one doesn't exist?
 
   def withoutSourceMapper: Document = copy(sourceMapper = None)
 
@@ -70,8 +78,10 @@ case class Document(
 
   lazy val separateOperations: Map[Option[String], Document] = analyzer.separateOperations
 
-  def separateOperation(definition: OperationDefinition): Document = analyzer.separateOperation(definition)
-  def separateOperation(operationName: Option[String]): Option[Document] = analyzer.separateOperation(operationName)
+  def separateOperation(definition: OperationDefinition): Document =
+    analyzer.separateOperation(definition)
+  def separateOperation(operationName: Option[String]): Option[Document] =
+    analyzer.separateOperation(operationName)
 
   override def equals(other: Any): Boolean = other match {
     case that: Document =>
@@ -202,29 +212,32 @@ sealed trait SelectionContainer extends AstNode with WithComments with WithTrail
 
 /** A definition in a [[Document GraphQL document]].
   *
-  * A GraphQL document consists primarily of definitions,
-  * which are either executable or representative of a GraphQL type system.
-  * The executable definitions are [[OperationDefinition operation]] and [[FragmentDefinition fragment definitions]];
-  * those that represent a type system fall into [[TypeSystemDefinition definition]]
-  * or [[TypeSystemExtensionDefinition extension]] categories.
+  * A GraphQL document consists primarily of definitions, which are either executable or
+  * representative of a GraphQL type system. The executable definitions are
+  * [[OperationDefinition operation]] and [[FragmentDefinition fragment definitions]]; those that
+  * represent a type system fall into [[TypeSystemDefinition definition]] or
+  * [[TypeSystemExtensionDefinition extension]] categories.
   *
-  * @see [[https://spec.graphql.org/June2018/#Definition]]
+  * @see
+  *   [[https://spec.graphql.org/June2018/#Definition]]
   */
 sealed trait Definition extends AstNode
 
 /** A definition of a GraphQL operation.
   *
-  * Every GraphQL request invokes a specific operation,
-  * possibly with values to substitute into the operation's variables.
+  * Every GraphQL request invokes a specific operation, possibly with values to substitute into the
+  * operation's variables.
   *
   * @param name
-  *   The name of the operation. Optional only if there is only one operation in the [[Document document]].
-  *   Used for selecting the specific operation to invoke in a GraphQL request.
+  *   The name of the operation. Optional only if there is only one operation in the
+  *   [[Document document]]. Used for selecting the specific operation to invoke in a GraphQL
+  *   request.
   * @param variables
-  *   The variables that must be substituted into the operation.
-  *   Values for these must be provided either by their defaults or with the GraphQL request.
+  *   The variables that must be substituted into the operation. Values for these must be provided
+  *   either by their defaults or with the GraphQL request.
   *
-  * @see [[https://spec.graphql.org/June2018/#OperationDefinition]]
+  * @see
+  *   [[https://spec.graphql.org/June2018/#OperationDefinition]]
   */
 case class OperationDefinition(
     operationType: OperationType = OperationType.Query,
@@ -257,11 +270,14 @@ case class FragmentDefinition(
 
 /** A definition of a variable to an [[OperationDefinition operation]].
   *
-  * @param name Name of the variable being defined.
+  * @param name
+  *   Name of the variable being defined.
   * @param defaultValue
-  *   Value that the variable should assume in an operation if none was provided with the GraphQL request.
+  *   Value that the variable should assume in an operation if none was provided with the GraphQL
+  *   request.
   *
-  * @see [[https://spec.graphql.org/June2018/#VariableDefinition]]
+  * @see
+  *   [[https://spec.graphql.org/June2018/#VariableDefinition]]
   */
 case class VariableDefinition(
     name: String,
@@ -357,24 +373,23 @@ case class Argument(
 
 /** A value that can be substituted into a GraphQL operation [[VariableDefinition variable]].
   *
-  * Called "input values" in the GraphQL spec.
-  * Input values can be [[ScalarValue scalars]], [[EnumValue enumeration values]], [[ListValue lists]],
-  * [[ObjectValue objects]], or [[NullValue null values]].
+  * Called "input values" in the GraphQL spec. Input values can be [[ScalarValue scalars]],
+  * [[EnumValue enumeration values]], [[ListValue lists]], [[ObjectValue objects]], or
+  * [[NullValue null values]].
   *
-  * @see [[https://spec.graphql.org/June2018/#Value]]
+  * @see
+  *   [[https://spec.graphql.org/June2018/#Value]]
   * @group value
   */
 sealed trait Value extends AstNode with WithComments {
   override def renderPretty: String = QueryRenderer.render(this, QueryRenderer.PrettyInput)
 }
 
-/**
-  * @group scalar
+/** @group scalar
   */
 sealed trait ScalarValue extends Value
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class IntValue(
     value: Int,
@@ -382,8 +397,7 @@ case class IntValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class BigIntValue(
     value: BigInt,
@@ -391,8 +405,7 @@ case class BigIntValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class FloatValue(
     value: Double,
@@ -400,8 +413,7 @@ case class FloatValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class BigDecimalValue(
     value: BigDecimal,
@@ -409,8 +421,7 @@ case class BigDecimalValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class StringValue(
     value: String,
@@ -420,8 +431,7 @@ case class StringValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group scalar
+/** @group scalar
   */
 case class BooleanValue(
     value: Boolean,
@@ -429,8 +439,7 @@ case class BooleanValue(
     location: Option[AstLocation] = None)
     extends ScalarValue
 
-/**
-  * @group value
+/** @group value
   */
 case class EnumValue(
     value: String,
@@ -438,8 +447,7 @@ case class EnumValue(
     location: Option[AstLocation] = None)
     extends Value
 
-/**
-  * @group value
+/** @group value
   */
 case class ListValue(
     values: Vector[Value],
@@ -447,8 +455,7 @@ case class ListValue(
     location: Option[AstLocation] = None)
     extends Value
 
-/**
-  * @group value
+/** @group value
   */
 case class VariableValue(
     name: String,
@@ -456,14 +463,12 @@ case class VariableValue(
     location: Option[AstLocation] = None)
     extends Value
 
-/**
-  * @group value
+/** @group value
   */
 case class NullValue(comments: Vector[Comment] = Vector.empty, location: Option[AstLocation] = None)
     extends Value
 
-/**
-  * @group value
+/** @group value
   */
 case class ObjectValue(
     fields: Vector[ObjectField],
@@ -476,8 +481,7 @@ case class ObjectValue(
     }
 }
 
-/**
-  * @group value
+/** @group value
   */
 object ObjectValue {
   def apply(fields: (String, Value)*): ObjectValue = ObjectValue(
@@ -724,6 +728,7 @@ case class OperationTypeDefinition(
 
 /** A node in the AST of a parsed GraphQL request document. */
 sealed trait AstNode {
+
   /** Location at which this node lexically begins in the GraphQL request source code. */
   def location: Option[AstLocation]
   def cacheKeyHash: Int = System.identityHashCode(this)

--- a/modules/core/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/core/src/main/scala/sangria/ast/QueryAst.scala
@@ -6,30 +6,45 @@ import sangria.parser.{AggregateSourceMapper, DeliveryScheme, SourceMapper}
 import sangria.renderer.QueryRenderer
 import sangria.validation.DocumentAnalyzer
 import sangria.schema.{InputType, Schema}
-import sangria.validation.{TypeInfo, Violation}
+import sangria.validation.TypeInfo
 import sangria.visitor._
 
 import scala.util.control.Breaks._
 import scala.collection.immutable.ListMap
 
+/** A complete GraphQL request operated on by a GraphQL service.
+  *
+  * @param definitions The definitions, which primarily constitute the document.
+  * @param sourceMapper
+  *
+  * @see [[https://spec.graphql.org/June2018/#Document]]
+  */
 case class Document(
     definitions: Vector[Definition],
-    trailingComments: Vector[Comment] = Vector.empty,
-    location: Option[AstLocation] = None,
+    override val trailingComments: Vector[Comment] = Vector.empty,
+    override val location: Option[AstLocation] = None,
     sourceMapper: Option[SourceMapper] = None)
     extends AstNode
     with WithTrailingComments {
-  lazy val operations = Map(definitions.collect { case op: OperationDefinition =>
+  /** Map of operation name to its definition. */
+  lazy val operations: Map[Option[String], OperationDefinition] = Map(definitions.collect { case op: OperationDefinition =>
     op.name -> op
   }: _*)
-  lazy val fragments = Map(definitions.collect { case fragment: FragmentDefinition =>
+
+  /** Map of fragment name to its definition. */
+  lazy val fragments: Map[String, FragmentDefinition] = Map(definitions.collect { case fragment: FragmentDefinition =>
     fragment.name -> fragment
   }: _*)
+
   lazy val source: Option[String] = sourceMapper.map(_.source)
 
   def operationType(operationName: Option[String] = None): Option[OperationType] =
     operation(operationName).map(_.operationType)
 
+  /** Return the operation for the given name.
+    *
+    * @return `None`, if no operations are defined or if the given name is ambiguous
+    */
   def operation(operationName: Option[String] = None): Option[OperationDefinition] =
     if (operationName.isEmpty && operations.size != 1)
       None
@@ -38,36 +53,35 @@ case class Document(
     else
       operationName
         .flatMap(opName => operations.get(Some(opName)))
-        .orElse(operations.values.headOption)
+        .orElse(operations.values.headOption)  //FIXME This appears to return the first operation if the named one doesn't exist?
 
-  def withoutSourceMapper = copy(sourceMapper = None)
+  def withoutSourceMapper: Document = copy(sourceMapper = None)
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Document]
 
-  /** Merges two documents. The `sourceMapper` is lost along the way.
-    */
-  def merge(other: Document) = Document.merge(Vector(this, other))
+  /** Merges two documents. The `sourceMapper`s are combined. */
+  def merge(other: Document): Document = Document.merge(Vector(this, other))
 
   /** An alias for `merge`
     */
-  def +(other: Document) = merge(other)
+  def +(other: Document): Document = merge(other)
 
-  lazy val analyzer = DocumentAnalyzer(this)
+  lazy val analyzer: DocumentAnalyzer = DocumentAnalyzer(this)
 
   lazy val separateOperations: Map[Option[String], Document] = analyzer.separateOperations
 
-  def separateOperation(definition: OperationDefinition) = analyzer.separateOperation(definition)
-  def separateOperation(operationName: Option[String]) = analyzer.separateOperation(operationName)
+  def separateOperation(definition: OperationDefinition): Document = analyzer.separateOperation(definition)
+  def separateOperation(operationName: Option[String]): Option[Document] = analyzer.separateOperation(operationName)
 
   override def equals(other: Any): Boolean = other match {
     case that: Document =>
-      (that.canEqual(this)) &&
+      that.canEqual(this) &&
         definitions == that.definitions &&
         location == that.location
     case _ => false
   }
 
-  private lazy val hash =
+  private[this] lazy val hash =
     Seq(definitions, location).map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
 
   override def hashCode(): Int = hash
@@ -112,11 +126,11 @@ case class InputDocument(
 
   /** Merges two documents. The `sourceMapper` is lost along the way.
     */
-  def merge(other: InputDocument) = InputDocument.merge(Vector(this, other))
+  def merge(other: InputDocument): InputDocument = InputDocument.merge(Vector(this, other))
 
   /** An alias for `merge`
     */
-  def +(other: InputDocument) = merge(other)
+  def +(other: InputDocument): InputDocument = merge(other)
 
   def to[T](
       schema: Schema[_, _],
@@ -186,17 +200,41 @@ sealed trait SelectionContainer extends AstNode with WithComments with WithTrail
   def location: Option[AstLocation]
 }
 
+/** A definition in a [[Document GraphQL document]].
+  *
+  * A GraphQL document consists primarily of definitions,
+  * which are either executable or representative of a GraphQL type system.
+  * The executable definitions are [[OperationDefinition operation]] and [[FragmentDefinition fragment definitions]];
+  * those that represent a type system fall into [[TypeSystemDefinition definition]]
+  * or [[TypeSystemExtensionDefinition extension]] categories.
+  *
+  * @see [[https://spec.graphql.org/June2018/#Definition]]
+  */
 sealed trait Definition extends AstNode
 
+/** A definition of a GraphQL operation.
+  *
+  * Every GraphQL request invokes a specific operation,
+  * possibly with values to substitute into the operation's variables.
+  *
+  * @param name
+  *   The name of the operation. Optional only if there is only one operation in the [[Document document]].
+  *   Used for selecting the specific operation to invoke in a GraphQL request.
+  * @param variables
+  *   The variables that must be substituted into the operation.
+  *   Values for these must be provided either by their defaults or with the GraphQL request.
+  *
+  * @see [[https://spec.graphql.org/June2018/#OperationDefinition]]
+  */
 case class OperationDefinition(
     operationType: OperationType = OperationType.Query,
     name: Option[String] = None,
     variables: Vector[VariableDefinition] = Vector.empty,
-    directives: Vector[Directive] = Vector.empty,
-    selections: Vector[Selection],
-    comments: Vector[Comment] = Vector.empty,
-    trailingComments: Vector[Comment] = Vector.empty,
-    location: Option[AstLocation] = None)
+    override val directives: Vector[Directive] = Vector.empty,
+    override val selections: Vector[Selection],
+    override val comments: Vector[Comment] = Vector.empty,
+    override val trailingComments: Vector[Comment] = Vector.empty,
+    override val location: Option[AstLocation] = None)
     extends Definition
     with WithDirectives
     with SelectionContainer
@@ -214,24 +252,24 @@ case class FragmentDefinition(
     with ConditionalFragment
     with WithDirectives
     with SelectionContainer {
-  lazy val typeConditionOpt = Some(typeCondition)
+  lazy val typeConditionOpt: Option[NamedType] = Some(typeCondition)
 }
 
-sealed trait OperationType
-
-object OperationType {
-  case object Query extends OperationType
-  case object Mutation extends OperationType
-  case object Subscription extends OperationType
-}
-
+/** A definition of a variable to an [[OperationDefinition operation]].
+  *
+  * @param name Name of the variable being defined.
+  * @param defaultValue
+  *   Value that the variable should assume in an operation if none was provided with the GraphQL request.
+  *
+  * @see [[https://spec.graphql.org/June2018/#VariableDefinition]]
+  */
 case class VariableDefinition(
     name: String,
     tpe: Type,
     defaultValue: Option[Value],
-    directives: Vector[Directive] = Vector.empty,
-    comments: Vector[Comment] = Vector.empty,
-    location: Option[AstLocation] = None)
+    override val directives: Vector[Directive] = Vector.empty,
+    override val comments: Vector[Comment] = Vector.empty,
+    override val location: Option[AstLocation] = None)
     extends AstNode
     with WithComments
     with WithDirectives
@@ -271,7 +309,7 @@ case class Field(
     extends Selection
     with SelectionContainer
     with WithArguments {
-  lazy val outputName = alias.getOrElse(name)
+  lazy val outputName: String = alias.getOrElse(name)
 }
 
 case class FragmentSpread(
@@ -291,7 +329,7 @@ case class InlineFragment(
     extends Selection
     with ConditionalFragment
     with SelectionContainer {
-  def typeConditionOpt = typeCondition
+  def typeConditionOpt: Option[NamedType] = typeCondition
 }
 
 sealed trait NameValue extends AstNode with WithComments {
@@ -317,6 +355,14 @@ case class Argument(
     location: Option[AstLocation] = None)
     extends NameValue
 
+/** A value that can be substituted into a GraphQL operation [[VariableDefinition variable]].
+  *
+  * Called "input values" in the GraphQL spec.
+  * Input values can be [[ScalarValue scalars]], [[EnumValue enumeration values]], [[ListValue lists]],
+  * [[ObjectValue objects]], or [[NullValue null values]].
+  *
+  * @see [[https://spec.graphql.org/June2018/#Value]]
+  */
 sealed trait Value extends AstNode with WithComments {
   override def renderPretty: String = QueryRenderer.render(this, QueryRenderer.PrettyInput)
 }
@@ -377,7 +423,7 @@ case class ObjectValue(
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends Value {
-  lazy val fieldsByName =
+  lazy val fieldsByName: Map[String, Value] =
     fields.foldLeft(ListMap.empty[String, Value]) { case (acc, field) =>
       acc + (field.name -> field.value)
     }
@@ -407,7 +453,7 @@ case class ScalarTypeDefinition(
     location: Option[AstLocation] = None)
     extends TypeDefinition
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): ScalarTypeDefinition = copy(name = newName)
 }
 
 case class FieldDefinition(
@@ -446,7 +492,7 @@ case class ObjectTypeDefinition(
     extends TypeDefinition
     with WithTrailingComments
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): ObjectTypeDefinition = copy(name = newName)
 }
 
 case class InterfaceTypeDefinition(
@@ -460,7 +506,7 @@ case class InterfaceTypeDefinition(
     extends TypeDefinition
     with WithTrailingComments
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): InterfaceTypeDefinition = copy(name = newName)
 }
 
 case class UnionTypeDefinition(
@@ -472,7 +518,7 @@ case class UnionTypeDefinition(
     location: Option[AstLocation] = None)
     extends TypeDefinition
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): UnionTypeDefinition = copy(name = newName)
 }
 
 case class EnumTypeDefinition(
@@ -486,7 +532,7 @@ case class EnumTypeDefinition(
     extends TypeDefinition
     with WithTrailingComments
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): EnumTypeDefinition = copy(name = newName)
 }
 
 case class EnumValueDefinition(
@@ -510,7 +556,7 @@ case class InputObjectTypeDefinition(
     extends TypeDefinition
     with WithTrailingComments
     with WithDescription {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): InputObjectTypeDefinition = copy(name = newName)
 }
 
 case class ObjectTypeExtensionDefinition(
@@ -523,7 +569,7 @@ case class ObjectTypeExtensionDefinition(
     location: Option[AstLocation] = None)
     extends ObjectLikeTypeExtensionDefinition
     with WithTrailingComments {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): ObjectTypeExtensionDefinition = copy(name = newName)
 }
 
 case class InterfaceTypeExtensionDefinition(
@@ -535,7 +581,7 @@ case class InterfaceTypeExtensionDefinition(
     location: Option[AstLocation] = None)
     extends ObjectLikeTypeExtensionDefinition
     with WithTrailingComments {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): InterfaceTypeExtensionDefinition = copy(name = newName)
 }
 
 case class InputObjectTypeExtensionDefinition(
@@ -547,7 +593,7 @@ case class InputObjectTypeExtensionDefinition(
     location: Option[AstLocation] = None)
     extends TypeExtensionDefinition
     with WithTrailingComments {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): InputObjectTypeExtensionDefinition = copy(name = newName)
 }
 
 case class EnumTypeExtensionDefinition(
@@ -559,7 +605,7 @@ case class EnumTypeExtensionDefinition(
     location: Option[AstLocation] = None)
     extends TypeExtensionDefinition
     with WithTrailingComments {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): EnumTypeExtensionDefinition = copy(name = newName)
 }
 
 case class UnionTypeExtensionDefinition(
@@ -569,7 +615,7 @@ case class UnionTypeExtensionDefinition(
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends TypeExtensionDefinition {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): UnionTypeExtensionDefinition = copy(name = newName)
 }
 
 case class ScalarTypeExtensionDefinition(
@@ -578,7 +624,7 @@ case class ScalarTypeExtensionDefinition(
     comments: Vector[Comment] = Vector.empty,
     location: Option[AstLocation] = None)
     extends TypeExtensionDefinition {
-  def rename(newName: String) = copy(name = newName)
+  def rename(newName: String): ScalarTypeExtensionDefinition = copy(name = newName)
 }
 
 case class SchemaExtensionDefinition(
@@ -626,14 +672,9 @@ case class OperationTypeDefinition(
     location: Option[AstLocation] = None)
     extends SchemaAstNode
 
-case class AstLocation(sourceId: String, index: Int, line: Int, column: Int)
-
-object AstLocation {
-  def apply(index: Int, line: Int, column: Int): AstLocation =
-    AstLocation("", index, line, column)
-}
-
+/** A node in the AST of a parsed GraphQL request document. */
 sealed trait AstNode {
+  /** Location at which this node lexically begins in the GraphQL request source code. */
   def location: Option[AstLocation]
   def cacheKeyHash: Int = System.identityHashCode(this)
 
@@ -690,27 +731,18 @@ trait AstVisitor {
   def onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue }
 }
 
-case class DefaultAstVisitor(
-    override val onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-      VisitorCommand.Continue
-    },
-    override val onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-      VisitorCommand.Continue
-    }
-) extends AstVisitor
-
 object AstVisitor {
   import AstVisitorCommand._
 
   def apply(
       onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue },
       onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue }
-  ) = DefaultAstVisitor(onEnter, onLeave)
+  ): DefaultAstVisitor = DefaultAstVisitor(onEnter, onLeave)
 
   def simple(
       onEnter: PartialFunction[AstNode, Unit] = { case _ => () },
       onLeave: PartialFunction[AstNode, Unit] = { case _ => () }
-  ) = DefaultAstVisitor(
+  ): DefaultAstVisitor = DefaultAstVisitor(
     {
       case node if onEnter.isDefinedAt(node) =>
         onEnter(node)
@@ -1134,12 +1166,4 @@ object AstVisitor {
       loop(doc)
     }
   }
-}
-
-object AstVisitorCommand extends Enumeration {
-  val Skip, Continue, Break = Value
-
-  val RightContinue: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Continue)
-  val RightSkip: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Skip)
-  val RightBreak: Either[Vector[Violation], AstVisitorCommand.Value] = Right(Break)
 }

--- a/modules/core/src/main/scala/sangria/ast/package.scala
+++ b/modules/core/src/main/scala/sangria/ast/package.scala
@@ -4,5 +4,13 @@ package sangria
   *
   * The root of the AST is the [[Document]] type, so that would be the place to start understanding the AST.
   * The AST closely follows the [[https://spec.graphql.org/June2018/#sec-Language specification]].
+  *
+  * @groupname value Value Nodes
+  * @groupdesc value Types that represent input value nodes in the GraphQL AST.
+  * @groupprio value 1
+  *
+  * @groupname scalar Scalar Value Nodes
+  * @groupdesc scalar Types that represent scalar input value nodes in the GraphQL AST.
+  * @groupprio scalar 2
   */
 package object ast {}

--- a/modules/core/src/main/scala/sangria/ast/package.scala
+++ b/modules/core/src/main/scala/sangria/ast/package.scala
@@ -2,15 +2,22 @@ package sangria
 
 /** Scala classes to represent the GraphQL AST (abstract syntax tree).
   *
-  * The root of the AST is the [[Document]] type, so that would be the place to start understanding the AST.
-  * The AST closely follows the [[https://spec.graphql.org/June2018/#sec-Language specification]].
+  * The root of the AST is the [[Document]] type, so that would be the place to start understanding
+  * the AST. The AST closely follows the
+  * [[https://spec.graphql.org/June2018/#sec-Language specification]].
   *
-  * @groupname value Value Nodes
-  * @groupdesc value Types that represent input value nodes in the GraphQL AST.
-  * @groupprio value 1
+  * @groupname value
+  *   Value Nodes
+  * @groupdesc value
+  *   Types that represent input value nodes in the GraphQL AST.
+  * @groupprio value
+  *   1
   *
-  * @groupname scalar Scalar Value Nodes
-  * @groupdesc scalar Types that represent scalar input value nodes in the GraphQL AST.
-  * @groupprio scalar 2
+  * @groupname scalar
+  *   Scalar Value Nodes
+  * @groupdesc scalar
+  *   Types that represent scalar input value nodes in the GraphQL AST.
+  * @groupprio scalar
+  *   2
   */
 package object ast {}

--- a/modules/core/src/main/scala/sangria/ast/package.scala
+++ b/modules/core/src/main/scala/sangria/ast/package.scala
@@ -1,0 +1,8 @@
+package sangria
+
+/** Scala classes to represent the GraphQL AST (abstract syntax tree).
+  *
+  * The root of the AST is the [[Document]] type, so that would be the place to start understanding the AST.
+  * The AST closely follows the [[https://spec.graphql.org/June2018/#sec-Language specification]].
+  */
+package object ast {}

--- a/modules/core/src/main/scala/sangria/marshalling/queryAst.scala
+++ b/modules/core/src/main/scala/sangria/marshalling/queryAst.scala
@@ -40,7 +40,7 @@ class QueryAstInputUnmarshaller extends InputUnmarshaller[ast.Value] {
   def isMapNode(node: ast.Value) = node.isInstanceOf[ast.ObjectValue]
   def getMapValue(node: ast.Value, key: String) =
     node.asInstanceOf[ast.ObjectValue].fieldsByName.get(key)
-  def getMapKeys(node: ast.Value) = node.asInstanceOf[ast.ObjectValue].fieldsByName.keys
+  def getMapKeys(node: ast.Value): Iterable[String] = node.asInstanceOf[ast.ObjectValue].fieldsByName.keys
 
   def isListNode(node: ast.Value) = node.isInstanceOf[ast.ListValue]
   def getListValue(node: ast.Value) = node.asInstanceOf[ast.ListValue].values

--- a/modules/core/src/main/scala/sangria/marshalling/queryAst.scala
+++ b/modules/core/src/main/scala/sangria/marshalling/queryAst.scala
@@ -40,7 +40,8 @@ class QueryAstInputUnmarshaller extends InputUnmarshaller[ast.Value] {
   def isMapNode(node: ast.Value) = node.isInstanceOf[ast.ObjectValue]
   def getMapValue(node: ast.Value, key: String) =
     node.asInstanceOf[ast.ObjectValue].fieldsByName.get(key)
-  def getMapKeys(node: ast.Value): Iterable[String] = node.asInstanceOf[ast.ObjectValue].fieldsByName.keys
+  def getMapKeys(node: ast.Value): Iterable[String] =
+    node.asInstanceOf[ast.ObjectValue].fieldsByName.keys
 
   def isListNode(node: ast.Value) = node.isInstanceOf[ast.ListValue]
   def getListValue(node: ast.Value) = node.asInstanceOf[ast.ListValue].values

--- a/modules/core/src/main/scala/sangria/parser/ParserConfig.scala
+++ b/modules/core/src/main/scala/sangria/parser/ParserConfig.scala
@@ -1,0 +1,50 @@
+package sangria.parser
+
+import org.parboiled2.ParserInput
+
+import java.util.UUID
+
+case class ParserConfig(
+  legacyImplementsInterface: Boolean = false,
+  legacyEmptyFields: Boolean = false,
+  experimentalFragmentVariables: Boolean = false,
+  sourceIdFn: ParserInput => String = ParserConfig.defaultSourceIdFn,
+  sourceMapperFn: (String, ParserInput) => Option[SourceMapper] = ParserConfig.defaultSourceMapperFn,
+  parseLocations: Boolean = true,
+  parseComments: Boolean = true
+) {
+  @deprecated("Use new syntax: `type Foo implements Bar & Baz`", "1.4.0")
+  def withLegacyImplementsInterface: ParserConfig = copy(legacyImplementsInterface = true)
+
+  @deprecated("Use new syntax: `type Foo` instead of legacy `type Foo {}`", "1.4.0")
+  def withLegacyEmptyFields: ParserConfig = copy(legacyEmptyFields = true)
+
+  def withExperimentalFragmentVariables: ParserConfig = copy(experimentalFragmentVariables = true)
+
+  /** Return a new configuration that uses [[ParserConfig#emptySourceIdFn the empty source ID generator]]. */
+  def withEmptySourceId: ParserConfig = copy(sourceIdFn = ParserConfig.emptySourceIdFn)
+
+  def withSourceMapper(fn: (String, ParserInput) => Option[SourceMapper]): ParserConfig =
+    copy(sourceMapperFn = fn)
+
+  /** Return a new configuration that uses [[ParserConfig#emptySourceMapperFn the empty source mapper]]. */
+  def withoutSourceMapper: ParserConfig = copy(sourceMapperFn = ParserConfig.emptySourceMapperFn)
+
+  def withoutLocations: ParserConfig = copy(parseLocations = false)
+
+  def withoutComments: ParserConfig = copy(parseComments = false)
+}
+
+object ParserConfig {
+  lazy val default: ParserConfig = ParserConfig()
+
+  /** Function that always generates an empty identifier. */
+  lazy val emptySourceIdFn: ParserInput => String = _ => ""
+
+  /** Function that generates a random identifier for each input. */
+  lazy val defaultSourceIdFn: ParserInput => String = _ => UUID.randomUUID().toString
+
+  lazy val emptySourceMapperFn: (String, ParserInput) => Option[SourceMapper] = (_, _) => None
+  lazy val defaultSourceMapperFn: (String, ParserInput) => Option[SourceMapper] =
+    (id, input) => Some(new DefaultSourceMapper(id, input))
+}

--- a/modules/core/src/main/scala/sangria/parser/ParserConfig.scala
+++ b/modules/core/src/main/scala/sangria/parser/ParserConfig.scala
@@ -5,13 +5,14 @@ import org.parboiled2.ParserInput
 import java.util.UUID
 
 case class ParserConfig(
-  legacyImplementsInterface: Boolean = false,
-  legacyEmptyFields: Boolean = false,
-  experimentalFragmentVariables: Boolean = false,
-  sourceIdFn: ParserInput => String = ParserConfig.defaultSourceIdFn,
-  sourceMapperFn: (String, ParserInput) => Option[SourceMapper] = ParserConfig.defaultSourceMapperFn,
-  parseLocations: Boolean = true,
-  parseComments: Boolean = true
+    legacyImplementsInterface: Boolean = false,
+    legacyEmptyFields: Boolean = false,
+    experimentalFragmentVariables: Boolean = false,
+    sourceIdFn: ParserInput => String = ParserConfig.defaultSourceIdFn,
+    sourceMapperFn: (String, ParserInput) => Option[SourceMapper] =
+      ParserConfig.defaultSourceMapperFn,
+    parseLocations: Boolean = true,
+    parseComments: Boolean = true
 ) {
   @deprecated("Use new syntax: `type Foo implements Bar & Baz`", "1.4.0")
   def withLegacyImplementsInterface: ParserConfig = copy(legacyImplementsInterface = true)
@@ -21,13 +22,17 @@ case class ParserConfig(
 
   def withExperimentalFragmentVariables: ParserConfig = copy(experimentalFragmentVariables = true)
 
-  /** Return a new configuration that uses [[ParserConfig#emptySourceIdFn the empty source ID generator]]. */
+  /** Return a new configuration that uses
+    * [[ParserConfig#emptySourceIdFn the empty source ID generator]].
+    */
   def withEmptySourceId: ParserConfig = copy(sourceIdFn = ParserConfig.emptySourceIdFn)
 
   def withSourceMapper(fn: (String, ParserInput) => Option[SourceMapper]): ParserConfig =
     copy(sourceMapperFn = fn)
 
-  /** Return a new configuration that uses [[ParserConfig#emptySourceMapperFn the empty source mapper]]. */
+  /** Return a new configuration that uses
+    * [[ParserConfig#emptySourceMapperFn the empty source mapper]].
+    */
   def withoutSourceMapper: ParserConfig = copy(sourceMapperFn = ParserConfig.emptySourceMapperFn)
 
   def withoutLocations: ParserConfig = copy(parseLocations = false)

--- a/modules/core/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/modules/core/src/main/scala/sangria/parser/PositionTracking.scala
@@ -6,6 +6,7 @@ import sangria.ast.AstLocation
 import scala.annotation.tailrec
 
 trait PositionTracking { this: Parser =>
+
   /** The indices (offsets into the source code) of the first characters of each line. */
   private[this] var lineIdx = Array(0)
 

--- a/modules/core/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/modules/core/src/main/scala/sangria/parser/PositionTracking.scala
@@ -6,7 +6,8 @@ import sangria.ast.AstLocation
 import scala.annotation.tailrec
 
 trait PositionTracking { this: Parser =>
-  private var lineIdx = Array(0)
+  /** The indices (offsets into the source code) of the first characters of each line. */
+  private[this] var lineIdx = Array(0)
 
   def parseLocations: Boolean
   def sourceId: String
@@ -19,9 +20,9 @@ trait PositionTracking { this: Parser =>
 
   def trackPos: Rule1[Option[AstLocation]] = rule {
     test(parseLocations) ~ push {
-      val (size, lastCursor) = findLastItem(lineIdx, cursor)
+      val (line, lastCursor) = findLastItem(lineIdx, cursor)
 
-      Some(AstLocation(sourceId, cursor, size, cursor - lastCursor + 1))
+      Some(AstLocation(sourceId, cursor, line, cursor - lastCursor + 1))
     } | push(None)
   }
 

--- a/modules/core/src/main/scala/sangria/parser/QueryParser.scala
+++ b/modules/core/src/main/scala/sangria/parser/QueryParser.scala
@@ -1,7 +1,5 @@
 package sangria.parser
 
-import java.util.UUID
-
 import org.parboiled2._
 import CharPredicate.{Digit19, HexDigit}
 import sangria.ast

--- a/modules/core/src/main/scala/sangria/parser/QueryParser.scala
+++ b/modules/core/src/main/scala/sangria/parser/QueryParser.scala
@@ -103,8 +103,11 @@ trait Tokens extends StringBuilding with PositionTracking { this: Parser with Ig
   def Keyword(s: String) = rule(atomic(Ignored.* ~ s ~ !NameChar ~ IgnoredNoComment.*))
 }
 
-/** Mix-in that defines GraphQL grammar productions that are typically ignored (whitespace, comments, etc.). */
+/** Mix-in that defines GraphQL grammar productions that are typically ignored (whitespace,
+  * comments, etc.).
+  */
 trait Ignored extends PositionTracking { this: Parser =>
+
   /** Whether comments should be parsed into the resulting AST. */
   def parseComments: Boolean
 

--- a/modules/core/src/main/scala/sangria/parser/SourceMapper.scala
+++ b/modules/core/src/main/scala/sangria/parser/SourceMapper.scala
@@ -3,46 +3,70 @@ package sangria.parser
 import org.parboiled2.ParserInput
 import sangria.ast.AstLocation
 
+/** Set of functions that convert a [[AstLocation GraphQL source code location]] to human-readable strings.
+  *
+  * When rendering the results of a GraphQL document parse, it's helpful to describe where parsing failed.
+  * This is the interface to that facility.
+  */
 trait SourceMapper {
+  /** Identifier for the GraphQL document being parsed. Should be unique. */
   def id: String
+
+  /** The GraphQL source code mapped by this object. */
   def source: String
+
+  /** Return a description of the given location. */
   def renderLocation(location: AstLocation): String
+
+  /** Return an indication of the line position of the given location.
+    *
+    * Useful for pointing to the location of a parsing error.
+    *
+    * @param prefix prefix to attach to the returned string
+    */
   def renderLinePosition(location: AstLocation, prefix: String = ""): String
 }
 
+/** [[SourceMapper]] for a single GraphQL document. */
 class DefaultSourceMapper(val id: String, val parserInput: ParserInput) extends SourceMapper {
-  lazy val source = parserInput.sliceString(0, parserInput.length)
+  override lazy val source: String = parserInput.sliceString(0, parserInput.length)
 
-  def renderLocation(location: AstLocation) =
+  override def renderLocation(location: AstLocation) =
     s"(line ${location.line}, column ${location.column})"
 
-  def renderLinePosition(location: AstLocation, prefix: String = "") =
+  override def renderLinePosition(location: AstLocation, prefix: String = ""): String =
     parserInput
       .getLine(location.line)
       .replace("\r", "") + "\n" + prefix + (" " * (location.column - 1)) + "^"
 }
 
+/** [[SourceMapper]] for potentially multiple GraphQL documents.
+  *
+  * Sometimes it's necessary to compose a GraphQL document from multiple component documents;
+  * this class provides the corresponding `SourceMapper` to support that.
+  *
+  * @param id Identifier for the combined document.
+  * @param delegates The component documents.
+  */
 class AggregateSourceMapper(val id: String, val delegates: Vector[SourceMapper])
     extends SourceMapper {
   lazy val delegateById: Map[String, SourceMapper] = delegates.iterator.map(d => d.id -> d).toMap
 
-  lazy val source = delegates.map(_.source.trim).mkString("\n\n")
+  override lazy val source: String = delegates.map(_.source.trim).mkString("\n\n")
 
-  def renderLocation(location: AstLocation) =
+  override def renderLocation(location: AstLocation): String =
     delegateById.get(location.sourceId).fold("")(sm => sm.renderLocation(location))
 
-  def renderLinePosition(location: AstLocation, prefix: String = "") =
+  override def renderLinePosition(location: AstLocation, prefix: String = ""): String =
     delegateById.get(location.sourceId).fold("")(sm => sm.renderLinePosition(location, prefix))
 }
 
 object AggregateSourceMapper {
-  def merge(mappers: Vector[SourceMapper]) = {
-    def expand(sm: SourceMapper): Vector[SourceMapper] =
-      sm match {
-        case agg: AggregateSourceMapper => agg.delegates.flatMap(expand)
-        case m => Vector(m)
-      }
-
-    new AggregateSourceMapper("merged", mappers.flatMap(expand))
+  private[this] def expand(sm: SourceMapper): Vector[SourceMapper] = sm match {
+    case agg: AggregateSourceMapper => agg.delegates.flatMap(expand)
+    case m => Vector(m)
   }
+
+  def merge(mappers: Vector[SourceMapper]): AggregateSourceMapper =
+    new AggregateSourceMapper("merged", mappers.flatMap(expand))
 }

--- a/modules/core/src/main/scala/sangria/parser/SourceMapper.scala
+++ b/modules/core/src/main/scala/sangria/parser/SourceMapper.scala
@@ -3,12 +3,14 @@ package sangria.parser
 import org.parboiled2.ParserInput
 import sangria.ast.AstLocation
 
-/** Set of functions that convert a [[AstLocation GraphQL source code location]] to human-readable strings.
+/** Set of functions that convert a [[AstLocation GraphQL source code location]] to human-readable
+  * strings.
   *
-  * When rendering the results of a GraphQL document parse, it's helpful to describe where parsing failed.
-  * This is the interface to that facility.
+  * When rendering the results of a GraphQL document parse, it's helpful to describe where parsing
+  * failed. This is the interface to that facility.
   */
 trait SourceMapper {
+
   /** Identifier for the GraphQL document being parsed. Should be unique. */
   def id: String
 
@@ -22,7 +24,8 @@ trait SourceMapper {
     *
     * Useful for pointing to the location of a parsing error.
     *
-    * @param prefix prefix to attach to the returned string
+    * @param prefix
+    *   prefix to attach to the returned string
     */
   def renderLinePosition(location: AstLocation, prefix: String = ""): String
 }
@@ -42,11 +45,13 @@ class DefaultSourceMapper(val id: String, val parserInput: ParserInput) extends 
 
 /** [[SourceMapper]] for potentially multiple GraphQL documents.
   *
-  * Sometimes it's necessary to compose a GraphQL document from multiple component documents;
-  * this class provides the corresponding `SourceMapper` to support that.
+  * Sometimes it's necessary to compose a GraphQL document from multiple component documents; this
+  * class provides the corresponding `SourceMapper` to support that.
   *
-  * @param id Identifier for the combined document.
-  * @param delegates The component documents.
+  * @param id
+  *   Identifier for the combined document.
+  * @param delegates
+  *   The component documents.
   */
 class AggregateSourceMapper(val id: String, val delegates: Vector[SourceMapper])
     extends SourceMapper {


### PR DESCRIPTION
Also:
- adds type annotations to public members, to address IDE warnings
- adds `override` modifiers
- moves some types from the huge QueryAst.scala file to their own files