### PR TITLE
sangria.execution.Resolver is now private

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,9 @@ lazy val core = project
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "sangria.execution.Resolver.resolveSimpleListValue"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Field.subs"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Field.apply")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Field.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.execution.Resolver.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.execution.Resolver#*")
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(


### PR DESCRIPTION
make `sangria.execution.Resolver` private. This enables us to change the implementation without breaking backwards compatibility.
I don't think anyone is using this directly. I'll cut a RC with that to check.
If it's an issue, I'll revert this.