### PR TITLE
always return an empty list for interfaces of interface

### DIFF
--- a/modules/core/src/main/scala/sangria/introspection/package.scala
+++ b/modules/core/src/main/scala/sangria/introspection/package.scala
@@ -272,8 +272,10 @@ package object introspection {
           "interfaces",
           OptionType(ListType(__Type)),
           resolve = _.value._2 match {
-            case t: ObjectLikeType[_, _] =>
+            case t: ObjectType[_, _] =>
               Some(t.allInterfaces.asInstanceOf[Vector[Type]].map(true -> _))
+            case _: InterfaceType[_, _] =>
+              Some(Vector.empty)
             case _ => None
           }
         ),


### PR DESCRIPTION
The change https://github.com/sangria-graphql/sangria/pull/960 introduces some support for interfaces of interface.

But this feature is not complete: it would need something like https://github.com/sangria-graphql/sangria/pull/597 for full support.

Right now, sometimes we support interfaces of interface and sometimes now.

To avoid this configuration, let's always return an empty list.

We can tackle the complete support for interfaces of interface later.