### PR TITLE
deprecate in 2.x the methods to be removed from the schema representation classes

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/Resolver.scala
+++ b/modules/core/src/main/scala/sangria/execution/Resolver.scala
@@ -1,7 +1,7 @@
 package sangria.execution
 
 import sangria.ast.AstLocation
-import sangria.ast
+import sangria.{ast, since2_1_7}
 import sangria.execution.deferred.{Deferred, DeferredResolver}
 import sangria.marshalling.{ResultMarshaller, ScalarValueInfo}
 import sangria.parser.SourceMapper
@@ -1831,7 +1831,34 @@ case class MappedCtxUpdate[Ctx, Val, NewVal](
     mapFn: Val => NewVal,
     onError: Throwable => Unit)
 
+@deprecated("Moved in 3.0. Use object Marshalling instead.", since2_1_7)
 object Resolver {
+  val DefaultComplexity = 1.0d
+
+  @deprecated("Moved in 3.0. Use Marshalling.marshalEnumValue instead.", since2_1_7)
+  def marshalEnumValue(
+      value: String,
+      marshaller: ResultMarshaller,
+      typeName: String): marshaller.Node = Marshalling.marshalEnumValue(value, marshaller, typeName)
+
+  @deprecated("Moved in 3.0. Use Marshalling.marshalScalarValue instead.", since2_1_7)
+  def marshalScalarValue(
+      value: Any,
+      marshaller: ResultMarshaller,
+      typeName: String,
+      scalarInfo: Set[ScalarValueInfo]): marshaller.Node =
+    Marshalling.marshalScalarValue(value, marshaller, typeName, scalarInfo)
+
+  @deprecated("Moved in 3.0. Use Marshalling.marshalAstValue() instead.", since2_1_7)
+  def marshalAstValue(
+      value: ast.Value,
+      marshaller: ResultMarshaller,
+      typeName: String,
+      scalarInfo: Set[ScalarValueInfo]): marshaller.Node =
+    Marshalling.marshalAstValue(value, marshaller, typeName, scalarInfo)
+}
+
+object Marshalling {
   val DefaultComplexity = 1.0d
 
   def marshalEnumValue(

--- a/modules/core/src/main/scala/sangria/introspection/model.scala
+++ b/modules/core/src/main/scala/sangria/introspection/model.scala
@@ -13,10 +13,16 @@ case class IntrospectionSchema(
     directives: Seq[IntrospectionDirective],
     description: Option[String]
 ) {
-  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•) instead.",
+    since2_1_7
+  )
   def toAst = SchemaRenderer.schemaAstFromIntrospection(this)
 
-  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•, filter) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•, filter) instead.",
+    since2_1_7
+  )
   def toAst(filter: SchemaFilter): Document =
     SchemaRenderer.schemaAstFromIntrospection(this, filter)
 
@@ -26,10 +32,16 @@ case class IntrospectionSchema(
   @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•, filter) instead.", since2_1_7)
   def renderPretty(filter: SchemaFilter): String = toAst(filter).renderPretty
 
-  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•)) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•)) instead.",
+    since2_1_7
+  )
   def renderCompact: String = toAst.renderCompact
 
-  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•, filter)) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•, filter)) instead.",
+    since2_1_7
+  )
   def renderCompact(filter: SchemaFilter): String = toAst(filter).renderCompact
 
   lazy val typesByName = types.groupBy(_.name).map { case (k, v) => (k, v.head) }

--- a/modules/core/src/main/scala/sangria/introspection/model.scala
+++ b/modules/core/src/main/scala/sangria/introspection/model.scala
@@ -1,5 +1,6 @@
 package sangria.introspection
 
+import sangria.since2_1_7
 import sangria.ast.Document
 import sangria.renderer.{SchemaFilter, SchemaRenderer}
 import sangria.schema.DirectiveLocation
@@ -12,14 +13,23 @@ case class IntrospectionSchema(
     directives: Seq[IntrospectionDirective],
     description: Option[String]
 ) {
+  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•) instead.", since2_1_7)
   def toAst = SchemaRenderer.schemaAstFromIntrospection(this)
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAstFromIntrospection(•, filter) instead.", since2_1_7)
   def toAst(filter: SchemaFilter): Document =
     SchemaRenderer.schemaAstFromIntrospection(this, filter)
 
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•) instead.", since2_1_7)
   def renderPretty: String = toAst.renderPretty
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•, filter) instead.", since2_1_7)
   def renderPretty(filter: SchemaFilter): String = toAst(filter).renderPretty
 
