### PR TITLE
different error format if before execution

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/Resolver.scala
+++ b/modules/core/src/main/scala/sangria/execution/Resolver.scala
@@ -153,7 +153,8 @@ class Resolver[Ctx](
           marshalResult(
             data.asInstanceOf[Option[resultResolver.marshaller.Node]],
             marshalErrors(errors),
-            marshallExtensions.asInstanceOf[Option[resultResolver.marshaller.Node]]
+            marshallExtensions.asInstanceOf[Option[resultResolver.marshaller.Node]],
+            beforeExecution = false
           ).asInstanceOf[marshaller.Node])
 
     case dr: DeferredResult =>
@@ -165,7 +166,8 @@ class Resolver[Ctx](
             marshalResult(
               data.asInstanceOf[Option[resultResolver.marshaller.Node]],
               marshalErrors(errors),
-              marshallExtensions.asInstanceOf[Option[resultResolver.marshaller.Node]]
+              marshallExtensions.asInstanceOf[Option[resultResolver.marshaller.Node]],
+              beforeExecution = false
             ).asInstanceOf[marshaller.Node]
         }
       )

--- a/modules/core/src/test/scala/sangria/execution/ExecutorSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/ExecutorSpec.scala
@@ -1230,7 +1230,7 @@ class ExecutorSpec extends AnyWordSpec with Matchers with FutureResultSupport {
             ...two
           }
         """,
-      expectedData = null,
+      expectedData = None,
       expectedErrorStrings = List(
         "Cannot spread fragment 'c' within itself." -> List(Pos(15, 13)),
         "Conflict at 'pic' because of differing arguments. Use different aliases on the fields to fetch both if this was intentional." -> List(
@@ -1266,7 +1266,7 @@ class ExecutorSpec extends AnyWordSpec with Matchers with FutureResultSupport {
             ...two
           }
         """,
-      expectedData = null,
+      expectedData = None,
       expectedErrorStrings = List(
         "Cannot spread fragment 'c' within itself via 'd'." -> List(Pos(15, 13), Pos(19, 13)),
         "Conflict at 'pic' because of differing arguments. Use different aliases on the fields to fetch both if this was intentional." -> List(

--- a/modules/core/src/test/scala/sangria/execution/QueryReducerSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/QueryReducerSpec.scala
@@ -611,7 +611,7 @@ class QueryReducerSpec extends AnyWordSpec with Matchers with FutureResultSuppor
           exceptionHandler = exceptionHandler,
           queryReducers = tagColl :: Nil)
         .awaitAndRecoverQueryAnalysisScala should be(
-        Map("data" -> null, "errors" -> List(Map("message" -> "boom!"))))
+        Map("errors" -> List(Map("message" -> "boom!"))))
     }
 
     "handle `TryValue` exceptions correctly" in {
@@ -639,7 +639,7 @@ class QueryReducerSpec extends AnyWordSpec with Matchers with FutureResultSuppor
           exceptionHandler = exceptionHandler,
           queryReducers = tagColl :: Nil)
         .awaitAndRecoverQueryAnalysisScala should be(
-        Map("data" -> null, "errors" -> List(Map("message" -> "boom!"))))
+        Map("errors" -> List(Map("message" -> "boom!"))))
     }
 
     "handle `FutureValue` exceptions correctly" in {
@@ -667,7 +667,7 @@ class QueryReducerSpec extends AnyWordSpec with Matchers with FutureResultSuppor
           exceptionHandler = exceptionHandler,
           queryReducers = tagColl :: Nil)
         .awaitAndRecoverQueryAnalysisScala should be(
-        Map("data" -> null, "errors" -> List(Map("message" -> "boom!"))))
+        Map("errors" -> List(Map("message" -> "boom!"))))
     }
 
     "collect all mapped tag values and update a user context" in {

--- a/modules/core/src/test/scala/sangria/execution/VariablesSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/VariablesSpec.scala
@@ -307,7 +307,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
               nnListNN(input: ["a1", null, "b1"])
             }
           """,
-          null,
+          None,
           List("Expected type 'String!', found 'null'." -> Seq(Pos(3, 38)))
         )
 
@@ -318,7 +318,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
               fieldWithObjectInput(input: {a: "foo", c: null})
             }
           """,
