### PR TITLE
use a max number of errors by default

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/Executor.scala
+++ b/modules/core/src/main/scala/sangria/execution/Executor.scala
@@ -20,7 +20,7 @@ case class Executor[Ctx, Root](
     middleware: List[Middleware[Ctx]] = Nil,
     maxQueryDepth: Option[Int] = None,
     queryReducers: List[QueryReducer[Ctx, _]] = Nil,
-    errorsLimit: Option[Int] = None
+    errorsLimit: Option[Int] = Some(10)
 )(implicit executionContext: ExecutionContext) {
   def prepare[Input](
       queryAst: ast.Document,


### PR DESCRIPTION
Use secure configuration by default
Follow-up of https://github.com/sangria-graphql/sangria/pull/1034