### PR TITLE
include enums on directive args in schema introspection

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/Schema.scala
+++ b/modules/core/src/main/scala/sangria/schema/Schema.scala
@@ -1494,7 +1494,15 @@ case class Schema[Ctx, Val](
       .map(collectTypes("a subscription type", 10, _, queryAndSubTypes))
       .getOrElse(queryAndSubTypes)
 
-    queryAndSubAndMutTypes
+    val queryAndSubAndMutAndDirArgTypes = directives.foldLeft(queryAndSubAndMutTypes) {
+      case (acc, dir) =>
+        val argumentTypes = dir.arguments.map(_.argumentType)
+        argumentTypes.foldLeft(acc) { case (acc, arg) =>
+          collectTypes("an argument type", 10, arg, acc)
+        }
+    }
+
+    queryAndSubAndMutAndDirArgTypes
   }
 
   lazy val typeList: Vector[Type with Named] =


### PR DESCRIPTION
Currently we're only including unused types in the additional types of ast based schemas. This causes enums that are only used on directive args to be missed when generating an introspection query result, as we are not collecting types on directive args.