-          null,
+          None,
           List("Expected type 'String!', found 'null'." -> Seq(Pos(3, 57)))
         )
 
@@ -329,7 +329,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
               nnListNN(input: null)
             }
           """,
-          null,
+          None,
           List("Expected type '[String!]!', found 'null'." -> Seq(Pos(3, 31)))
         )
 
@@ -340,7 +340,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
               fieldWithObjectInput(input: {a: "foo", c: "baz", d: ["aa", null]})
             }
           """,
-          null,
+          None,
           List("Expected type 'String!', found 'null'." -> Seq(Pos(3, 74)))
         )
 
@@ -391,7 +391,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
               fieldWithObjectInput(input: ["foo", "bar", "baz"])
             }
           """,
-          Map("fieldWithObjectInput" -> null),
+          Some(Map("fieldWithObjectInput" -> null)),
           List(
             """Value '["foo","bar","baz"]' of wrong type was provided to the field of type 'TestInputObject!' at path 'input'.""" -> List(
               Pos(3, 15),
@@ -479,7 +479,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             .awaitAndRecoverQueryAnalysisScala
             .asInstanceOf[Map[String, AnyRef]]
 
-          result("data") should equal(null)
+          result.get("data") should equal(None)
 
           val errors = result("errors").asInstanceOf[Seq[Map[String, Any]]]
 
@@ -622,7 +622,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithNonNullableStringInput(input: $value)
           }
         """,
-        null,
+        None,
         List(
           """Variable '$value' expected value of type 'String!' but value is undefined.""" -> List(
             Pos(2, 33)))
@@ -635,7 +635,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithNonNullableStringInput(input: $value)
           }
         """,
-        null,
+        None,
         List(
           """Variable '$value' expected value of type 'String!' but got: null.""" -> List(
             Pos(2, 33))),
@@ -676,7 +676,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithNonNullableStringInput
           }
         """,
-        Map("fieldWithNonNullableStringInput" -> null),
+        Some(Map("fieldWithNonNullableStringInput" -> null)),
         List(
           "Null value was provided for the NotNull Type 'String!' at path 'input'." -> Seq(
             Pos(3, 13))),
@@ -695,7 +695,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithNonNullableStringInput(input: $foo)
           }
         """,
-        Map("fieldWithNonNullableStringInput" -> null),
+        Some(Map("fieldWithNonNullableStringInput" -> null)),
         List(
           "Null value was provided for the NotNull Type 'String!' at path 'input'." -> Seq(
             Pos(3, 13))),
@@ -744,7 +744,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             nnList(input: $input)
           }
         """,
-        null,
+        None,
         List(
           """Variable '$input' expected value of type '[String]!' but got: null.""" -> List(
             Pos(2, 19))),
@@ -802,7 +802,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             listNN(input: $input)
           }
         """,
-        null,
+        None,
         List(
           """Variable '$input' expected value of type '[String!]' but got: ["A",null,"B"].""" -> List(
             Pos(2, 19))),
@@ -816,7 +816,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             nnListNN(input: $input)
           }
         """,
-        Map("nnListNN" -> null),
+        Some(Map("nnListNN" -> null)),
         List(
           "Null value was provided for the NotNull Type '[String!]!' at path 'input'." -> Seq(
             Pos(3, 13))),
@@ -842,7 +842,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             nnListNN(input: $input)
           }
         """,
-        null,
+        None,
         List(
           """Variable '$input' expected value of type '[String!]!' but got: ["A",null,"B"].""" -> List(
             Pos(2, 19))),
@@ -856,7 +856,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithObjectInput(input: $input)
           }
         """,
-        null,
+        None,
         List(
           """Variable 'TestType!' expected value of type '$input' which cannot be used as an input type.""" -> List(
             Pos(2, 19))),
@@ -871,7 +871,7 @@ class VariablesSpec extends AnyWordSpec with Matchers with GraphQlSupport {
             fieldWithObjectInput(input: $input)
           }
         """,
-        null,
+        None,
         List(
           """Variable 'UnknownType!' expected value of type '$input' which cannot be used as an input type.""" -> List(
             Pos(2, 19))),

--- a/modules/core/src/test/scala/sangria/execution/deferred/DeferredResolverSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/deferred/DeferredResolverSpec.scala
@@ -279,7 +279,7 @@ class DeferredResolverSpec extends AnyWordSpec with Matchers with FutureResultSu
           fail2 {name}
         }
       """,
