### PR TITLE
Add an option to limit number of errors returned

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import sbt.Developer
 import sbt.Keys._
 
+import com.typesafe.tools.mima.core._
+
 val isScala3 = Def.setting(scalaBinaryVersion.value == "3")
 
 // sbt-github-actions needs configuration in `ThisBuild`
@@ -91,6 +93,10 @@ lazy val core = project
     name := "sangria-core",
     description := "Scala GraphQL implementation",
     mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-core" % "4.0.0"),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.validation.RuleBasedQueryValidator.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.validation.ValidationContext.this")
+    ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(
       // AST Visitor

--- a/modules/benchmarks/src/main/scala/sangria/benchmarks/OverlappingFieldsCanBeMergedBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/sangria/benchmarks/OverlappingFieldsCanBeMergedBenchmark.scala
@@ -11,7 +11,7 @@ import sangria.validation.{QueryValidator, RuleBasedQueryValidator, Violation}
 @State(Scope.Thread)
 class OverlappingFieldsCanBeMergedBenchmark {
 
-  val validator: QueryValidator = new RuleBasedQueryValidator(
+  val validator: QueryValidator = RuleBasedQueryValidator(
     List(new rules.OverlappingFieldsCanBeMerged))
 
   val schema: Schema[_, _] =

--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -45,14 +45,18 @@ object QueryValidator {
     new SingleFieldSubscriptions
   )
 
-  def ruleBased(rules: List[ValidationRule]) = RuleBasedQueryValidator(rules)
+  @deprecated("use ruleBased setting 'errorsLimit' instead", "4.0.1")
+  def ruleBased(rules: List[ValidationRule]): RuleBasedQueryValidator =
+    RuleBasedQueryValidator(rules)
+  def ruleBased(rules: List[ValidationRule], errorsLimit: Option[Int]): RuleBasedQueryValidator =
+    new RuleBasedQueryValidator(rules, errorsLimit)
 
-  val empty = new QueryValidator {
+  val empty: QueryValidator = new QueryValidator {
     def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] =
       Vector.empty
   }
 
-  val default: RuleBasedQueryValidator = ruleBased(allRules)
+  val default: RuleBasedQueryValidator = ruleBased(allRules, errorsLimit = Some(10))
 }
 
 class RuleBasedQueryValidator(

--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -162,7 +162,7 @@ class ValidationContext(
     val doc: ast.Document,
     val sourceMapper: Option[SourceMapper],
     val typeInfo: TypeInfo,
-    val errorsLimit: Option[Int]) {
+    errorsLimit: Option[Int]) {
   // Using mutable data-structures and mutability to minimize validation footprint
 
   private val errors = ListBuffer[Violation]()

--- a/modules/core/src/test/scala/sangria/util/CatsSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/CatsSupport.scala
@@ -220,7 +220,7 @@ object CatsScenarioExecutor extends FutureResultSupport {
 
     case Validate(rules) =>
       ValidationResult(
-        new RuleBasedQueryValidator(rules.toList)
+        RuleBasedQueryValidator(rules.toList)
           .validateQuery(`given`.schema, QueryParser.parse(`given`.query).get))
 
     case Execute(validate, value, vars, op) =>

--- a/modules/core/src/test/scala/sangria/util/ValidationSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/ValidationSupport.scala
@@ -455,5 +455,5 @@ trait ValidationSupport extends Matchers {
     violations shouldBe empty
   }
 
-  def validator(rules: List[ValidationRule]) = new RuleBasedQueryValidator(rules)
+  def validator(rules: List[ValidationRule]) = RuleBasedQueryValidator(rules)
 }

--- a/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
@@ -1,0 +1,63 @@
+package sangria.validation
+
+import org.scalatest.wordspec.AnyWordSpec
+import sangria.parser.QueryParser
+import sangria.schema._
+
+import scala.util.Success
+
+class QueryValidatorSpec extends AnyWordSpec {
+  "QueryValidator" when {
+    val rules = QueryValidator.allRules
+
+    "testing RuleBasedQueryValidator" should {
+      val TestInputType = InputObjectType(
+        name = "TestInput",
+        fields = List(
+          InputField("field1", StringType),
+          InputField("field2", StringType)
+        )
+      )
+
+      val QueryType = ObjectType(
+        name = "Query",
+        fields = fields[Unit, Unit](
+          Field(
+            name = "testField",
+            fieldType = OptionType(StringType),
+            arguments = List(Argument("testArg", ListInputType(TestInputType))),
+            resolve = _ => None
+          )
+        )
+      )
+
+      val schema = Schema(QueryType)
+
+      val invalidQuery =
+        """
+          query {
+            testField(testArg: [{}, {}, {}, {}, {}])
+          }
+        """
+
+      "not limit number of errors returned if the limit is not provided" in {
+        val validator = new RuleBasedQueryValidator(rules)
+
+        val Success(doc) = QueryParser.parse(invalidQuery)
+        val result = validator.validateQuery(schema, doc)
+
+        // 10 errors are expected because there are 5 input objects in the list with 2 missing fields each
+        assertResult(10)(result.length)
+      }
+      "limit number of errors returned if the limit is provided" in {
+        val errorsLimit = 5
+        val validator = new RuleBasedQueryValidator(rules, Some(errorsLimit))
+
+        val Success(doc) = QueryParser.parse(invalidQuery)
+        val result = validator.validateQuery(schema, doc)
+
+        assertResult(errorsLimit)(result.length)
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
@@ -41,7 +41,7 @@ class QueryValidatorSpec extends AnyWordSpec {
         """
 
       "not limit number of errors returned if the limit is not provided" in {
-        val validator = new RuleBasedQueryValidator(rules)
+        val validator = RuleBasedQueryValidator(rules)
 
         val Success(doc) = QueryParser.parse(invalidQuery)
         val result = validator.validateQuery(schema, doc)


### PR DESCRIPTION
# What?
Add an option to limit the number of errors returned.

# Why?
There is a possibility that the lack of limits could be abused to induce memory pressure in the server/service handling the request and can lead to the potential denial of service (i.e. no DDoS needed).