### PR TITLE
introduce ExecutionPath.cacheKeyReversedIterator

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/ExecutionPath.scala
+++ b/modules/core/src/main/scala/sangria/execution/ExecutionPath.scala
@@ -39,6 +39,7 @@ class ExecutionPath private (
 
   def cacheKey: ExecutionPath.PathCacheKey = cacheKeyPath.reverseIterator.toVector
   def cacheKeyReversed: ExecutionPath.PathCacheKeyReversed = cacheKeyPath
+  def cacheKeyReversedIterator: Iterator[String] = cacheKeyPath.iterator
 
   override def toString: String = _path.reverseIterator
     .foldLeft(new StringBuilder) {

--- a/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/DeprecationTrackerSpec.scala
@@ -107,6 +107,10 @@ class DeprecationTrackerSpec
       deprecationTracker.ctx.get.path.path should be(Vector("nested", "aa", "bb"))
       deprecationTracker.ctx.get.path.cacheKey should be(
         Vector("nested", "TestType", "aa", "TestType", "bb", "TestType"))
+      deprecationTracker.ctx.get.path.cacheKeyReversed should be(
+        List("TestType", "bb", "TestType", "aa", "TestType", "nested"))
+      deprecationTracker.ctx.get.path.cacheKeyReversedIterator.toList should be(
+        List("TestType", "bb", "TestType", "aa", "TestType", "nested"))
       deprecationTracker.ctx.get.field.name should be("deprecated")
       deprecationTracker.ctx.get.parentType.name should be("TestType")
     }


### PR DESCRIPTION
same API as in sangria 2.x: https://github.com/sangria-graphql/sangria/pull/781
It will allow to optimize sangria-slow-logs