-      Map("fail1" -> null, "root" -> Map("name" -> "Cat root"), "fail2" -> null),
+      Some(Map("fail1" -> null, "root" -> Map("name" -> "Cat root"), "fail2" -> null)),
       List("foo" -> List(Pos(3, 11)), "foo" -> List(Pos(5, 11))),
       resolver = new MyDeferredResolver
     )
@@ -294,7 +294,7 @@ class DeferredResolverSpec extends AnyWordSpec with Matchers with FutureResultSu
           fail2 {name}
         }
       """,
-      Map("fail1" -> null, "root" -> Map("name" -> "Cat root"), "fail2" -> null),
+      Some(Map("fail1" -> null, "root" -> Map("name" -> "Cat root"), "fail2" -> null)),
       List("foo" -> List(Pos(3, 11)), "foo" -> List(Pos(5, 11))),
       resolver = new MyDeferredResolver
     )

--- a/modules/core/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/deferred/FetcherSpec.scala
@@ -558,7 +558,7 @@ class FetcherSpec extends AnyWordSpec with Matchers with FutureResultSupport {
             }
           }
         """,
-        Map("c1" -> null, "c2" -> Map("name" -> "Root", "selfOpt" -> null)),
+        Some(Map("c1" -> null, "c2" -> Map("name" -> "Root", "selfOpt" -> null))),
         List(
           "Fetcher has not resolved non-optional ID 'foo!'." -> List(Pos(3, 41)),
           "Fetcher has not resolved non-optional ID 'qwe'." -> List(Pos(7, 17))),
@@ -875,7 +875,7 @@ class FetcherSpec extends AnyWordSpec with Matchers with FutureResultSupport {
           }
         }
       """,
-      Map("category" -> null),
+      Some(Map("category" -> null)),
       List(
         "Fetcher has not resolved non-optional relation ID '1' for relation 'SimpleRelation(product-category)'." -> List(
           Pos(4, 13))),

--- a/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
@@ -1656,7 +1656,7 @@ class AstSchemaMaterializerSpec
               }
             }
           """,
