### PR TITLE
Optimize AstVisitor

### DIFF
--- a/modules/core/src/main/scala/sangria/ast/AstVisitor.scala
+++ b/modules/core/src/main/scala/sangria/ast/AstVisitor.scala
@@ -7,21 +7,21 @@ import sangria.visitor._
 import scala.util.control.Breaks.{break, breakable}
 
 trait AstVisitor {
-  def onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue }
-  def onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue }
+  def onEnter: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty
+  def onLeave: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty
 }
 
 object AstVisitor {
   import AstVisitorCommand._
 
   def apply(
-      onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue },
-      onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ => VisitorCommand.Continue }
+      onEnter: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty,
+      onLeave: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty
   ): DefaultAstVisitor = DefaultAstVisitor(onEnter, onLeave)
 
   def simple(
-      onEnter: PartialFunction[AstNode, Unit] = { case _ => () },
-      onLeave: PartialFunction[AstNode, Unit] = { case _ => () }
+      onEnter: PartialFunction[AstNode, Unit] = PartialFunction.empty,
+      onLeave: PartialFunction[AstNode, Unit] = PartialFunction.empty
   ): DefaultAstVisitor = DefaultAstVisitor(
     {
       case node if onEnter.isDefinedAt(node) =>

--- a/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
+++ b/modules/core/src/main/scala/sangria/ast/DefaultAstVisitor.scala
@@ -3,10 +3,6 @@ package sangria.ast
 import sangria.visitor.VisitorCommand
 
 case class DefaultAstVisitor(
-    override val onEnter: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-      VisitorCommand.Continue
-    },
-    override val onLeave: PartialFunction[AstNode, VisitorCommand] = { case _ =>
-      VisitorCommand.Continue
-    }
+    override val onEnter: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty,
+    override val onLeave: PartialFunction[AstNode, VisitorCommand] = PartialFunction.empty
 ) extends AstVisitor


### PR DESCRIPTION
Use an empty PartialFunction by default, to avoid calling apply on it (shortcuts with `isDefinedAt`).