### PR TITLE
Do not force QueryValidator to use List

### DIFF
--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -16,7 +16,7 @@ trait QueryValidator {
 }
 
 object QueryValidator {
-  val allRules: List[ValidationRule] = List(
+  val allRules: Seq[ValidationRule] = Seq(
     new ValuesOfCorrectType,
     new ExecutableDefinitions,
     new FieldsOnCorrectType,
@@ -46,7 +46,7 @@ object QueryValidator {
     new SingleFieldSubscriptions
   )
 
-  def ruleBased(rules: List[ValidationRule]) = new RuleBasedQueryValidator(rules)
+  def ruleBased(rules: Seq[ValidationRule]) = new RuleBasedQueryValidator(rules)
 
   val empty = new QueryValidator {
     def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] =
@@ -56,7 +56,7 @@ object QueryValidator {
   val default: RuleBasedQueryValidator = ruleBased(allRules)
 }
 
-class RuleBasedQueryValidator(rules: List[ValidationRule]) extends QueryValidator {
+class RuleBasedQueryValidator(rules: Seq[ValidationRule]) extends QueryValidator {
   def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] = {
     val ctx = new ValidationContext(schema, queryAst, queryAst.sourceMapper, new TypeInfo(schema))
 
@@ -93,7 +93,7 @@ class RuleBasedQueryValidator(rules: List[ValidationRule]) extends QueryValidato
   def validateUsingRules(
       queryAst: ast.AstNode,
       ctx: ValidationContext,
-      visitors: List[ValidationRule#AstValidatingVisitor],
+      visitors: Iterable[ValidationRule#AstValidatingVisitor],
       topLevel: Boolean): Unit = AstVisitor.visitAstRecursive(
     doc = queryAst,
     onEnter = node => {


### PR DESCRIPTION
Do not force the use of `List` type for rules when creating a `QueryValidator`. 

List is not a very efficient type and forcing the clients to create rules in `List` has no obvious benefit because Sangeria is not using any functionality from an actual `List` type.

This gives the users the flexibility to use the types they need, if they need `List` or `Vector` or anything else, this will allow them to do it.

Also, for the `def validateUsingRules()` function, since visitors parameter only gets iterated once, there's no need to mandate any collection type other than an `Iterable`.