### PR TITLE
add input value deprecation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,40 @@ lazy val core = project
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "sangria.validation.RuleBasedQueryValidator.validateQuery"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "sangria.validation.ValidationContext.this")
+        "sangria.validation.ValidationContext.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.IntrospectionInputValue.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.IntrospectionInputValue.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.IntrospectionInputValue.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("sangria.introspection.IntrospectionInputValue$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.IntrospectionInputValue.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.package.introspectionQueryString"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.package.introspectionQuery"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.package.introspectionQuery"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.introspection.package.introspectionQueryString"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Argument.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Argument.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "sangria.schema.Argument.copy$default$6"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.schema.Argument._6"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Argument.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.Argument.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.InputField.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.InputField.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "sangria.schema.InputField.copy$default$5"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.schema.InputField._5"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.InputField.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("sangria.schema.InputField.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "sangria.schema.InputValue.deprecationReason")
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(

--- a/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
+++ b/modules/core/src/main/scala/sangria/introspection/IntrospectionParser.scala
@@ -24,7 +24,9 @@ object IntrospectionParser {
       name = mapStringField(value, "name", path),
       description = mapStringFieldOpt(value, "description"),
       tpe = parseTypeRef(mapField(value, "type", path), path :+ "type"),
-      defaultValue = mapStringFieldOpt(value, "defaultValue")
+      defaultValue = mapStringFieldOpt(value, "defaultValue"),
+      isDeprecated = mapBooleanFieldOpt(value, "isDeprecated", path),
+      deprecationReason = mapStringFieldOpt(value, "deprecationReason")
     )
 
   private def parseField[In: InputUnmarshaller](field: In, path: Vector[String]) =

--- a/modules/core/src/main/scala/sangria/introspection/model.scala
+++ b/modules/core/src/main/scala/sangria/introspection/model.scala
@@ -115,7 +115,10 @@ case class IntrospectionInputValue(
     name: String,
     description: Option[String],
     tpe: IntrospectionTypeRef,
-    defaultValue: Option[String])
+    defaultValue: Option[String],
+    isDeprecated: Option[Boolean],
+    deprecationReason: Option[String]
+)
 
 sealed trait IntrospectionTypeRef {
   def kind: TypeKind.Value

--- a/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
+++ b/modules/core/src/main/scala/sangria/renderer/SchemaRenderer.scala
@@ -79,7 +79,9 @@ object SchemaRenderer {
       arg.name,
       renderTypeNameAst(arg.argumentType),
       arg.defaultValue.flatMap(renderDefault(_, arg.argumentType)),
-      arg.astDirectives,
+      withoutDeprecated(arg.astDirectives) ++ renderDeprecation(
+        arg.deprecationReason.isDefined,
+        arg.deprecationReason),
       renderDescription(arg.description)
     )
 
@@ -138,14 +140,18 @@ object SchemaRenderer {
       field.name,
       renderTypeName(field.tpe),
       renderDefault(field.defaultValue),
-      description = renderDescription(field.description))
+      directives = renderDeprecation(field.isDeprecated.getOrElse(false), field.deprecationReason),
+      description = renderDescription(field.description)
+    )
 
   def renderInputField(field: InputField[_]) =
     ast.InputValueDefinition(
       field.name,
       renderTypeNameAst(field.fieldType),
       field.defaultValue.flatMap(renderDefault(_, field.fieldType)),
-      field.astDirectives,
+      withoutDeprecated(field.astDirectives) ++ renderDeprecation(
+        field.deprecationReason.isDefined,
+        field.deprecationReason),
       renderDescription(field.description)
     )
 

--- a/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/AstSchemaBuilder.scala
@@ -691,6 +691,7 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
         fieldType = tpe,
         defaultValue = defaultValue,
         astDirectives = definition.directives,
+        deprecationReason = inputValueDeprecationReason(definition),
         astNodes = Vector(definition)
       ))
 
@@ -719,7 +720,8 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
         defaultValue = defaultValue,
         fromInput = argumentFromInput(typeDefinition, fieldDefinition, definition),
         astDirectives = definition.directives,