-          Map("foo" -> null),
+          Some(Map("foo" -> null)),
           List(
             """Cannot return null for non-nullable type""" -> List(Pos(4, 17)),
             """Cannot return null for non-nullable type""" -> List(Pos(5, 17)),

--- a/modules/core/src/test/scala/sangria/schema/CustomScalarSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/CustomScalarSpec.scala
@@ -74,7 +74,7 @@ class CustomScalarSpec extends AnyWordSpec with Matchers {
             foo(dateInput: "2015-05-test")
           }
         """,
-        null,
+        None,
         List(
           """Expected type 'Date!', found '"2015-05-test"'. Date value expected""" -> List(
             Pos(3, 28)))

--- a/modules/core/src/test/scala/sangria/schema/EnumTypeSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/EnumTypeSpec.scala
@@ -78,7 +78,7 @@ class EnumTypeSpec extends AnyWordSpec with Matchers with GraphQlSupport {
     "does not accept string literals" in checkContainsErrors(
       (),
       """{ colorEnum(fromEnum: "GREEN") }""",
-      Map("colorEnum" -> null),
+      Some(Map("colorEnum" -> null)),
       List(
         "Argument 'fromEnum' has wrong value: Enum value expected." -> List(Pos(1, 3), Pos(1, 23))),
       validateQuery = false
@@ -87,7 +87,7 @@ class EnumTypeSpec extends AnyWordSpec with Matchers with GraphQlSupport {
     "does not accept internal value in place of enum literal" in checkContainsErrors(
       (),
       """{ colorEnum(fromEnum: 1) }""",
-      Map("colorEnum" -> null),
+      Some(Map("colorEnum" -> null)),
       List(
         "Argument 'fromEnum' has wrong value: Enum value expected." -> List(Pos(1, 3), Pos(1, 23))),
       validateQuery = false
@@ -112,20 +112,20 @@ class EnumTypeSpec extends AnyWordSpec with Matchers with GraphQlSupport {
       JsObject("color" -> JsString("GREEN"))
     )
 
-    "does not accept internal value as enum variables" in checkContainsErrors(
+    "not accept internal value as enum variables" in checkContainsErrors(
       (),
       """query test($color: Color!) { colorEnum(fromEnum: $color) }""",
-      null,
+      None,
       List(
         "Variable '$color' expected value of type 'Color!' but got: 1. Reason: Enum value expected" -> List(
           Pos(1, 12))),
       JsObject("color" -> JsNumber(1))
     )
 
-    "does not accept string variables as enum input" in checkContainsErrors(
+    "not accept string variables as enum input" in checkContainsErrors(
       (),
       """query test($color: String!) { colorEnum(fromEnum: $color) }""",
-      null,
+      None,
       List(
         "Variable '$color' of type 'String!' used in position expecting type 'Color'." -> List(
           Pos(1, 12),
@@ -134,10 +134,10 @@ class EnumTypeSpec extends AnyWordSpec with Matchers with GraphQlSupport {
       validateQuery = true
     )
 
-    "does not accept internal value variable as enum input" in checkContainsErrors(
+    "not accept internal value variable as enum input" in checkContainsErrors(
       (),
       """query test($color: Int!) { colorEnum(fromEnum: $color) }""",
-      null,
+      None,
       List(
         "Variable '$color' of type 'Int!' used in position expecting type 'Color'." -> List(
           Pos(1, 12),

--- a/modules/core/src/test/scala/sangria/schema/IntrospectionSchemaMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/IntrospectionSchemaMaterializerSpec.scala
@@ -475,7 +475,7 @@ class IntrospectionSchemaMaterializerSpec
         clientSchema,
         (),
         "query NoNo($v: Custom) { foo(custom1: 123, custom2: $v) }",
-        null,
+        None,
         List(
           """Schema was materialized and cannot be used for any queries except introspection queries.""" -> List(
             Pos(1, 39))),

--- a/modules/core/src/test/scala/sangria/schema/SchemaExtensionSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/SchemaExtensionSpec.scala
@@ -134,7 +134,7 @@ class SchemaExtensionSpec
         schema = schema.extend(ast),
         data = (),
         query = "{ newField }",
-        expectedData = Map("newField" -> null),
+        expectedData = Some(Map("newField" -> null)),
         expectedErrorStrings =
           List(DefaultIntrospectionSchemaBuilder.MaterializedSchemaErrorMessage -> List(Pos(1, 3)))
       )

--- a/modules/core/src/test/scala/sangria/schema/TypeFieldConstraintsSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/TypeFieldConstraintsSpec.scala
@@ -487,7 +487,7 @@ class TypeFieldConstraintsSpec extends AnyWordSpec with Matchers {
           }
          }
         """,
-        null,
+        None,
         List(
           "Cannot query field 'color' on type 'Fruit'. Did you mean to use an inline fragment on 'Apple'?" -> List(
             Pos(5, 15)))

--- a/modules/core/src/test/scala/sangria/util/GraphQlSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/GraphQlSupport.scala
@@ -94,7 +94,7 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
       schema: Schema[_, _],
       data: T,
       query: String,
-      expectedData: Map[String, Any],
+      expectedData: Option[Map[String, Any]],
       expectedErrorStrings: Seq[(String, Seq[Pos])],
       args: JsValue = JsObject.empty,
       userContext: Any = (),
@@ -110,7 +110,7 @@ object SimpleGraphQlSupport extends FutureResultSupport with Matchers {
       userContext = userContext,
       resolver = resolver.asInstanceOf[DeferredResolver[Any]]).asInstanceOf[Map[String, Any]]
 
-    result("data") should be(expectedData)
+    result.get("data") should be(expectedData)
 
     val errors = result.getOrElse("errors", Vector.empty).asInstanceOf[Seq[Map[String, Any]]]
 
@@ -254,7 +254,7 @@ trait GraphQlSupport extends FutureResultSupport with Matchers {
   def checkContainsErrors[T](
       data: T,
       query: String,
-      expectedData: Map[String, Any],
+      expectedData: Option[Map[String, Any]],
       expectedErrorStrings: Seq[(String, Seq[Pos])],
       args: JsValue = JsObject.empty,
       validateQuery: Boolean = true): Unit =


### PR DESCRIPTION
See https://spec.graphql.org/October2021/#sec-Data

If the error happened before the execution, the response should not include the `data` field.
Otherwise, the response should include a `null` `data` field.