### PR TITLE
DRAFT / WIP: Limit number of errors returned (when variables are used)

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/Executor.scala
+++ b/modules/core/src/main/scala/sangria/execution/Executor.scala
@@ -4,9 +4,10 @@ import sangria.ast
 import sangria.ast.SourceMapper
 import sangria.marshalling.{InputUnmarshaller, ResultMarshaller}
 import sangria.schema._
-import sangria.validation.QueryValidator
+import sangria.validation.{QueryValidator, RuleBasedQueryValidator}
 import InputUnmarshaller.emptyMapVars
 import sangria.execution.deferred.DeferredResolver
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -43,7 +44,9 @@ case class Executor[Ctx, Root](
         userContext,
         exceptionHandler,
         scalarMiddleware,
-        false)(um)
+        false,
+        errorsLimit = queryValidator.errorsLimit
+      )(um)
 
       val executionResult = for {
         operation <- Executor.getOperation(exceptionHandler, queryAst, operationName)
@@ -155,7 +158,9 @@ case class Executor[Ctx, Root](
         userContext,
         exceptionHandler,
         scalarMiddleware,
-        false)(um)
+        false,
+        errorsLimit = queryValidator.errorsLimit
+      )(um)
 
       val executionResult = for {
         operation <- Executor.getOperation(exceptionHandler, queryAst, operationName)

--- a/modules/core/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
+++ b/modules/core/src/main/scala/sangria/execution/InputDocumentMaterializer.scala
@@ -26,7 +26,9 @@ case class InputDocumentMaterializer[Vars](
       (),
       ExceptionHandler.empty,
       None,
-      false)(iu)
+      false,
+      errorsLimit = None
+    )(iu)
 
     val violations = QueryValidator.default.validateInputDocument(schema, document, inputType)
 

--- a/modules/core/src/main/scala/sangria/execution/QueryReducerExecutor.scala
+++ b/modules/core/src/main/scala/sangria/execution/QueryReducerExecutor.scala
@@ -35,7 +35,9 @@ object QueryReducerExecutor {
         userContext,
         exceptionHandler,
         scalarMiddleware,
-        true)(InputUnmarshaller.scalaInputUnmarshaller[Any @@ ScalaInput])
+        true,
+        errorsLimit = queryValidator.errorsLimit
+      )(InputUnmarshaller.scalaInputUnmarshaller[Any @@ ScalaInput])
 
       val executionResult = for {
         operation <- Executor.getOperation(exceptionHandler, queryAst, operationName)

--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -12,6 +12,7 @@ import scala.reflect.{ClassTag, classTag}
 
 trait QueryValidator {
   def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation]
+  def errorsLimit: Option[Int]
 }
 
 object QueryValidator {
@@ -54,14 +55,15 @@ object QueryValidator {
   val empty: QueryValidator = new QueryValidator {
     def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] =
       Vector.empty
+    override val errorsLimit: Option[Int] = None
   }
 
-  val default: RuleBasedQueryValidator = ruleBased(allRules, errorsLimit = Some(10))
+  val default: RuleBasedQueryValidator = ruleBased(allRules, errorsLimit = Some(1))
 }
 
 class RuleBasedQueryValidator(
     rules: List[ValidationRule],
-    errorsLimit: Option[Int]
+    override val errorsLimit: Option[Int]
 ) extends QueryValidator {
   def validateQuery(schema: Schema[_, _], queryAst: ast.Document): Vector[Violation] = {
     val ctx = new ValidationContext(

--- a/modules/core/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/ValueCoercionHelperSpec.scala
@@ -213,7 +213,9 @@ class ValueCoercionHelperSpec extends AnyWordSpec with Matchers {
       (),
       ExceptionHandler.empty,
       None,
-      true)
+      true,
+      errorsLimit = None
+    )
     val variables = valueCollector
       .getVariableValues(
         QueryParser


### PR DESCRIPTION
Follow up to https://github.com/sangria-graphql/sangria/pull/1017

The solution from the previous PR works only for cases where input is specified (hardcoded) as a part of the query but doesn't work/executed when variables are used. For example, the following query will still return an unlimited number of errors:
```
mutation createProduct($input: CreateProductInput!) {
  product {
    createProduct(input: $input) {
      ...
    }
  }
}

// variables
{
    "input":{
      "field_with_invalid_objects":[{},{},{},{},{}, ...]
    }
  }
```

@yanns I'd appreciate your guidance here on the best way to design it 🙂 