-        astNodes = Vector(definition)
+        astNodes = Vector(definition),
+        deprecationReason = inputValueDeprecationReason(definition)
       ))
 
   def buildArgumentType(
@@ -851,6 +853,9 @@ class DefaultAstSchemaBuilder[Ctx] extends AstSchemaBuilder[Ctx] {
     None
 
   def enumValueDeprecationReason(definition: ast.EnumValueDefinition): Option[String] =
+    deprecationReason(definition.directives.toList)
+
+  def inputValueDeprecationReason(definition: ast.InputValueDefinition): Option[String] =
     deprecationReason(definition.directives.toList)
 
   def fieldDeprecationReason(definition: ast.FieldDefinition): Option[String] =

--- a/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/IntrospectionSchemaBuilder.scala
@@ -260,6 +260,7 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
       InputField(
         name = inputFieldName(definition),
         description = inputFieldDescription(definition),
+        deprecationReason = inputValueDeprecationReason(definition),
         fieldType = tpe,
         defaultValue = defaultValue,
         astDirectives = Vector.empty,
@@ -280,7 +281,8 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
         defaultValue = defaultValue,
         fromInput = argumentFromInput(fieldDefinition, definition),
         astDirectives = Vector.empty,
-        astNodes = Vector.empty
+        astNodes = Vector.empty,
+        deprecationReason = inputValueDeprecationReason(definition)
       ))
 
   def buildDirective(
@@ -376,6 +378,11 @@ class DefaultIntrospectionSchemaBuilder[Ctx] extends IntrospectionSchemaBuilder[
 
   def enumValue(definition: IntrospectionEnumValue): String =
     definition.name
+
+  def inputValueDeprecationReason(definition: IntrospectionInputValue): Option[String] =
+    definition.deprecationReason.orElse(
+      if (definition.isDeprecated.getOrElse(false)) Some(DefaultDeprecationReason) else None
+    )
 
   def fieldDeprecationReason(definition: IntrospectionField): Option[String] =
     definition.deprecationReason.orElse(

--- a/modules/core/src/main/scala/sangria/schema/package.scala
+++ b/modules/core/src/main/scala/sangria/schema/package.scala
@@ -258,7 +258,12 @@ package object schema {
     "deprecated",
     description = Some("Marks an element of a GraphQL schema as no longer supported."),
     arguments = ReasonArg :: Nil,
-    locations = Set(DirectiveLocation.FieldDefinition, DirectiveLocation.EnumValue),
+    locations = Set(
+      DirectiveLocation.FieldDefinition,
+      DirectiveLocation.EnumValue,
+      DirectiveLocation.ArgumentDefinition,
+      DirectiveLocation.InputFieldDefinition
+    ),
     shouldInclude = ctx => !ctx.arg(IfArg)
   )
 

--- a/modules/core/src/test/scala/sangria/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/sangria/introspection/IntrospectionSpec.scala
@@ -91,7 +91,12 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
                 Map(
                   "name" -> "args",
                   "description" -> null,
-                  "args" -> Vector.empty,
+                  "args" -> Vector(Map(
+                    "name" -> "includeDeprecated",
+                    "description" -> null,
+                    "type" -> Map("kind" -> "SCALAR", "name" -> "Boolean", "ofType" -> null),
+                    "defaultValue" -> "false"
+                  )),
                   "type" -> Map(
                     "kind" -> "NON_NULL",
                     "name" -> null,
@@ -309,7 +314,12 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
                 Map(
                   "name" -> "args",
                   "description" -> null,
-                  "args" -> Vector.empty,
+                  "args" -> Vector(Map(
+                    "name" -> "includeDeprecated",
+                    "description" -> null,
+                    "type" -> Map("kind" -> "SCALAR", "name" -> "Boolean", "ofType" -> null),
+                    "defaultValue" -> "false"
+                  )),
                   "type" -> Map(
                     "kind" -> "NON_NULL",
                     "name" -> null,
@@ -401,6 +411,22 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
                 Map(
                   "name" -> "defaultValue",
                   "description" -> "A GraphQL-formatted string representing the default value for this input value.",
+                  "args" -> Vector.empty,
+                  "type" -> Map("kind" -> "SCALAR", "name" -> "String", "ofType" -> null),
+                  "isDeprecated" -> false,
+                  "deprecationReason" -> null
+                ),
+                Map(
+                  "name" -> "isDeprecated",
+                  "description" -> null,
+                  "args" -> Vector.empty,
+                  "type" -> Map("kind" -> "SCALAR", "name" -> "Boolean", "ofType" -> null),
+                  "isDeprecated" -> false,
+                  "deprecationReason" -> null
+                ),
+                Map(
+                  "name" -> "deprecationReason",
+                  "description" -> null,
                   "args" -> Vector.empty,
                   "type" -> Map("kind" -> "SCALAR", "name" -> "String", "ofType" -> null),
                   "isDeprecated" -> false,
@@ -599,7 +625,12 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
                 Map(
                   "name" -> "inputFields",
                   "description" -> null,
-                  "args" -> Vector.empty,
+                  "args" -> Vector(Map(
+                    "name" -> "includeDeprecated",
+                    "description" -> null,
+                    "type" -> Map("kind" -> "SCALAR", "name" -> "Boolean", "ofType" -> null),
+                    "defaultValue" -> "false"
+                  )),
                   "type" -> Map(
                     "kind" -> "LIST",
                     "name" -> null,
@@ -746,7 +777,11 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
             Map(
               "name" -> "deprecated",
               "description" -> "Marks an element of a GraphQL schema as no longer supported.",
-              "locations" -> Vector("ENUM_VALUE", "FIELD_DEFINITION"),
+              "locations" -> Vector(
+                "ARGUMENT_DEFINITION",
+                "ENUM_VALUE",
+                "FIELD_DEFINITION",
+                "INPUT_FIELD_DEFINITION"),
               "args" -> Vector(Map(
                 "name" -> "reason",
                 "description" -> "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",

--- a/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
+++ b/modules/core/src/test/scala/sangria/renderer/SchemaRenderSpec.scala
@@ -883,7 +883,7 @@ class SchemaRenderSpec
         |  name: String!
         |  description: String
         |  locations: [__DirectiveLocation!]!
-        |  args: [__InputValue!]!
+        |  args(includeDeprecated: Boolean = false): [__InputValue!]!
         |
         |  "Permits using the directive multiple times at the same location."
         |  isRepeatable: Boolean!
@@ -961,7 +961,7 @@ class SchemaRenderSpec
         |type __Field {
         |  name: String!
         |  description: String
-        |  args: [__InputValue!]!
+        |  args(includeDeprecated: Boolean = false): [__InputValue!]!
         |  type: __Type!
         |  isDeprecated: Boolean!
         |  deprecationReason: String
@@ -975,6 +975,8 @@ class SchemaRenderSpec
         |
         |  "A GraphQL-formatted string representing the default value for this input value."
         |  defaultValue: String
+        |  isDeprecated: Boolean
+        |  deprecationReason: String
         |}
         |
         |"A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
@@ -1010,7 +1012,7 @@ class SchemaRenderSpec
         |  interfaces: [__Type!]
         |  possibleTypes: [__Type!]
         |  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-        |  inputFields: [__InputValue!]
+        |  inputFields(includeDeprecated: Boolean = false): [__InputValue!]
         |  ofType: __Type
         |}
         |

--- a/modules/core/src/test/scala/sangria/util/StringMatchers.scala
+++ b/modules/core/src/test/scala/sangria/util/StringMatchers.scala
@@ -9,7 +9,13 @@ trait StringMatchers {
 
   def stripCarriageReturns(s: String) = s.replaceAll("\\r", "")
 
+  val whitespace = "\\s+".r
+
+  def normalizeAllWhitespace(str: String): String =
+    whitespace.replaceAllIn(str, " ").trim
+
   implicit class StringHelpers(s: String) {
     def stripCR: String = stripCarriageReturns(s)
+    def normalizeAllWS: String = normalizeAllWhitespace(s)
   }
 }

--- a/modules/core/src/test/scala/sangria/validation/DocumentAnalyzerSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/DocumentAnalyzerSpec.scala
@@ -1,5 +1,6 @@
 package sangria.validation
 
+import sangria.ast
 import sangria.schema._
 import sangria.macros._
 import sangria.util.StringMatchers
@@ -11,11 +12,24 @@ import sangria.util.tag.@@ // Scala 3 issue workaround
 import sangria.marshalling.FromInput.CoercedScalaResult
 
 class DocumentAnalyzerSpec extends AnyWordSpec with Matchers with StringMatchers {
+  def makeDirective(name: String): (Directive, ast.Directive) = (
+    Directive(
+      name,
+      arguments = Argument[Option[Int @@ CoercedScalaResult]](
+        s"${name}Arg",
+        OptionInputType(IntType)
+      ).withDeprecationReason("Some dir arg reason.") :: Nil),
+    ast.Directive(name, Vector(ast.Argument(s"${name}Arg", ast.IntValue(123))))
+  )
+
   val NumberType = EnumType(
     "Number",
     values = List(
       EnumValue("ONE", value = 1),
       EnumValue("TWO", value = 2, deprecationReason = Some("Some enum reason."))))
+
+  val fieldDirective = makeDirective("fieldDir")
+  val ioDirective = makeDirective("ioDir")
 
   val QueryType = ObjectType(
     "Query",
@@ -32,11 +46,57 @@ class DocumentAnalyzerSpec extends AnyWordSpec with Matchers with StringMatchers
         "deprecatedField",
         OptionType(StringType),
         deprecationReason = Some("Some field reason."),
-        resolve = _ => "foo")
+        resolve = _ => "foo"),
+      Field(
+        "fieldWithDeprecatedArg",
+        OptionType(StringType),
+        resolve = ctx => ctx.argOpt[String]("deprecatedArg"),
+        arguments = Argument[Option[Int @@ CoercedScalaResult]](
+          "deprecatedArg",
+          OptionInputType(IntType)
+        ).withDeprecationReason("Some arg reason.") :: Nil
+      ),
+      Field(
+        "fieldWithInputObjectFieldDeprecated",
+        OptionType(StringType),
+        resolve = _ => "foo",
+        arguments = Argument(
+          "input",
+          InputObjectType(
+            "FooInput",
+            "",
+            fieldsFn = () =>
+              InputField("deprecatedField", StringType)
+                .withDeprecationReason("Some input field reason.") :: Nil
+          ).withDirective(ioDirective._2)
+        ) :: Nil
+      ),
+      Field(
+        "fieldWithOptionalInputObjectFieldDeprecated",
+        OptionType(StringType),
+        resolve = _ => "foo",
+        arguments = Argument(
+          "input",
+          OptionInputType(
+            InputObjectType(
+              "FooInput",
+              "",
+              fieldsFn = () =>
+                InputField("deprecatedField", OptionInputType(StringType))
+                  .withDeprecationReason("Some input field reason.") :: Nil
+            ).withDirective(ioDirective._2))
+        ) :: Nil
+      ),
+      Field(
+        "fieldWithDeprecatedDirectiveArg",
+        OptionType(StringType),
+        resolve = _ => "foo",
+        astDirectives = Vector(fieldDirective._2)
+      )
     )
   )
 
-  val schema = Schema(QueryType)
+  val schema = Schema(QueryType, directives = List(fieldDirective, ioDirective).map(_._1))
 
   "DocumentAnalyzer" should {
     "report empty set for no deprecated usages" in {
@@ -57,6 +117,53 @@ class DocumentAnalyzerSpec extends AnyWordSpec with Matchers with StringMatchers
         .deprecatedUsages
         .map(_.errorMessage) should
         contain("The enum value 'Number.TWO' is deprecated. Some enum reason.")
+    }
+
+    "report usage of deprecated field args" in {
+      schema
+        .analyzer(gql"""{ fieldWithDeprecatedArg(deprecatedArg: "foo") }""")
+        .deprecatedUsages
+        .map(_.errorMessage) should
+        contain(
+          "The argument 'deprecatedArg' on 'Query.fieldWithDeprecatedArg' is deprecated. Some arg reason.")
+    }
+
+    "report usage of deprecated field directive arg" in {
+      schema
+        .analyzer(
+          gql"""{ fieldWithDeprecatedDirectiveArg @fieldDir(fieldDirArg: 123)}"""
+        )
+        .deprecatedUsages
+        .map(_.errorMessage) should contain(
+        "The argument 'fieldDirArg' on directive 'fieldDir' is deprecated. Some dir arg reason.")
+    }
+
+    "report usage of deprecated input object field args" in {
+      schema
+        .analyzer(
+          gql"""{ fieldWithInputObjectFieldDeprecated(input: { deprecatedField: "foo" }) }""")
+        .deprecatedUsages
+        .map(_.errorMessage) should
+        contain(
+          "The input field 'FooInput.deprecatedField' is deprecated. Some input field reason.")
+    }
+
+    "report usage of deprecated optional input object field args" in {
+      schema
+        .analyzer(
+          gql"""{ fieldWithOptionalInputObjectFieldDeprecated(input: { deprecatedField: "foo" }) }""")
+        .deprecatedUsages
+        .map(_.errorMessage) should
+        contain(
+          "The input field 'FooInput.deprecatedField' is deprecated. Some input field reason.")
+    }
+
+    "report usage of deprecated input object directive args" in {
+      schema
+        .analyzer(gql"""{ fieldWithInputObjectFieldDeprecated @ioDir(ioDirArg: 123) }""")
+        .deprecatedUsages
+        .map(_.errorMessage) should
+        contain("The argument 'ioDirArg' on directive 'ioDir' is deprecated. Some dir arg reason.")
     }
 
     "report usage of deprecated enums in variables" in {

--- a/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -603,25 +603,34 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
             "id",
             None,
             IntrospectionNamedTypeRef(TypeKind.Scalar, "Int"),
-            Some("123")),
+            Some("123"),
+            None,
+            None),
           IntrospectionInputValue(
             "songs",
             None,
             IntrospectionNonNullTypeRef(IntrospectionListTypeRef(
               IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Scalar, "String")))),
+            None,
+            None,
             None
           ),
           IntrospectionInputValue(
             "pet",
             None,
             IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"),
-            Some("""{name:"xxx",size:322}""")),
+            Some("""{name:"xxx",size:322}"""),
+            None,
+            None),
           IntrospectionInputValue(
             "aaa",
             Some("bbbb"),
             IntrospectionListTypeRef(
               IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Enum, "Color"))),
-            Some("[Red]"))
+            Some("[Red]"),
+            None,
+            None
+          )
         ))
 
       val Some(optField) = introType.fields.find(_.name == "opt")
@@ -634,16 +643,22 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
             "str",
             None,
             IntrospectionNamedTypeRef(TypeKind.Scalar, "String"),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "color",
             None,
             IntrospectionNamedTypeRef(TypeKind.Enum, "Color"),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "pet",
             None,
             IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"),
+            None,
+            None,
             None)
         ))
 
