### PR TITLE
Update IEEE 754 wikipedia page link

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/package.scala
+++ b/modules/core/src/main/scala/sangria/schema/package.scala
@@ -82,7 +82,7 @@ package object schema {
     "Float",
     description = Some(
       "The `Float` scalar type represents signed double-precision fractional " +
-        "values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."),
+        "values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754)."),
     coerceOutput = (v, _) =>
       // .isNaN and .isInfinity box, we explicitly avoid that here
       if (java.lang.Double.isNaN(v) || java.lang.Double.isInfinite(v))


### PR DESCRIPTION
In our project which is based on Sangria we generate pages with all types that exists in our schema. Including scalar types from Sangria. 
We have tests that verify links in types descriptions. These tests started to fail with timeout for `http://en.wikipedia.org/wiki/IEEE_floating_point`, so I checked the link of IEEE 754 wikipedia page and issued this PR with up to date link