### PR TITLE
Check a sangria type declared multiple times to have the same fields

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -1270,7 +1270,7 @@ case class Schema[Ctx, Val](
 
       (t1, t2) match {
         case (ot1: ObjectType[_, _], ot2: ObjectType[_, _]) =>
-          sameSangriaType && (ot1.valClass == ot2.valClass)
+          sameSangriaType && (ot1.valClass == ot2.valClass) && (ot1.fieldsByName.keySet == ot2.fieldsByName.keySet)
         case (ot1: InputObjectType[_], ot2: InputObjectType[_]) =>
           sameSangriaType && (ot1.fieldsByName.keySet == ot2.fieldsByName.keySet)
         case _ => sameSangriaType


### PR DESCRIPTION
Hi 👋 ,

Last week I spotted an unexpected behaviour while cleaning our schemas.. and it turned out the main cause is that Sangria won't raise a violation if there're two `ObjectType` with the same `name` and `valClass`, but different field set.

This PR will extend the current validation by also checking the fields set.
I added a new test case to cover the behaviour.

Not sure about the impact of this little change.. is ok to change that straight away or would it better to make this check configurable and opt-in?