@@ -656,12 +671,16 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
             "id",
             None,
             IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Scalar, "ID")),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "defaultId",
             None,
             IntrospectionNamedTypeRef(TypeKind.Scalar, "ID"),
-            Some(""""47589""""))
+            Some(""""47589""""),
+            None,
+            None)
         ))
     }
 
@@ -720,24 +739,32 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
             "id",
             Some("`id`"),
             IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Scalar, "Int")),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "songs",
             Some("`songs`"),
             IntrospectionListTypeRef(
               IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Scalar, "String"))),
-            Some("""["My favorite song"]""")
+            Some("""["My favorite song"]"""),
+            None,
+            None
           ),
           IntrospectionInputValue(
             "pet",
             Some("`pet`"),
             IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"),
-            Some("""{name:"Octocat"}""")),
+            Some("""{name:"Octocat"}"""),
+            None,
+            None),
           IntrospectionInputValue(
             "colors",
             None,
             IntrospectionNonNullTypeRef(IntrospectionListTypeRef(
               IntrospectionNonNullTypeRef(IntrospectionNamedTypeRef(TypeKind.Enum, "Color")))),
+            None,
+            None,
             None
           )
         ))
@@ -752,17 +779,23 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
             "description",
             Some("Optional description"),
             IntrospectionNamedTypeRef(TypeKind.Scalar, "String"),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "color",
             Some("a color"),
             IntrospectionNamedTypeRef(TypeKind.Enum, "Color"),
