### PR TITLE
avoid breaking sangria slow logs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,10 +120,8 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.execution.ExecutionPath.apply"),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "sangria.execution.ExecutionPath.productElementNames"),
-  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.execution.ExecutionPath.path"),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "sangria.execution.ExecutionPath.cacheKeyPath"),
-  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.execution.ExecutionPath.cacheKey"),
   ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.execution.ExecutionPath.copy"),
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "sangria.execution.ExecutionPath.copy$default$*"),

--- a/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -104,7 +104,9 @@ class DeprecationTrackerSpec
       Executor.execute(schema, query, deprecationTracker = deprecationTracker).await
 
       deprecationTracker.times.get should be(1)
-      deprecationTracker.ctx.get.path.path should be(List("nested", "aa", "bb"))
+      deprecationTracker.ctx.get.path.path should be(Vector("nested", "aa", "bb"))
+      deprecationTracker.ctx.get.path.cacheKey should be(
+        Vector("nested", "TestType", "aa", "TestType", "bb", "TestType"))
       deprecationTracker.ctx.get.field.name should be("deprecated")
       deprecationTracker.ctx.get.parentType.name should be("TestType")
     }


### PR DESCRIPTION
Follow-up on https://github.com/sangria-graphql/sangria/pull/769
avoid breaking types of `path` and `cacheKey`.

Fix https://github.com/sangria-graphql/sangria/issues/773