### PR TITLE
Introspection complexity for TypeNameMetaField

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,10 @@ lazy val core = project
       "eu.timepit" %% "refined" % "0.9.28" % Test,
       // CATs
       "net.jcazevedo" %% "moultingyaml" % "0.4.2" % Test,
-      "io.github.classgraph" % "classgraph" % "4.8.143" % Test
+      "io.github.classgraph" % "classgraph" % "4.8.143" % Test,
+      // Config
+      "com.typesafe" % "config" % "1.4.2",
+      "com.iheart" %% "ficus" % "1.5.2"
     ),
     apiURL := {
       val ver = CrossVersion.binaryScalaVersion(scalaVersion.value)
@@ -202,3 +205,5 @@ lazy val shellSettings = Seq(
 lazy val noPublishSettings = Seq(
   publish / skip := true
 )
+
+logLevel := Level.Error

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+sangria {
+  introspectionComplexity = 1
+}

--- a/modules/core/src/main/scala/sangria/Config.scala
+++ b/modules/core/src/main/scala/sangria/Config.scala
@@ -1,0 +1,13 @@
+package sangria
+
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+
+case class Config(introspectionComplexity: Option[Double] = None)
+
+object Config {
+
+  import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+
+  val config: Config = ConfigFactory.load().as[Config]("sangria")
+}

--- a/modules/core/src/main/scala/sangria/Config.scala
+++ b/modules/core/src/main/scala/sangria/Config.scala
@@ -9,5 +9,5 @@ object Config {
 
   import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 
-  val config: Config = ConfigFactory.load().as[Config]("sangria")
+  def load(): Config = ConfigFactory.load().as[Config]("sangria")
 }

--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -429,6 +429,7 @@ package object introspection {
     name = "__typename",
     fieldType = StringType,
     description = Some("The name of the current Object type at runtime."),
+    complexity = Config.config.introspectionComplexity.map(c => (_: Any, _, _) => c),
     resolve = ctx => ctx.parentType.name)
 
   val MetaFieldNames = Set(SchemaMetaField.name, TypeMetaField.name, TypeNameMetaField.name)

--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -425,12 +425,13 @@ package object introspection {
     resolve = ctx => ctx.schema.types.get(ctx.arg[String]("name")).map(true -> _._2)
   )
 
-  val TypeNameMetaField: Field[Unit, Unit] = Field(
+  def TypeNameMetaField: Field[Unit, Unit] = Field(
     name = "__typename",
     fieldType = StringType,
     description = Some("The name of the current Object type at runtime."),
-    complexity = Config.config.introspectionComplexity.map(c => (_: Any, _, _) => c),
-    resolve = ctx => ctx.parentType.name)
+    complexity = Config.load().introspectionComplexity.map(c => (_: Any, _, _) => c),
+    resolve = ctx => ctx.parentType.name
+  )
 
   val MetaFieldNames = Set(SchemaMetaField.name, TypeMetaField.name, TypeNameMetaField.name)
 

--- a/modules/core/src/test/resources/app.conf
+++ b/modules/core/src/test/resources/app.conf
@@ -1,0 +1,3 @@
+sangria {
+  introspectionComplexity = 0
+}


### PR DESCRIPTION
please review 🙏 

### Motivation

Currently sangria has a default complexity of 1 for each field, even for introspection field. In this PR, I am making it possible to have a different complexity value for the introspection __typename field, by adding a [config file]( modules/core/src/main/resources/reference.conf) with the relative settings.

### Notes for reviewer

- The PR doesn't break the default complexity setting for __typename. I ensured this by adding [reference.conf](modules/core/src/main/resources/reference.conf) which defaults to 1. Applications can change the value by adding a different setting in application.conf (example is in the unit tests).

- To be able to use different configurations in the tests, I needed to make TypeNameMetaField a function: https://github.com/sangria-graphql/sangria/blob/04736fe703e8e69dd52be7b381f4c76840211357/modules/core/src/main/scala/sangria/introspection/package.scala#L428 
this will probably add some time overhead but it's the only simple way that I could think of to do this without changing the overall structure. If there are any concerns about this please let me know.