### PR TITLE
Make SubscriptionValue public

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/Context.scala
+++ b/modules/core/src/main/scala/sangria/schema/Context.scala
@@ -163,7 +163,7 @@ object UpdateCtx {
     new UpdateCtx(action, newCtx)
 }
 
-private[sangria] case class SubscriptionValue[Ctx, Val, S[_]](
+case class SubscriptionValue[Ctx, Val, S[_]](
     source: Val,
     stream: SubscriptionStream[S])
     extends LeafAction[Ctx, Val] {


### PR DESCRIPTION
`SubscriptionValue` is seemingly needlessly private at the moment, and it is the only implementer of `LeafAction` that is private. This pr makes it part of the public api.

I have found this to be necessary for the use case of implementing subscriptions with a materialized schema. Without `SubscriptionValue` being public, the only way to make a resolver that can return a stream is via `Field.subs`. Thus, creating a fake field and then taking its resolver (`Field.subs(...).resolver`) is an unfortunate consequence of `SubscriptionValue` being private when using a materialized schema.