### PR TITLE
'interfaces' on interface should be an empty list

### DIFF
--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -272,7 +272,7 @@ package object introspection {
           "interfaces",
           OptionType(ListType(__Type)),
           resolve = _.value._2 match {
-            case t: ObjectType[_, _] =>
+            case t: ObjectLikeType[_, _] =>
               Some(t.allInterfaces.asInstanceOf[Vector[Type]].map(true -> _))
             case _ => None
           }

--- a/modules/core/src/test/resources/scenarios/execution/UnionInterface.yaml
+++ b/modules/core/src/test/resources/scenarios/execution/UnionInterface.yaml
@@ -70,13 +70,13 @@ tests:
     when:
       execute:
     then:
-      data: 
+      data:
         Named:
           kind: "INTERFACE"
           name: "Named"
           fields:
             - name: "name"
-          interfaces: null
+          interfaces: []
           possibleTypes:
             - name: "Cat"
             - name: "Dog"
@@ -93,7 +93,7 @@ tests:
             - name: "Cat"
           enumValues: null
           inputFields: null
-  
+
   - name: executes using union types
     given:
       query: |
@@ -112,7 +112,7 @@ tests:
         validate-query: false
         test-value: bob
     then:
-      data: 
+      data:
         __typename: "Person"
         name: "Bob"
         pets:
@@ -122,7 +122,7 @@ tests:
           - __typename: "Dog"
             name: "Odie"
             barks: true
-              
+
   - name: executes union types with inline fragments
     given:
       query: |
@@ -145,7 +145,7 @@ tests:
       execute:
         test-value: bob
     then:
-      data: 
+      data:
         __typename: "Person"
         name: "Bob"
         pets:
@@ -208,7 +208,7 @@ tests:
       data:
         __typename: "Person"
         name: "Bob"
-        friends: 
+        friends:
           - __typename: "Person"
             name: "Liz"
           - __typename: "Dog"

--- a/modules/core/src/test/scala/sangria/execution/UnionInterfaceSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/UnionInterfaceSpec.scala
@@ -116,7 +116,7 @@ class UnionInterfaceSpec
             "fields" -> List(
               Map("name" -> "name")
             ),
-            "interfaces" -> null,
+            "interfaces" -> Nil,
             "possibleTypes" -> List(
               Map("name" -> "Cat"),
               Map("name" -> "Dog"),

--- a/modules/core/src/test/scala/sangria/introspection/InterfaceOfInterfaceSpec.scala
+++ b/modules/core/src/test/scala/sangria/introspection/InterfaceOfInterfaceSpec.scala
@@ -1,0 +1,58 @@
+package sangria.introspection
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sangria.schema._
+import sangria.util.{FutureResultSupport, GraphQlSupport}
+
+class InterfaceOfInterfaceSpec
+    extends AnyWordSpec
+    with Matchers
+    with FutureResultSupport
+    with GraphQlSupport {
+
+  trait Named {
+    def name: Option[String]
+  }
+
+  case class Dog(name: Option[String], barks: Option[Boolean]) extends Named
+
+  val NamedType = InterfaceType(
+    "Named",
+    fields[Unit, Named](Field("name", OptionType(StringType), resolve = _.value.name)))
+
+  val DogType = ObjectType(
+    "Dog",
+    interfaces[Unit, Dog](NamedType),
+    fields[Unit, Dog](Field("barks", OptionType(BooleanType), resolve = _.value.barks)))
+
+  val schema = Schema(DogType)
+
+  "Interfaces of interfaces introspection" should {
+    "introspect on interface of an interface should be empty array" in check(
+      (),
+      """
+        {
+          Named: __type(name: "Named") {
+            kind
+            name
+            fields { name }
+            interfaces { name }
+          }
+        }
+      """,
+      Map(
+        "data" -> Map(
+          "Named" -> Map(
+            "kind" -> "INTERFACE",
+            "name" -> "Named",
+            "fields" -> List(
+              Map("name" -> "name")
+            ),
+            "interfaces" -> List.empty
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
Follow-up of https://github.com/sangria-graphql/sangria/pull/956

Steps to reproduce:

```
{
  __schema {
    types {
      name
      interfaces {
        name
      }
    }
  }
}
```

returns:
```
...
{ "name" : "SomeInterfaceName", "interfaces" : null } 
...
```

but according to specs it should return:
```
...
{ "name" : "SomeInterfaceName", "interfaces" : [] } 
...
```

More details: https://spec.graphql.org/October2021/#sec-The-__Type-Type.Interface
> interfaces must return the set of interfaces that an object implements (if none, interfaces must return the empty set).


Knowing that [sangria does not support interfaces of interfaces for now](https://github.com/sangria-graphql/sangria/pull/597), we just change the introspection result to render an empty array instead of null.
