### PR TITLE
same order as ObjectTypeExtensionDefinition

### DIFF
--- a/modules/ast/src/main/scala/sangria/ast/QueryAst.scala
+++ b/modules/ast/src/main/scala/sangria/ast/QueryAst.scala
@@ -640,8 +640,8 @@ case class ObjectTypeExtensionDefinition(
   */
 case class InterfaceTypeExtensionDefinition(
     name: String,
-    fields: Vector[FieldDefinition],
     interfaces: Vector[NamedType],
+    fields: Vector[FieldDefinition],
     directives: Vector[Directive] = Vector.empty,
     comments: Vector[Comment] = Vector.empty,
     trailingComments: Vector[Comment] = Vector.empty,
@@ -653,6 +653,14 @@ case class InterfaceTypeExtensionDefinition(
 }
 
 object InterfaceTypeExtensionDefinition {
+  def apply(name: String, fields: Vector[FieldDefinition]): InterfaceTypeExtensionDefinition =
+    new InterfaceTypeExtensionDefinition(name, Vector.empty, fields)
+
+  def apply(
+      name: String,
+      fields: Vector[FieldDefinition],
+      directives: Vector[Directive]): InterfaceTypeExtensionDefinition =
+    new InterfaceTypeExtensionDefinition(name, Vector.empty, fields, directives)
 
   def apply(
       name: String,
@@ -661,16 +669,14 @@ object InterfaceTypeExtensionDefinition {
       comments: Vector[Comment],
       trailingComments: Vector[Comment],
       location: Option[AstLocation]): InterfaceTypeExtensionDefinition =
-    InterfaceTypeExtensionDefinition(
+    new InterfaceTypeExtensionDefinition(
       name,
-      fields,
       Vector.empty,
+      fields,
       directives,
       comments,
       trailingComments,
-      location
-    )
-
+      location)
 }
 
 /** @group typesystem

--- a/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/QueryRenderer.scala
@@ -732,7 +732,7 @@ object QueryRenderer {
           renderDirs(dirs, config, indent, withSep = fields.nonEmpty) +
           renderFieldDefinitions(fields, ted, indent, config)
 
-      case ext @ InterfaceTypeExtensionDefinition(name, fields, interfaces, dirs, _, _, _) =>
+      case ext @ InterfaceTypeExtensionDefinition(name, interfaces, fields, dirs, _, _, _) =>
         renderComment(ext, prev, indent, config) +
           indent.str + "extend" + config.mandatorySeparator + "interface" + config.mandatorySeparator + name +
           (if (interfaces.nonEmpty) config.mandatorySeparator else "") +

--- a/modules/parser/src/main/scala/sangria/parser/QueryParser.scala
+++ b/modules/parser/src/main/scala/sangria/parser/QueryParser.scala
@@ -312,8 +312,8 @@ private[parser] sealed trait TypeSystemDefinitions {
       (comment, location, name, interfaces, dirs, fields) =>
         ast.InterfaceTypeExtensionDefinition(
           name,
-          fields._1.toVector,
           interfaces,
+          fields._1.toVector,
           dirs,
           comment,
           fields._2,
@@ -322,8 +322,8 @@ private[parser] sealed trait TypeSystemDefinitions {
         Vector.empty))) ~ DirectivesConst ~> ((comment, location, name, interfaces, dirs) =>
         ast.InterfaceTypeExtensionDefinition(
           name,
-          Vector.empty,
           interfaces,
+          Vector.empty,
           dirs,
           comment,
           Vector.empty,
@@ -332,8 +332,8 @@ private[parser] sealed trait TypeSystemDefinitions {
         (comment, location, name, interfaces) =>
           ast.InterfaceTypeExtensionDefinition(
             name,
-            Vector.empty,
             interfaces,
+            Vector.empty,
             Vector.empty,
             comment,
             Vector.empty,

--- a/modules/parser/src/test/scala/sangria/parser/SchemaParserSpec.scala
+++ b/modules/parser/src/test/scala/sangria/parser/SchemaParserSpec.scala
@@ -1846,6 +1846,7 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
             ),
             InterfaceTypeExtensionDefinition(
               "Baz",
+              Vector(NamedType("Bar", Some(AstLocation(144, 14, 33)))),
               Vector(
                 FieldDefinition(
                   "baz",
@@ -1872,7 +1873,6 @@ class SchemaParserSpec extends AnyWordSpec with Matchers with StringMatchers {
                   Vector.empty,
                   Some(AstLocation(178, 17, 3)))
               ),
-              Vector(NamedType("Bar", Some(AstLocation(144, 14, 33)))),
               Vector.empty,
               Vector.empty,
               Vector.empty,


### PR DESCRIPTION
In `InterfaceTypeExtensionDefinition`, use the fields in the same order as `ObjectTypeExtensionDefinition`.
Add some `apply` to cover all major cases of instantiations (tested with some internal applications)