### PR TITLE
backport ExecutionPath.cacheKeyReversed

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/ExecutionPath.scala
+++ b/modules/core/src/main/scala/sangria/execution/ExecutionPath.scala
@@ -29,6 +29,8 @@ case class ExecutionPath private (path: Vector[Any], cacheKeyPath: ExecutionPath
   })
 
   def cacheKey: ExecutionPath.PathCacheKey = cacheKeyPath
+  def cacheKeyReversed: ExecutionPath.PathCacheKeyReversed = cacheKeyPath.reverseIterator.toList
+  def cacheKeyReversedIterator: Iterator[String] = cacheKeyPath.reverseIterator
 
   override def toString = path.foldLeft("") {
     case ("", str: String) => str
@@ -42,6 +44,7 @@ case class ExecutionPath private (path: Vector[Any], cacheKeyPath: ExecutionPath
 
 object ExecutionPath {
   type PathCacheKey = Vector[String]
+  type PathCacheKeyReversed = List[String]
 
   val empty = new ExecutionPath(Vector.empty, Vector.empty)
 }

--- a/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -105,6 +105,12 @@ class DeprecationTrackerSpec
 
       deprecationTracker.times.get should be(1)
       deprecationTracker.ctx.get.path.path should be(Vector("nested", "aa", "bb"))
+      deprecationTracker.ctx.get.path.cacheKey should be(
+        Vector("nested", "TestType", "aa", "TestType", "bb", "TestType"))
+      deprecationTracker.ctx.get.path.cacheKeyReversed should be(
+        List("TestType", "bb", "TestType", "aa", "TestType", "nested"))
+      deprecationTracker.ctx.get.path.cacheKeyReversedIterator.toList should be(
+        List("TestType", "bb", "TestType", "aa", "TestType", "nested"))
       deprecationTracker.ctx.get.field.name should be("deprecated")
       deprecationTracker.ctx.get.parentType.name should be("TestType")
     }


### PR DESCRIPTION
From https://github.com/sangria-graphql/sangria/pull/775
and https://github.com/sangria-graphql/sangria/pull/774

By using this in sangria-slow-logs, we will be able to generate much less objects.