### PR TITLE
use scala 2.13 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.2.0]
+        scala: [2.13.8]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val isScala3 = Def.setting(
 
 // sbt-github-actions needs configuration in `ThisBuild`
 ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.8", "3.2.0")
-ThisBuild / scalaVersion := crossScalaVersions.value.last
+ThisBuild / scalaVersion := crossScalaVersions.value.tail.head
 ThisBuild / githubWorkflowBuildPreamble ++= List(
   WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check binary compatibility")),
   WorkflowStep.Sbt(List("scalafmtCheckAll"), name = Some("Check formatting"))


### PR DESCRIPTION
Some IDEA are not yet ready for scala 3.
Using scala 2.13 by default is a better dev experience.