### PR TITLE
scala 3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17, 2.13.10, 3.2.2]
+        scala: [2.12.17, 2.13.10, 3.3.0]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -127,12 +127,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2)
+      - name: Download target directories (3.3.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.2.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.2.2)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,10 @@ import sbt.Keys._
 
 import com.typesafe.tools.mima.core._
 
-val isScala3 = Def.setting(
-  CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)
-)
+val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
 
 // sbt-github-actions needs configuration in `ThisBuild`
-ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", "3.2.2")
+ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", "3.3.0")
 ThisBuild / scalaVersion := crossScalaVersions.value.tail.head
 ThisBuild / githubWorkflowBuildPreamble ++= List(
   WorkflowStep.Sbt(List("mimaReportBinaryIssues"), name = Some("Check binary compatibility")),


### PR DESCRIPTION
Scala 3.3 is a big release since its LTS, which means it will be supported for a long time (critical bugs/security fixes will be backported to the 3.3 branch) so its a good idea to prune out any potential issues before the release is made.