+  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•)) instead.", since2_1_7)
   def renderCompact: String = toAst.renderCompact
+
+  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAstFromIntrospection(•, filter)) instead.", since2_1_7)
   def renderCompact(filter: SchemaFilter): String = toAst(filter).renderCompact
 
   lazy val typesByName = types.groupBy(_.name).map { case (k, v) => (k, v.head) }

--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -443,11 +443,14 @@ package object introspection {
   val IntrospectionTypesByName: Map[String, Type with Named] =
     IntrospectionTypes.groupBy(_.name).map { case (k, v) => (k, v.head) }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def introspectionQuery: ast.Document = introspectionQuery()
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def introspectionQuery(schemaDescription: Boolean = true): ast.Document =
     QueryParser.parse(introspectionQueryString(schemaDescription))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def introspectionQueryString(schemaDescription: Boolean = true): String =
     s"""query IntrospectionQuery {
        |  __schema {

--- a/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -4,7 +4,7 @@ import sangria.execution.ValueCoercionHelper
 import sangria.introspection._
 import sangria.marshalling.{InputUnmarshaller, ToInput}
 import sangria.schema._
-import sangria.ast
+import sangria.{ast, since2_1_7}
 import sangria.ast.{AstNode, AstVisitor}
 import sangria.introspection.__DirectiveLocation
 import sangria.parser.QueryParser
@@ -58,6 +58,7 @@ object SchemaRenderer {
       case IntrospectionNamedTypeRef(_, name) => ast.NamedType(name)
     }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderDefault(defaultValue: Option[String]) =
     defaultValue.flatMap(d => QueryParser.parseInput(d).toOption)
 
@@ -67,6 +68,7 @@ object SchemaRenderer {
     DefaultValueRenderer.renderInputValue(value, tpe, coercionHelper)
   }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderArg(arg: IntrospectionInputValue) =
     ast.InputValueDefinition(
       arg.name,
@@ -95,24 +97,28 @@ object SchemaRenderer {
       case _ => Vector.empty
     }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderArgsI(args: Seq[IntrospectionInputValue]) =
     args.map(renderArg).toVector
 
   def renderArgs(args: Seq[Argument[_]]) =
     args.map(renderArg).toVector
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderFieldsI(fields: Seq[IntrospectionField]) =
     fields.map(renderField).toVector
 
   def renderFields(fields: Seq[Field[_, _]]) =
     fields.map(renderField).toVector
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderInputFieldsI(fields: Seq[IntrospectionInputValue]) =
     fields.map(renderInputField).toVector
 
   def renderInputFields(fields: Seq[InputField[_]]) =
     fields.map(renderInputField).toVector
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderField(field: IntrospectionField) =
     ast.FieldDefinition(
       field.name,
@@ -133,6 +139,7 @@ object SchemaRenderer {
       renderDescription(field.description)
     )
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderInputField(field: IntrospectionInputValue) =
     ast.InputValueDefinition(
       field.name,
@@ -149,6 +156,7 @@ object SchemaRenderer {
       renderDescription(field.description)
     )
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderObject(tpe: IntrospectionObjectType) =
     ast.ObjectTypeDefinition(
       tpe.name,
@@ -203,6 +211,7 @@ object SchemaRenderer {
   def renderScalar(tpe: ScalarType[_]) =
     ast.ScalarTypeDefinition(tpe.name, tpe.astDirectives, renderDescription(tpe.description))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderInputObject(tpe: IntrospectionInputObjectType) =
     ast.InputObjectTypeDefinition(
       tpe.name,
@@ -216,6 +225,7 @@ object SchemaRenderer {
       tpe.astDirectives,
       renderDescription(tpe.description))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderInterface(tpe: IntrospectionInterfaceType) =
     ast.InterfaceTypeDefinition(
       tpe.name,
@@ -242,6 +252,7 @@ object SchemaRenderer {
       tpe.astDirectives,
       renderDescription(tpe.description))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   private def renderSchemaDefinition(schema: IntrospectionSchema): Option[ast.SchemaDefinition] =
     if (isSchemaOfCommonNames(
         schema.queryType.name,
@@ -289,6 +300,7 @@ object SchemaRenderer {
     query == "Query" && mutation.fold(true)(_ == "Mutation") && subscription.fold(true)(
       _ == "Subscription")
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderType(tpe: IntrospectionType): ast.TypeDefinition =
     tpe match {
       case o: IntrospectionObjectType => renderObject(o)
@@ -322,6 +334,7 @@ object SchemaRenderer {
       dir.locations.toVector.map(renderDirectiveLocation).sortBy(_.name),
       renderDescription(dir.description))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderDirective(dir: IntrospectionDirective) =
     ast.DirectiveDefinition(
       dir.name,
@@ -329,6 +342,7 @@ object SchemaRenderer {
       dir.locations.toVector.map(renderDirectiveLocation).sortBy(_.name),
       renderDescription(dir.description))
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def schemaAstFromIntrospection(
       introspectionSchema: IntrospectionSchema,
       filter: SchemaFilter = SchemaFilter.default): ast.Document = {
@@ -345,9 +359,11 @@ object SchemaRenderer {
     ast.Document(schemaDef.toVector ++ types ++ directives)
   }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderSchema(introspectionSchema: IntrospectionSchema): String =
     schemaAstFromIntrospection(introspectionSchema, SchemaFilter.default).renderPretty
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderSchema[T: InputUnmarshaller](introspectionResult: T): String = {
     import sangria.parser.DeliveryScheme.Throw
 
@@ -356,9 +372,11 @@ object SchemaRenderer {
       SchemaFilter.default).renderPretty
   }
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderSchema(introspectionSchema: IntrospectionSchema, filter: SchemaFilter): String =
     schemaAstFromIntrospection(introspectionSchema, filter).renderPretty
 
+  @deprecated("Removed in 3.0.", since2_1_7)
   def renderSchema[T: InputUnmarshaller](introspectionResult: T, filter: SchemaFilter): String = {
     import sangria.parser.DeliveryScheme.Throw
 

--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -1465,6 +1465,7 @@ object Schema {
     * @param introspectionResult
     *   the result of introspection query
     */
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildFromIntrospection instead.", since2_1_7)
   def buildFromIntrospection[T: InputUnmarshaller](introspectionResult: T) =
     IntrospectionSchemaMaterializer.buildSchema[T](introspectionResult)
 
@@ -1478,26 +1479,33 @@ object Schema {
     * @param introspectionResult
     *   the result of introspection query
     */
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildFromIntrospection instead.", since2_1_7)
   def buildFromIntrospection[Ctx, T: InputUnmarshaller](
       introspectionResult: T,
       builder: IntrospectionSchemaBuilder[Ctx]) =
     IntrospectionSchemaMaterializer.buildSchema[Ctx, T](introspectionResult, builder)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildFromAst instead.", since2_1_7)
   def buildFromAst(document: ast.Document) =
     AstSchemaMaterializer.buildSchema(document)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildFromAst instead.", since2_1_7)
   def buildFromAst[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]) =
     AstSchemaMaterializer.buildSchema[Ctx](document, builder)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildStubFromAst instead.", since2_1_7)
   def buildStubFromAst(document: ast.Document) =
     AstSchemaMaterializer.buildSchema(Document.emptyStub + document)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildStubFromAst instead.", since2_1_7)
   def buildStubFromAst[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]) =
     AstSchemaMaterializer.buildSchema[Ctx](Document.emptyStub + document, builder)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildDefinitions instead.", since2_1_7)
   def buildDefinitions(document: ast.Document) =
     AstSchemaMaterializer.definitions(document)
 
+  @deprecated("Moved in 3.0. Use SchemaMaterializer.buildDefinitions instead.", since2_1_7)
   def buildDefinitions[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]) =
     AstSchemaMaterializer.definitions[Ctx](document, builder)
 }

--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -135,6 +135,8 @@ case class ScalarType[T](
     with UnmodifiedType
     with Named {
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 }
 
@@ -154,6 +156,8 @@ case class ScalarAlias[T, ST](
 
   def astDirectives = aliasFor.astDirectives
   def astNodes = aliasFor.astNodes
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 }
 
@@ -201,6 +205,7 @@ sealed trait ObjectLikeType[Ctx, Val]
       else Vector.empty
     else fieldsByName.getOrElse(fieldName, Vector.empty)
 
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 }
 
@@ -506,6 +511,8 @@ case class UnionType[Ctx](
     with UnmodifiedType
     with HasAstInfo {
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 
   /** Creates a type-safe version of union type which might be useful in cases where the value is
@@ -567,6 +574,8 @@ case class Field[Ctx, Val](
   def withPossibleTypes(possible: () => List[PossibleObject[Ctx, Val]]) =
     copy(manualPossibleTypes = () => possible().map(_.objectType))
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderField(•) instead.", since2_1_7)
   def toAst: ast.FieldDefinition = SchemaRenderer.renderField(this)
 }
 
@@ -658,6 +667,8 @@ case class Argument[T](
     with HasAstInfo {
   def inputValueType = argumentType
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderArg(•) instead.", since2_1_7)
   def toAst: ast.InputValueDefinition = SchemaRenderer.renderArg(this)
 }
 
@@ -917,6 +928,8 @@ case class EnumType[T](
   def coerceOutput(value: T): String = byValue(value).name
 
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 }
 
@@ -931,6 +944,8 @@ case class EnumValue[+T](
     with HasDeprecation
     with HasAstInfo {
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderEnumValue(•) instead.", since2_1_7)
   def toAst: ast.EnumValueDefinition = SchemaRenderer.renderEnumValue(this)
 }
 
@@ -950,6 +965,8 @@ case class InputObjectType[T](
     fields.groupBy(_.name).map { case (k, v) => (k, v.head) }.toMap
 
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderType(•) instead.", since2_1_7)
   def toAst: ast.TypeDefinition = SchemaRenderer.renderType(this)
 }
 
@@ -1007,6 +1024,8 @@ case class InputField[T](
     with HasAstInfo {
   def inputValueType: InputType[T] = fieldType
   def rename(newName: String): InputField.this.type = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderInputField(•) instead.", since2_1_7)
   def toAst: ast.InputValueDefinition = SchemaRenderer.renderInputField(this)
 }
 
@@ -1151,6 +1170,8 @@ case class Directive(
     extends HasArguments
     with Named {
   def rename(newName: String) = copy(name = newName).asInstanceOf[this.type]
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderDirective(•) instead.", since2_1_7)
   def toAst: ast.DirectiveDefinition = SchemaRenderer.renderDirective(this)
 }
 
@@ -1174,13 +1195,22 @@ case class Schema[Ctx, Val](
   def compare(oldSchema: Schema[_, _]): Vector[SchemaChange] =
     SchemaComparator.compare(oldSchema, this)
 
+  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAst(•) instead.", since2_1_7)
   lazy val toAst: Document = SchemaRenderer.schemaAst(this)
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.schemaAst(•, filter) instead.", since2_1_7)
   def toAst(filter: SchemaFilter): Document = SchemaRenderer.schemaAst(this, filter)
 
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•) instead.", since2_1_7)
   def renderPretty: String = toAst.renderPretty
+
+  @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•, filter) instead.", since2_1_7)
   def renderPretty(filter: SchemaFilter): String = toAst(filter).renderPretty
 
+  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•)) instead.", since2_1_7)
   def renderCompact: String = toAst.renderCompact
+
+  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•, filter)) instead.", since2_1_7)
   def renderCompact(filter: SchemaFilter): String = toAst(filter).renderCompact
 
   lazy val types: Map[String, (Int, Type with Named)] = {

--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -1207,10 +1207,16 @@ case class Schema[Ctx, Val](
   @deprecated("Removed in 3.0. Use SchemaRenderer.renderSchema(•, filter) instead.", since2_1_7)
   def renderPretty(filter: SchemaFilter): String = toAst(filter).renderPretty
 
-  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•)) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•)) instead.",
+    since2_1_7
+  )
   def renderCompact: String = toAst.renderCompact
 
-  @deprecated("Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•, filter)) instead.", since2_1_7)
+  @deprecated(
+    "Removed in 3.0. Use QueryRenderer.renderCompact(SchemaRenderer.schemaAst(•, filter)) instead.",
+    since2_1_7
+  )
   def renderCompact(filter: SchemaFilter): String = toAst(filter).renderCompact
 
   lazy val types: Map[String, (Int, Type with Named)] = {

--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -1187,11 +1187,16 @@ case class Schema[Ctx, Val](
     astNodes: Vector[ast.AstNode] = Vector.empty)
     extends HasAstInfo
     with HasDescription {
+  @deprecated(
+    "Removed in 3.0. Use AstSchemaMaterializer.extendSchema(•, document, builder) instead.",
+    since2_1_7
+  )
   def extend(
       document: ast.Document,
       builder: AstSchemaBuilder[Ctx] = AstSchemaBuilder.default[Ctx]): Schema[Ctx, Val] =
     AstSchemaMaterializer.extendSchema(this, document, builder)
 
+  @deprecated("Removed in 3.0. Use SchemaComparator.compare(oldSchema, •) instead.", since2_1_7)
   def compare(oldSchema: Schema[_, _]): Vector[SchemaChange] =
     SchemaComparator.compare(oldSchema, this)
 

--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -6,7 +6,7 @@ import language.implicitConversions
 import sangria.execution.{FieldTag, SubscriptionField}
 import sangria.marshalling.FromInput.{CoercedScalaResult, InputObjectResult}
 import sangria.marshalling._
-import sangria.{ast, introspection}
+import sangria.{ast, introspection, since2_1_7}
 import sangria.validation._
 import sangria.introspection._
 import sangria.renderer.{SchemaFilter, SchemaRenderer}
@@ -1394,6 +1394,7 @@ case class Schema[Ctx, Val](
   def isPossibleType(baseTypeName: String, tpe: ObjectType[_, _]) =
     possibleTypes.get(baseTypeName).exists(_.exists(_.name == tpe.name))
 
+  @deprecated("Removed in 3.0. Use SchemaBasedDocumentAnalyzer(•, query) instead.", since2_1_7)
   def analyzer(query: Document) = SchemaBasedDocumentAnalyzer(this, query)
 
   SchemaValidationRule.validateWithException(this, validationRules)

--- a/modules/core/src/main/scala/sangria/schema/SchemaMaterializer.scala
+++ b/modules/core/src/main/scala/sangria/schema/SchemaMaterializer.scala
@@ -1,0 +1,56 @@
+package sangria.schema
+
+import sangria.ast
+import sangria.ast.Document
+import sangria.marshalling.InputUnmarshaller
+
+object SchemaMaterializer {
+
+  /** Build a `Schema` for use by client tools.
+    *
+    * Given the result of a client running the introspection query, creates and returns a `Schema`
+    * instance which can be then used with all sangria tools, but cannot be used to execute a query,
+    * as introspection does not represent the "resolver", "parse" or "serialize" functions or any
+    * other server-internal mechanisms.
+    *
+    * @param introspectionResult
+    *   the result of introspection query
+    */
+  def buildFromIntrospection[T: InputUnmarshaller](introspectionResult: T): Schema[Any, Any] =
+    IntrospectionSchemaMaterializer.buildSchema[T](introspectionResult)
+
+  /** Build a `Schema` for use by client tools.
+    *
+    * Given the result of a client running the introspection query, creates and returns a `Schema`
+    * instance which can be then used with all sangria tools, but cannot be used to execute a query,
+    * as introspection does not represent the "resolver", "parse" or "serialize" functions or any
+    * other server-internal mechanisms.
+    *
+    * @param introspectionResult
+    *   the result of introspection query
+    */
+  def buildFromIntrospection[Ctx, T: InputUnmarshaller](
+      introspectionResult: T,
+      builder: IntrospectionSchemaBuilder[Ctx]): Schema[Ctx, Any] =
+    IntrospectionSchemaMaterializer.buildSchema[Ctx, T](introspectionResult, builder)
+
+  def buildFromAst(document: ast.Document): Schema[Any, Any] =
+    AstSchemaMaterializer.buildSchema(document)
+
+  def buildFromAst[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]): Schema[Ctx, Any] =
+    AstSchemaMaterializer.buildSchema[Ctx](document, builder)
+
+  def buildStubFromAst(document: ast.Document): Schema[Any, Any] =
+    AstSchemaMaterializer.buildSchema(Document.emptyStub + document)
+
+  def buildStubFromAst[Ctx](
+      document: ast.Document,
+      builder: AstSchemaBuilder[Ctx]): Schema[Ctx, Any] =
+    AstSchemaMaterializer.buildSchema[Ctx](Document.emptyStub + document, builder)
+
+  def buildDefinitions(document: ast.Document): Vector[Named] =
+    AstSchemaMaterializer.definitions(document)
+
+  def buildDefinitions[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]): Vector[Named] =
+    AstSchemaMaterializer.definitions[Ctx](document, builder)
+}


### PR DESCRIPTION
Fixes #823.