### PR TITLE
Description with empty line rendering

### DIFF
--- a/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -477,7 +477,10 @@ object QueryRenderer {
       extraIndent: Boolean = true): String =
     if (node.value.trim.nonEmpty) {
       val ind = if (extraIndent) indent.incForce.str else indent.strForce
-      val lines = escapeBlockString(node.value).split("\n").iterator.map(ind + _)
+      val lines = escapeBlockString(node.value).split("\n").iterator.map { line =>
+        if (line.isEmpty) line // do not output lines with only whitespaces inside
+        else ind + line
+      }
 
       lines.mkString(
         "\"\"\"" + config.mandatoryLineBreak,

--- a/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -322,13 +322,19 @@ class SchemaRenderSpec
 
       val bar = ObjectType(
         "Bar",
+        description,
         interfaces[Unit, Unit](foo),
-        fields[Unit, Unit](Field("str", OptionType(StringType), resolve = _ => "foo")))
+        fields[Unit, Unit](
+          Field(
+            "str",
+            OptionType(StringType),
+            description = Some(description),
+            resolve = _ => "foo")))
 
       val root = ObjectType(
         "Root",
         fields[Unit, Unit](
-          Field("bar", OptionType(bar), resolve = _ => ())
+          Field("bar", OptionType(bar), description = Some(description), resolve = _ => ())
         ))
 
       val schema = Schema(root)
@@ -338,7 +344,17 @@ class SchemaRenderSpec
         |  query: Root
         |}
         |
+        |$quotes
+        |first line followed by empty line
+        |
+        |second line
+        |$quotes
         |type Bar implements Foo {
+        |  $quotes
+        |  first line followed by empty line
+        |
+        |  second line
+        |  $quotes
         |  str: String
         |}
         |
@@ -357,6 +373,11 @@ class SchemaRenderSpec
         |}
         |
         |type Root {
+        |  $quotes
+        |  first line followed by empty line
+        |
+        |  second line
+        |  $quotes
         |  bar: Bar
         |}
         |""".stripMargin)(after.being(strippedOfCarriageReturns))

--- a/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -332,7 +332,6 @@ class SchemaRenderSpec
         ))
 
       val schema = Schema(root)
-      val doubleSpaces = "  "
 
       render(schema) should equal(s"""
         |schema {
@@ -351,7 +350,7 @@ class SchemaRenderSpec
         |interface Foo {
         |  $quotes
         |  first line followed by empty line
-        |$doubleSpaces
+        |
         |  second line
         |  $quotes
         |  str: String


### PR DESCRIPTION
sangria should impose any style for line breaks.

Sangria should output whatever the user has written in the documentation, letting the user control how to render line breaks.