### PR TITLE
Fix interface introspection response

### DIFF
--- a/modules/ast/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/ast/src/main/scala/sangria/ast/QueryAst.scala
@@ -534,7 +534,8 @@ case class InterfaceTypeDefinition(
     description: Option[StringValue] = None,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
-    location: Option[AstLocation] = None)
+    location: Option[AstLocation] = None,
+    interfaces: Vector[NamedType] = Vector.empty)
     extends TypeDefinition
     with WithTrailingComments
     with WithDescription {

--- a/modules/core/src/main/scala/sangria/ast/AstVisitor.scala
+++ b/modules/core/src/main/scala/sangria/ast/AstVisitor.scala
@@ -310,6 +310,7 @@ object AstVisitor {
               description,
               comment,
               trailingComments,
+              _,
               _) =>
           if (breakOrSkip(onEnter(n))) {
             fields.foreach(d => loop(d))

--- a/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
+++ b/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
@@ -65,7 +65,8 @@ object IntrospectionParser {
       possibleTypes = mapFieldOpt(tpe, "possibleTypes")
         .map(um.getListValue)
         .getOrElse(Vector.empty)
-        .map(i => parseNamedTypeRef(i, path :+ "possibleTypes"))
+        .map(i => parseNamedTypeRef(i, path :+ "possibleTypes")),
+      interfaces = Seq.empty
     )
 
   private def parseUnion[In: InputUnmarshaller](tpe: In, path: Vector[String]) =

--- a/modules/core/src/main/scala/sangria/introspection/model.scala
+++ b/modules/core/src/main/scala/sangria/introspection/model.scala
@@ -61,7 +61,8 @@ case class IntrospectionInterfaceType(
     name: String,
     description: Option[String],
     fields: Seq[IntrospectionField],
-    possibleTypes: Seq[IntrospectionNamedTypeRef])
+    possibleTypes: Seq[IntrospectionNamedTypeRef],
+    interfaces: Seq[IntrospectionNamedTypeRef] = Seq.empty)
     extends IntrospectionType {
   val kind = TypeKind.Interface
 }

--- a/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -447,7 +447,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
         name = typeName(definition),
         description = typeDescription(definition),
         fieldsFn = fields,
-        interfaces = Nil,
+        interfaces = List.empty,
         manualPossibleTypes = () => Nil,
         astDirectives = directives,
         astNodes = (definition +: extensions).toVector
@@ -463,7 +463,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
     existing.copy(
       fieldsFn = fields,
       manualPossibleTypes = () => Nil,
-      interfaces = Nil,
+      interfaces = List.empty,
       astDirectives = existing.astDirectives ++ extensions.flatMap(_.directives),
       astNodes = existing.astNodes ++ extensions
     )

--- a/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
@@ -163,7 +163,7 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
         name = typeName(definition),
         description = typeDescription(definition),
         fieldsFn = fields,
-        interfaces = Nil,
+        interfaces = List.empty,
         manualPossibleTypes = () => Nil,
         astDirectives = Vector.empty,
         astNodes = Vector.empty

--- a/modules/core/src/test/scala/sangria/introspection/InterfaceOfInterfaceSpec.scala
+++ b/modules/core/src/test/scala/sangria/introspection/InterfaceOfInterfaceSpec.scala
@@ -1,0 +1,57 @@
+package sangria.introspection
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sangria.schema._
+import sangria.util.{FutureResultSupport, GraphQlSupport}
+
+class InterfaceOfInterfaceSpec
+    extends AnyWordSpec
+    with Matchers
+    with FutureResultSupport
+    with GraphQlSupport {
+  trait Named {
+    def name: Option[String]
+  }
+
+  case class Dog(name: Option[String], barks: Option[Boolean]) extends Named
+
+  val NamedType = InterfaceType(
+    "Named",
+    fields[Unit, Named](Field("name", OptionType(StringType), resolve = _.value.name)))
+
+  val DogType = ObjectType(
+    "Dog",
+    interfaces[Unit, Dog](NamedType),
+    fields[Unit, Dog](Field("barks", OptionType(BooleanType), resolve = _.value.barks)))
+
+  val schema = Schema(DogType)
+
+  "Interfaces of interfaces introspection" should {
+    "introspect on interface of an interface should be empty array" in check(
+      (),
+      """
+        {
+          Named: __type(name: "Named") {
+            kind
+            name
+            fields { name }
+            interfaces { name }
+          }
+        }
+      """,
+      Map(
+        "data" -> Map(
+          "Named" -> Map(
+            "kind" -> "INTERFACE",
+            "name" -> "Named",
+            "fields" -> List(
+              Map("name" -> "name")
+            ),
+            "interfaces" -> List.empty
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
Steps to reproduce:

```
{
  __schema {
    types {
      name
      interfaces {
        name
      }
    }
  }
}
```

returns:
```
...
{ "name" : "SomeInterfaceName", "interfaces" : null } 
...
```

but according to specs it should return:
```
...
{ "name" : "SomeInterfaceName", "interfaces" : [] } 
...
```

More details: https://spec.graphql.org/October2021/#sec-The-__Type-Type.Interface
> interfaces must return the set of interfaces that an object implements (if none, interfaces must return the empty set).


Knowing that sangria does not support interfaces of interfaces, I have tried to only change this for introspection, so it renders an empty array instead of null.

However all the changes in this PR did not change it (because the following test is still passing:  https://github.com/sangria-graphql/sangria/blob/main/modules/core/src/test/scala/sangria/execution/UnionInterfaceSpec.scala#L119)

@yanns do you have some hints as the most active contributor? 🤔  Any help is appreciated!