+            None,
+            None,
             None),
           IntrospectionInputValue(
             "pet",
             None,
             IntrospectionNamedTypeRef(TypeKind.InputObject, "Pet"),
-            Some("""{name:"Bell",size:3}"""))
+            Some("""{name:"Bell",size:3}"""),
+            None,
+            None)
         ))
     }
 


### PR DESCRIPTION
Input value deprecation is a feature added a few years ago elsewhere that we would like to add support for. See [here](https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts#L34) and [here](https://github.com/graphql/graphql-js/blob/7a6d055defd7a888f50c6133faae2b9010d45fad/src/type/directives.ts#L220) for graphql-js usage in introspection.

There are two main things I believe I still need to work on, one of which particularly I'd like some input on.
- ~~[x] add to deprecation tracking~~ removed
- [x] handling directive arg deprecation in various places~~ removed
- [x] fix a test

~~Regarding directives, when looking at tests in `DocumentAnalyzerSpec` and `IntrospectionSchemaMaterializerSpec`, I would like to test a field having a directive with a deprecated argument. However, the field only has `ast.Directive`s on it, which lack deprecation information (same for other types with deprecation, it's not in the `ast` objects).~~

~~It seems like I'd have to replace `Field.astDirectives: Vector[ast.Directive]` to instead be `Field.directives: Vector[schema.Directive]`. It is more align that way with `Field.arguments: List[schema.Argument]`, which has deprecation information. So it seems more in line with keeping `schema` type objects on itself.~~

~~I was wondering if that sounds like a good approach, or why `Field` has `ast.Directive` instead of `schema.Directive` in the first place?~~

~~(same goes for `InputField`, `Argument`, and various other places directives, being `ast.Directive` instead of `schema.Directive`)~~

answer @ `ast.Directive` vs `schema.Directive`, can usually find the corresponding `schema.Directive` on `Schema.directives`