### PR TITLE
Support oneOf directive on input objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,17 @@ lazy val core = project
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "sangria.validation.RuleBasedQueryValidator.validateInputDocument"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "sangria.validation.RuleBasedQueryValidator.validateInputDocument")
+        "sangria.validation.RuleBasedQueryValidator.validateInputDocument"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.schema.SchemaChange#AbstractAstDirectiveAdded.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.schema.SchemaChange#InputObjectTypeAstDirectiveAdded.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.schema.SchemaChange#InputObjectTypeAstDirectiveAdded.this"),
+      ProblemFilters.exclude[MissingTypesProblem](
+        "sangria.schema.SchemaChange$InputObjectTypeAstDirectiveAdded$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.schema.SchemaChange#InputObjectTypeAstDirectiveAdded.apply")
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,11 @@ lazy val core = project
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
         "sangria.schema.WithInputTypeRendering.deprecationTracker"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "sangria.schema.WithInputTypeRendering.deprecationTracker")
+        "sangria.schema.WithInputTypeRendering.deprecationTracker"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.validation.RuleBasedQueryValidator.validateInputDocument"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.validation.RuleBasedQueryValidator.validateInputDocument")
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     libraryDependencies ++= Seq(

--- a/modules/benchmarks/src/main/scala/sangria/benchmarks/OverlappingFieldsCanBeMergedBenchmark.scala
+++ b/modules/benchmarks/src/main/scala/sangria/benchmarks/OverlappingFieldsCanBeMergedBenchmark.scala
@@ -98,7 +98,7 @@ class OverlappingFieldsCanBeMergedBenchmark {
     bh.consume(doValidate(validator, deepAbstractConcrete))
 
   private def doValidate(validator: QueryValidator, document: Document): Vector[Violation] = {
-    val result = validator.validateQuery(schema, document, None)
+    val result = validator.validateQuery(schema, document, Map.empty, None)
     require(result.isEmpty)
     result
   }

--- a/modules/core/src/main/scala/sangria/execution/Executor.scala
+++ b/modules/core/src/main/scala/sangria/execution/Executor.scala
@@ -52,9 +52,7 @@ case class Executor[Ctx, Root](
     operationCtx match {
       case Failure(error) =>
         // return validation errors without variables first if variables is what failed
-        val (violations, validationTiming) =
-          TimeMeasurement.measure(
-            queryValidator.validateQuery(schema, queryAst, Map.empty, errorsLimit))
+        val violations = queryValidator.validateQuery(schema, queryAst, Map.empty, errorsLimit)
 
         if (violations.nonEmpty)
           Future.failed(ValidationError(violations, exceptionHandler))
@@ -185,10 +183,7 @@ case class Executor[Ctx, Root](
     operationCtx match {
       case Failure(error) =>
         // return validation errors without variables first if variables is what failed
-        val (violations, validationTiming) =
-          TimeMeasurement.measure(
-            queryValidator.validateQuery(schema, queryAst, Map.empty, errorsLimit))
-
+        val violations = queryValidator.validateQuery(schema, queryAst, Map.empty, errorsLimit)
         if (violations.nonEmpty)
           scheme.failed(ValidationError(violations, exceptionHandler))
         else

--- a/modules/core/src/main/scala/sangria/execution/QueryReducerExecutor.scala
+++ b/modules/core/src/main/scala/sangria/execution/QueryReducerExecutor.scala
@@ -22,7 +22,7 @@ object QueryReducerExecutor {
       middleware: List[Middleware[Ctx]] = Nil,
       errorsLimit: Option[Int] = None
   )(implicit executionContext: ExecutionContext): Future[(Ctx, TimeMeasurement)] = {
-    val violations = queryValidator.validateQuery(schema, queryAst, errorsLimit)
+    val violations = queryValidator.validateQuery(schema, queryAst, Map.empty, errorsLimit)
 
     if (violations.nonEmpty)
       Future.failed(ValidationError(violations, exceptionHandler))

--- a/modules/core/src/main/scala/sangria/execution/batch/BatchExecutor.scala
+++ b/modules/core/src/main/scala/sangria/execution/batch/BatchExecutor.scala
@@ -101,7 +101,10 @@ object BatchExecutor {
             inferVariableDefinitions,
             exceptionHandler))
         .flatMap { case res @ (updatedDocument, _) =>
-          val violations = queryValidator.validateQuery(schema, updatedDocument, errorsLimit)
+          // we're not going to pass variables here, as we call validateQuery again on
+          // executeIndividual which has the unmarshalled variables at that point
+          val violations =
+            queryValidator.validateQuery(schema, updatedDocument, Map.empty, errorsLimit)
 
           if (violations.nonEmpty) Failure(ValidationError(violations, exceptionHandler))
           else Success(res)

--- a/modules/core/src/main/scala/sangria/schema/ResolverBasedAstSchemaBuilder.scala
+++ b/modules/core/src/main/scala/sangria/schema/ResolverBasedAstSchemaBuilder.scala
@@ -63,7 +63,8 @@ class ResolverBasedAstSchemaBuilder[Ctx](val resolvers: Seq[AstSchemaResolver[Ct
       schema: ast.Document,
       validator: QueryValidator = ResolverBasedAstSchemaBuilder.validator,
       errorsLimit: Option[Int] = None): Vector[Violation] =
-    allowKnownDynamicDirectives(validator.validateQuery(validationSchema, schema, errorsLimit))
+    allowKnownDynamicDirectives(
+      validator.validateQuery(validationSchema, schema, Map.empty, errorsLimit))
 
   def validateSchemaWithException(
       schema: ast.Document,

--- a/modules/core/src/main/scala/sangria/schema/SchemaComparator.scala
+++ b/modules/core/src/main/scala/sangria/schema/SchemaComparator.scala
@@ -280,7 +280,11 @@ object SchemaComparator {
     val directiveChanges = findInAstDirs(
       oldType.astDirectives,
       newType.astDirectives,
-      added = SchemaChange.InputObjectTypeAstDirectiveAdded(newType, _),
+      added = d =>
+        SchemaChange.InputObjectTypeAstDirectiveAdded(
+          newType,
+          d,
+          breaking = d.name == OneOfDirective.name),
       removed = SchemaChange.InputObjectTypeAstDirectiveRemoved(newType, _)
     )
 
@@ -900,9 +904,9 @@ object SchemaChange {
 
   abstract class AbstractAstDirectiveAdded(
       val description: String,
-      val location: DirectiveLocation.Value)
+      val location: DirectiveLocation.Value,
+      val breakingChange: Boolean)
       extends AstDirectiveAdded {
-    val breakingChange = false
     val dangerousChange = false
   }
 
@@ -920,7 +924,9 @@ object SchemaChange {
       directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on a field `${tpe.name}.${field.name}`",
-        DirectiveLocation.FieldDefinition)
+        DirectiveLocation.FieldDefinition,
+        breakingChange = false
+      )
 
   case class FieldAstDirectiveRemoved(
       tpe: ObjectLikeType[_, _],
@@ -937,7 +943,9 @@ object SchemaChange {
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(
             directive)}` added on an enum value `${tpe.name}.${value.name}`",
-        DirectiveLocation.EnumValue)
+        DirectiveLocation.EnumValue,
+        breakingChange = false
+      )
 
   case class EnumValueAstDirectiveRemoved(
       tpe: EnumType[_],
@@ -955,7 +963,9 @@ object SchemaChange {
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(
             directive)}` added on an input field `${tpe.name}.${field.name}`",
-        DirectiveLocation.InputFieldDefinition)
+        DirectiveLocation.InputFieldDefinition,
+        breakingChange = false
+      )
 
   case class InputFieldAstDirectiveRemoved(
       tpe: InputObjectType[_],
@@ -974,7 +984,8 @@ object SchemaChange {
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(
             directive)}` added on a directive argument `${dir.name}.${argument.name}`",
-        DirectiveLocation.ArgumentDefinition
+        DirectiveLocation.ArgumentDefinition,
+        breakingChange = false
       )
 
   case class DirectiveArgumentAstDirectiveRemoved(
@@ -995,7 +1006,8 @@ object SchemaChange {
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(
             directive)}` added on a field argument `${tpe.name}.${field.name}[${argument.name}]`",
-        DirectiveLocation.ArgumentDefinition
+        DirectiveLocation.ArgumentDefinition,
+        breakingChange = false
       )
 
   case class FieldArgumentAstDirectiveRemoved(
@@ -1012,7 +1024,8 @@ object SchemaChange {
   case class ObjectTypeAstDirectiveAdded(tpe: ObjectType[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on an object type `${tpe.name}`",
-        DirectiveLocation.Object)
+        DirectiveLocation.Object,
+        breakingChange = false)
 
   case class ObjectTypeAstDirectiveRemoved(tpe: ObjectType[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1022,7 +1035,8 @@ object SchemaChange {
   case class InterfaceTypeAstDirectiveAdded(tpe: InterfaceType[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on an interface type `${tpe.name}`",
-        DirectiveLocation.Interface)
+        DirectiveLocation.Interface,
+        breakingChange = false)
 
   case class InterfaceTypeAstDirectiveRemoved(tpe: InterfaceType[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1032,7 +1046,8 @@ object SchemaChange {
   case class UnionTypeAstDirectiveAdded(tpe: UnionType[_], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on a union type `${tpe.name}`",
-        DirectiveLocation.Union)
+        DirectiveLocation.Union,
+        breakingChange = false)
 
   case class UnionTypeAstDirectiveRemoved(tpe: UnionType[_], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1042,7 +1057,8 @@ object SchemaChange {
   case class EnumTypeAstDirectiveAdded(tpe: EnumType[_], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on an enum type `${tpe.name}`",
-        DirectiveLocation.Enum)
+        DirectiveLocation.Enum,
+        breakingChange = false)
 
   case class EnumTypeAstDirectiveRemoved(tpe: EnumType[_], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1052,17 +1068,13 @@ object SchemaChange {
   case class ScalarTypeAstDirectiveAdded(tpe: ScalarType[_], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on a scalar type `${tpe.name}`",
-        DirectiveLocation.Scalar)
+        DirectiveLocation.Scalar,
+        breakingChange = false)
 
   case class ScalarTypeAstDirectiveRemoved(tpe: ScalarType[_], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
         s"Directive `${QueryRenderer.renderCompact(directive)}` removed from a scalar type `${tpe.name}`",
         DirectiveLocation.Scalar)
-
-  case class InputObjectTypeAstDirectiveAdded(tpe: InputObjectType[_], directive: ast.Directive)
-      extends AbstractAstDirectiveAdded(
-        s"Directive `${QueryRenderer.renderCompact(directive)}` added on an input type `${tpe.name}`",
-        DirectiveLocation.InputObject)
 
   case class InputObjectTypeAstDirectiveRemoved(tpe: InputObjectType[_], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1072,7 +1084,8 @@ object SchemaChange {
   case class SchemaAstDirectiveAdded(schema: Schema[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveAdded(
         s"Directive `${QueryRenderer.renderCompact(directive)}` added on a schema",
-        DirectiveLocation.Schema)
+        DirectiveLocation.Schema,
+        breakingChange = false)
 
   case class SchemaAstDirectiveRemoved(schema: Schema[_, _], directive: ast.Directive)
       extends AbstractAstDirectiveRemoved(
@@ -1080,6 +1093,15 @@ object SchemaChange {
         DirectiveLocation.Schema)
 
   // May be a breaking change
+
+  case class InputObjectTypeAstDirectiveAdded(
+      tpe: InputObjectType[_],
+      directive: ast.Directive,
+      breaking: Boolean)
+      extends AbstractAstDirectiveAdded(
+        s"Directive `${QueryRenderer.renderCompact(directive)}` added on an input type `${tpe.name}`",
+        DirectiveLocation.InputObject,
+        breakingChange = breaking)
 
   case class InputFieldAdded(tpe: InputObjectType[_], field: InputField[_], breaking: Boolean)
       extends AbstractChange(

--- a/modules/core/src/main/scala/sangria/schema/SchemaValidationRule.scala
+++ b/modules/core/src/main/scala/sangria/schema/SchemaValidationRule.scala
@@ -616,24 +616,24 @@ object OneOfInputObjectValidator extends SchemaElementValidator {
       schema: Schema[_, _],
       tpe: InputObjectType[_]
   ): Vector[Violation] = if (tpe.astDirectives.exists(_.name == OneOfDirective.name))
-    tpe.fields.toVector.flatMap { field =>
+    tpe.fields.iterator.flatMap { field =>
       val defaultValueError =
         field.defaultValue.map(_ => OneOfDefaultValueField(field.name, tpe.name, None, List.empty))
 
-      val nonOptionalError = field.fieldType.isOptional match {
-        case false =>
-          Some(
-            OneOfMandatoryField(
-              field.name,
-              tpe.name,
-              None,
-              List.empty
-            )
+      val nonOptionalError = if (field.fieldType.isOptional) {
+        None
+      } else {
+        Some(
+          OneOfMandatoryField(
+            field.name,
+            tpe.name,
+            None,
+            List.empty
           )
-        case true => None
+        )
       }
-      Vector(defaultValueError, nonOptionalError).flatten
-    }
+      Iterator(defaultValueError, nonOptionalError).flatten
+    }.toVector
   else Vector.empty
 }
 

--- a/modules/core/src/main/scala/sangria/schema/package.scala
+++ b/modules/core/src/main/scala/sangria/schema/package.scala
@@ -267,8 +267,18 @@ package object schema {
     shouldInclude = ctx => !ctx.arg(IfArg)
   )
 
+  val OneOfDirective: Directive = Directive(
+    "oneOf",
+    description =
+      Some("Indicates exactly one field must be supplied and this field must not be `null`."),
+    arguments = List.empty,
+    locations = Set(
+      DirectiveLocation.InputObject
+    )
+  )
+
   val BuiltinDirectives: List[Directive] =
-    IncludeDirective :: SkipDirective :: DeprecatedDirective :: Nil
+    IncludeDirective :: SkipDirective :: DeprecatedDirective :: OneOfDirective :: Nil
 
   val BuiltinDirectivesByName: Map[String, Directive] =
     BuiltinDirectives.groupBy(_.name).map { case (k, v) => (k, v.head) }

--- a/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
+++ b/modules/core/src/main/scala/sangria/validation/QueryValidator.scala
@@ -45,7 +45,8 @@ object QueryValidator {
     new VariablesAreInputTypes,
     new VariablesInAllowedPosition,
     new InputDocumentNonConflictingVariableInference,
-    new SingleFieldSubscriptions
+    new SingleFieldSubscriptions,
+    new ExactlyOneOfFieldGiven
   )
 
   def ruleBased(rules: List[ValidationRule]): RuleBasedQueryValidator =

--- a/modules/core/src/main/scala/sangria/validation/Violation.scala
+++ b/modules/core/src/main/scala/sangria/validation/Violation.scala
@@ -1105,6 +1105,25 @@ case class NoQueryTypeViolation(sourceMapper: Option[SourceMapper], locations: L
     "Must provide schema definition with query type or a type named Query."
 }
 
+case class OneOfMandatoryField(
+    fieldName: String,
+    typeName: String,
+    sourceMapper: Option[SourceMapper],
+    locations: List[AstLocation]
+) extends AstNodeViolation {
+  lazy val simpleErrorMessage = s"oneOf input field '${typeName}.${fieldName}' must be nullable."
+}
+
+case class OneOfDefaultValueField(
+    fieldName: String,
+    typeName: String,
+    sourceMapper: Option[SourceMapper],
+    locations: List[AstLocation]
+) extends AstNodeViolation {
+  lazy val simpleErrorMessage =
+    s"oneOf input field '${typeName}.${fieldName}' cannot have a default value."
+}
+
 case class NonUniqueTypeDefinitionViolation(
     typeName: String,
     sourceMapper: Option[SourceMapper],

--- a/modules/core/src/main/scala/sangria/validation/Violation.scala
+++ b/modules/core/src/main/scala/sangria/validation/Violation.scala
@@ -1105,6 +1105,14 @@ case class NoQueryTypeViolation(sourceMapper: Option[SourceMapper], locations: L
     "Must provide schema definition with query type or a type named Query."
 }
 
+case class NotExactlyOneOfField(
+    typeName: String,
+    sourceMapper: Option[SourceMapper],
+    locations: List[AstLocation]
+) extends AstNodeViolation {
+  lazy val simpleErrorMessage = s"Exactly one key must be specified for oneOf type '${typeName}'."
+}
+
 case class OneOfMandatoryField(
     fieldName: String,
     typeName: String,

--- a/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
+++ b/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
@@ -10,90 +10,88 @@ import sangria.marshalling.CoercedScalaResultMarshaller
 
 /** For oneOf input objects, exactly one field should be non-null. */
 class ExactlyOneOfFieldGiven extends ValidationRule {
-  val marshaller = CoercedScalaResultMarshaller.default
+  private val marshaller = CoercedScalaResultMarshaller.default
+  private val oneOfDirectiveName = schema.OneOfDirective.name
 
-  override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
-    private def getResolvedVariableValue(
-        name: String,
-        inputType: schema.InputType[_],
-        variableValues: Map[String, execution.VariableValue]
-    ): Option[Any] = {
-      val variableValue = ctx.variables.get(name)
+  private def hasOneOfDirective(inputObject: schema.InputObjectType[_]) =
+    inputObject.astDirectives.exists(_.name == oneOfDirectiveName)
 
-      variableValue.map(_.resolve(marshaller, marshaller, inputType)) match {
-        case Some(Right(Defined(resolved))) => Some(resolved)
-        case Some(Right(NullWithDefault(resolved))) => Some(resolved)
-        case _ => None
+  private def getResolvedVariableValue(
+      name: String,
+      inputType: schema.InputType[_],
+      variableValues: Map[String, execution.VariableValue]
+  ): Option[Any] = {
+    val variableValue = variableValues.get(name)
+
+    variableValue.map(_.resolve(marshaller, marshaller, inputType)) match {
+      case Some(Right(Defined(resolved))) => Some(resolved)
+      case Some(Right(NullWithDefault(resolved))) => Some(resolved)
+      case _ => None
+    }
+  }
+
+  private def visitNode(
+      ctx: ValidationContext,
+      inputType: Option[schema.InputType[_]],
+      node: Either[ast.ObjectValue, ast.VariableValue]
+  ): Either[Vector[Violation], AstVisitorCommand.Value] =
+    inputType.fold(AstVisitorCommand.RightContinue) { inputType =>
+      inputType.namedInputType match {
+        case namedInputType: schema.InputObjectType[_] if hasOneOfDirective(namedInputType) =>
+          val nonNullFields = node match {
+            case Left(ast.ObjectValue(fields, _, _)) =>
+              fields.filter { field =>
+                field.value match {
+                  case ast.NullValue(_, _) => false
+                  case ast.VariableValue(name, _, _) =>
+                    val fieldInputType = namedInputType.fieldsByName
+                      .get(field.name)
+                      .map(_.fieldType)
+
+                    fieldInputType.forall { fieldInputType =>
+                      getResolvedVariableValue(name, fieldInputType, ctx.variables).isDefined
+                    }
+                  case _ => true
+                }
+              }
+
+            case Right(ast.VariableValue(name, _, _)) =>
+              val variableValue = getResolvedVariableValue(name, namedInputType, ctx.variables)
+
+              try
+                variableValue match {
+                  case Some(resolved) =>
+                    val variableObj = resolved.asInstanceOf[Map[String, Any]]
+                    namedInputType.fields.filter { field =>
+                      variableObj.get(field.name).fold(false)(_ != None)
+                    }
+                  case _ => Vector.empty
+                }
+              catch {
+                // could get this from asInstanceOf failing for unexpected variable type.
+                // other validation will cover this problem.
+                case _: Throwable => Vector.empty
+              }
+          }
+
+          nonNullFields.size match {
+            case 1 => AstVisitorCommand.RightContinue
+            case _ =>
+              val pos = node.fold(_.location, _.location)
+              Left(
+                Vector(
+                  NotExactlyOneOfField(namedInputType.name, ctx.sourceMapper, pos.toList)
+                )
+              )
+          }
+        case _ => AstVisitorCommand.RightContinue
       }
     }
 
-    private def hasOneOfDirective(inputObject: schema.InputObjectType[_]) =
-      inputObject.astDirectives.exists(_.name == schema.OneOfDirective.name)
-
-    private def visitNode(
-        inputType: Option[schema.InputType[_]],
-        node: Either[ast.ObjectValue, ast.VariableValue]
-    ) =
-      inputType.fold(AstVisitorCommand.RightContinue) { inputType =>
-        inputType.namedInputType match {
-          case namedInputType: schema.InputObjectType[_] if hasOneOfDirective(namedInputType) =>
-            val pos = node match {
-              case Left(node) => node.location
-              case Right(node) => node.location
-            }
-
-            val nonNullFields = node match {
-              case Left(ast.ObjectValue(fields, _, _)) =>
-                fields.filter { field =>
-                  field.value match {
-                    case ast.NullValue(_, _) => false
-                    case ast.VariableValue(name, _, _) =>
-                      val fieldInputType = namedInputType.fieldsByName
-                        .get(field.name)
-                        .map(_.fieldType)
-
-                      val variableValue = fieldInputType.flatMap { fieldInputType =>
-                        getResolvedVariableValue(name, fieldInputType, ctx.variables)
-                      }
-
-                      variableValue.isDefined
-                    case _ => true
-                  }
-                }
-              case Right(ast.VariableValue(name, _, _)) =>
-                val variableValue = getResolvedVariableValue(name, namedInputType, ctx.variables)
-
-                try
-                  variableValue match {
-                    case Some(resolved) =>
-                      val variableObj = resolved.asInstanceOf[Map[String, Any]]
-                      namedInputType.fields.filter { field =>
-                        variableObj.get(field.name).fold(false)(_ != None)
-                      }
-                    case _ => Vector.empty
-                  }
-                catch {
-                  // could get this from asInstanceOf failing for unexpected variable type.
-                  // other validation will cover this problem.
-                  case _: Throwable => Vector.empty
-                }
-            }
-
-            nonNullFields.size match {
-              case 1 => AstVisitorCommand.RightContinue
-              case _ =>
-                Left(
-                  Vector(
-                    NotExactlyOneOfField(namedInputType.name, ctx.sourceMapper, pos.toList)
-                  )
-                )
-            }
-          case _ => AstVisitorCommand.RightContinue
-        }
-      }
+  override def visitor(ctx: ValidationContext): AstValidatingVisitor = new AstValidatingVisitor {
     override val onEnter: ValidationVisit = {
-      case node: ast.ObjectValue => visitNode(ctx.typeInfo.inputType, Left(node))
-      case node: ast.VariableValue => visitNode(ctx.typeInfo.inputType, Right(node))
+      case node: ast.ObjectValue => visitNode(ctx, ctx.typeInfo.inputType, Left(node))
+      case node: ast.VariableValue => visitNode(ctx, ctx.typeInfo.inputType, Right(node))
     }
   }
 }

--- a/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
+++ b/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
@@ -1,37 +1,99 @@
 package sangria.validation.rules
 
 import sangria.ast
+import sangria.execution
+import sangria.execution.Trinary.{Defined, NullWithDefault}
 import sangria.schema
 import sangria.ast.AstVisitorCommand
 import sangria.validation._
+import sangria.marshalling.CoercedScalaResultMarshaller
 
 /** For oneOf input objects, exactly one field should be non-null. */
 class ExactlyOneOfFieldGiven extends ValidationRule {
+  val marshaller = CoercedScalaResultMarshaller.default
+
   override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
-    override val onEnter: ValidationVisit = { case ast.ObjectValue(fields, _, pos) =>
-      ctx.typeInfo.inputType match {
-        case Some(inputType) =>
-          inputType.namedInputType match {
-            case schema.InputObjectType(name, _, _, directives, _) if directives.exists { d =>
-                  d.name == schema.OneOfDirective.name
-                } =>
-              val nonNullFields = fields.filter { field =>
-                field.value match {
-                  case ast.NullValue(_, _) => false
-                  case _ => true
-                }
-              }
+    private def getResolvedVariableValue(
+        name: String,
+        inputType: schema.InputType[_],
+        variableValues: Map[String, execution.VariableValue]
+    ): Option[Any] = {
+      val variableValue = ctx.variables.get(name)
 
-              nonNullFields.size match {
-                case 1 => AstVisitorCommand.RightContinue
-                case _ =>
-                  Left(Vector(NotExactlyOneOfField(name, ctx.sourceMapper, pos.toList)))
-              }
-
-            case _ => AstVisitorCommand.RightContinue
-          }
-        case None => AstVisitorCommand.RightContinue
+      variableValue.map(_.resolve(marshaller, marshaller, inputType)) match {
+        case Some(Right(Defined(resolved))) => Some(resolved)
+        case Some(Right(NullWithDefault(resolved))) => Some(resolved)
+        case _ => None
       }
+    }
+
+    private def hasOneOfDirective(inputObject: schema.InputObjectType[_]) =
+      inputObject.astDirectives.exists(_.name == schema.OneOfDirective.name)
+
+    private def visitNode(
+        inputType: Option[schema.InputType[_]],
+        node: Either[ast.ObjectValue, ast.VariableValue]
+    ) =
+      inputType.fold(AstVisitorCommand.RightContinue) { inputType =>
+        inputType.namedInputType match {
+          case namedInputType: schema.InputObjectType[_] if hasOneOfDirective(namedInputType) =>
+            val pos = node match {
+              case Left(node) => node.location
+              case Right(node) => node.location
+            }
+
+            val nonNullFields = node match {
+              case Left(ast.ObjectValue(fields, _, _)) =>
+                fields.filter { field =>
+                  field.value match {
+                    case ast.NullValue(_, _) => false
+                    case ast.VariableValue(name, _, _) =>
+                      val fieldInputType = namedInputType.fieldsByName
+                        .get(field.name)
+                        .map(_.fieldType)
+
+                      val variableValue = fieldInputType.flatMap { fieldInputType =>
+                        getResolvedVariableValue(name, fieldInputType, ctx.variables)
+                      }
+
+                      variableValue.isDefined
+                    case _ => true
+                  }
+                }
+              case Right(ast.VariableValue(name, _, _)) =>
+                val variableValue = getResolvedVariableValue(name, namedInputType, ctx.variables)
+
+                try
+                  variableValue match {
+                    case Some(resolved) =>
+                      val variableObj = resolved.asInstanceOf[Map[String, Any]]
+                      namedInputType.fields.filter { field =>
+                        variableObj.get(field.name).fold(false)(_ != None)
+                      }
+                    case _ => Vector.empty
+                  }
+                catch {
+                  // could get this from asInstanceOf failing for unexpected variable type.
+                  // other validation will cover this problem.
+                  case _: Throwable => Vector.empty
+                }
+            }
+
+            nonNullFields.size match {
+              case 1 => AstVisitorCommand.RightContinue
+              case _ =>
+                Left(
+                  Vector(
+                    NotExactlyOneOfField(namedInputType.name, ctx.sourceMapper, pos.toList)
+                  )
+                )
+            }
+          case _ => AstVisitorCommand.RightContinue
+        }
+      }
+    override val onEnter: ValidationVisit = {
+      case node: ast.ObjectValue => visitNode(ctx.typeInfo.inputType, Left(node))
+      case node: ast.VariableValue => visitNode(ctx.typeInfo.inputType, Right(node))
     }
   }
 }

--- a/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
+++ b/modules/core/src/main/scala/sangria/validation/rules/ExactlyOneOfFieldGiven.scala
@@ -1,0 +1,37 @@
+package sangria.validation.rules
+
+import sangria.ast
+import sangria.schema
+import sangria.ast.AstVisitorCommand
+import sangria.validation._
+
+/** For oneOf input objects, exactly one field should be non-null. */
+class ExactlyOneOfFieldGiven extends ValidationRule {
+  override def visitor(ctx: ValidationContext) = new AstValidatingVisitor {
+    override val onEnter: ValidationVisit = { case ast.ObjectValue(fields, _, pos) =>
+      ctx.typeInfo.inputType match {
+        case Some(inputType) =>
+          inputType.namedInputType match {
+            case schema.InputObjectType(name, _, _, directives, _) if directives.exists { d =>
+                  d.name == schema.OneOfDirective.name
+                } =>
+              val nonNullFields = fields.filter { field =>
+                field.value match {
+                  case ast.NullValue(_, _) => false
+                  case _ => true
+                }
+              }
+
+              nonNullFields.size match {
+                case 1 => AstVisitorCommand.RightContinue
+                case _ =>
+                  Left(Vector(NotExactlyOneOfField(name, ctx.sourceMapper, pos.toList)))
+              }
+
+            case _ => AstVisitorCommand.RightContinue
+          }
+        case None => AstVisitorCommand.RightContinue
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/execution/InputDocumentMaterializerSpec.scala
@@ -2,6 +2,7 @@ package sangria.execution
 
 import sangria.macros._
 import sangria.ast
+import sangria.execution
 import sangria.marshalling.ScalaInput.scalaInput
 import sangria.marshalling.sprayJson._
 import sangria.parser.QueryParser
@@ -111,7 +112,11 @@ class InputDocumentMaterializerSpec extends AnyWordSpec with Matchers with Strin
           }
         """
 
-      val errors = QueryValidator.default.validateInputDocument(schema, inp, "Config")
+      val errors = QueryValidator.default.validateInputDocument(
+        schema,
+        inp,
+        "Config",
+        Map.empty[String, execution.VariableValue])
 
       assertViolations(
         errors,
@@ -164,7 +169,11 @@ class InputDocumentMaterializerSpec extends AnyWordSpec with Matchers with Strin
           }
         """
 
-      val errors = QueryValidator.default.validateInputDocument(schema, inp, "Config")
+      val errors = QueryValidator.default.validateInputDocument(
+        schema,
+        inp,
+        "Config",
+        Map.empty[String, execution.VariableValue])
 
       assertViolations(
         errors,

--- a/modules/core/src/test/scala/sangria/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/sangria/introspection/IntrospectionSpec.scala
@@ -790,6 +790,13 @@ class IntrospectionSpec extends AnyWordSpec with Matchers with FutureResultSuppo
                 "defaultValue" -> "\"No longer supported\""
               )),
               "isRepeatable" -> false
+            ),
+            Map(
+              "name" -> "oneOf",
+              "description" -> "Indicates exactly one field must be supplied and this field must not be `null`.",
+              "locations" -> Vector("INPUT_OBJECT"),
+              "args" -> Vector.empty,
+              "isRepeatable" -> false
             )
           ),
           "description" -> null

--- a/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
@@ -581,6 +581,44 @@ class AstSchemaMaterializerSpec
         error.getMessage should include("Must provide only one mutation type in schema.")
       }
 
+      "Does not allow mandatory fields in oneOf input objects" in {
+        val ast = graphql"""
+          type Query {
+            query(input: OneOfInput!): String
+          }
+
+          input OneOfInput @oneOf {
+            foo: String!
+            bar: Int
+          }
+        """
+
+        val error = intercept[SchemaValidationException](Schema.buildFromAst(ast))
+
+        error.getMessage should include("oneOf input field 'OneOfInput.foo' must be nullable.")
+      }
+
+      "Does not allow mandatory fields in oneOf input object extensions" in {
+        val ast = graphql"""
+          type Query {
+            query(input: OneOfInput!): String
+          }
+
+          input OneOfInput @oneOf {
+            foo: String
+            bar: Int
+          }
+
+          extend input OneOfInput @oneOf {
+            more: Boolean!
+          }
+        """
+
+        val error = intercept[SchemaValidationException](Schema.buildFromAst(ast))
+
+        error.getMessage should include("oneOf input field 'OneOfInput.more' must be nullable.")
+      }
+
       "Allows only a single subscription type" in {
         val ast =
           graphql"""

--- a/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/AstSchemaMaterializerSpec.scala
@@ -81,11 +81,12 @@ class AstSchemaMaterializerSpec
 
         val schema = Schema.buildFromAst(ast)
 
-        schema.directives should have size 3
+        schema.directives should have size 4
 
         (schema.directivesByName("skip") should be).theSameInstanceAs(SkipDirective)
         (schema.directivesByName("include") should be).theSameInstanceAs(IncludeDirective)
         (schema.directivesByName("deprecated") should be).theSameInstanceAs(DeprecatedDirective)
+        (schema.directivesByName("oneOf") should be).theSameInstanceAs(OneOfDirective)
       }
 
       "Overriding directives excludes specified" in {
@@ -98,6 +99,7 @@ class AstSchemaMaterializerSpec
             directive @skip on FIELD
             directive @include on FIELD
             directive @deprecated on FIELD_DEFINITION
+            directive @oneOf on FIELD_DEFINITION
 
             type Hello {
               str: String
@@ -106,12 +108,13 @@ class AstSchemaMaterializerSpec
 
         val schema = Schema.buildFromAst(ast)
 
-        schema.directives should have size 3
+        schema.directives should have size 4
 
         // We don't allow to override the built-in directives, since it's too dangerous
         (schema.directivesByName("skip") should be).theSameInstanceAs(SkipDirective)
         (schema.directivesByName("include") should be).theSameInstanceAs(IncludeDirective)
         (schema.directivesByName("deprecated") should be).theSameInstanceAs(DeprecatedDirective)
+        (schema.directivesByName("oneOf") should be).theSameInstanceAs(OneOfDirective)
       }
 
       "Adding directives maintains built-in one" in {
@@ -130,11 +133,12 @@ class AstSchemaMaterializerSpec
 
         val schema = Schema.buildFromAst(ast)
 
-        schema.directives should have size 4
+        schema.directives should have size 5
 
         (schema.directivesByName("skip") should be).theSameInstanceAs(SkipDirective)
         (schema.directivesByName("include") should be).theSameInstanceAs(IncludeDirective)
         (schema.directivesByName("deprecated") should be).theSameInstanceAs(DeprecatedDirective)
+        (schema.directivesByName("oneOf") should be).theSameInstanceAs(OneOfDirective)
       }
 
       "Type modifiers" in {

--- a/modules/core/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/SchemaComparatorSpec.scala
@@ -668,6 +668,60 @@ class SchemaComparatorSpec extends AnyWordSpec with Matchers {
       nonBreakingChange[ScalarTypeAstDirectiveRemoved](
         "Directive `@bar(ids:[1,2])` removed from a scalar type `Foo5`")
     )
+
+    "detect removal of @oneOf" in checkChangesWithoutQueryType(
+      gql"""
+        input UserBy @oneOf {
+          id: ID
+          email: String
+          username: String
+          registrationNumber: Int
+        }
+        type Query {
+          user(by: UserBy!): String
+        }
+      """,
+      gql"""
+        input UserBy {
+          id: ID
+          email: String
+          username: String
+          registrationNumber: Int
+        }
+        type Query {
+          user(by: UserBy!): String
+        }
+      """,
+      nonBreakingChange[InputObjectTypeAstDirectiveRemoved](
+        "Directive `@oneOf` removed from an input type `UserBy`")
+    )
+
+    "detect add of @oneOf" in checkChangesWithoutQueryType(
+      gql"""
+        input UserBy {
+          id: ID
+          email: String
+          username: String
+          registrationNumber: Int
+        }
+        type Query {
+          user(by: UserBy!): String
+        }
+      """,
+      gql"""
+        input UserBy @oneOf {
+          id: ID
+          email: String
+          username: String
+          registrationNumber: Int
+        }
+        type Query {
+          user(by: UserBy!): String
+        }
+      """,
+      breakingChange[InputObjectTypeAstDirectiveAdded](
+        "Directive `@oneOf` added on an input type `UserBy`")
+    )
   }
 
   private[this] def breakingChange[T: ClassTag](description: String) =

--- a/modules/core/src/test/scala/sangria/starWars/StartWarsValidationSpec.scala
+++ b/modules/core/src/test/scala/sangria/starWars/StartWarsValidationSpec.scala
@@ -30,7 +30,8 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should be(Symbol("empty"))
+      QueryValidator.default.validateQuery(StarWarsSchema, query, Map.empty, None) should be(
+        Symbol("empty"))
     }
 
     "Notes that non-existent fields are invalid" in {
@@ -42,7 +43,11 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should have size 1
+      QueryValidator.default.validateQuery(
+        StarWarsSchema,
+        query,
+        Map.empty,
+        None) should have size 1
     }
 
     "Requires fields on objects" in {
@@ -52,7 +57,11 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should have size 1
+      QueryValidator.default.validateQuery(
+        StarWarsSchema,
+        query,
+        Map.empty,
+        None) should have size 1
     }
 
     "Disallows fields on scalars" in {
@@ -66,7 +75,11 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should have size 1
+      QueryValidator.default.validateQuery(
+        StarWarsSchema,
+        query,
+        Map.empty,
+        None) should have size 1
     }
 
     "Disallows object fields on interfaces" in {
@@ -79,7 +92,11 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should have size 1
+      QueryValidator.default.validateQuery(
+        StarWarsSchema,
+        query,
+        Map.empty,
+        None) should have size 1
     }
 
     "Allows object fields in fragments" in {
@@ -96,7 +113,8 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should be(Symbol("empty"))
+      QueryValidator.default.validateQuery(StarWarsSchema, query, Map.empty, None) should be(
+        Symbol("empty"))
     }
 
     "Allows object fields in inline fragments" in {
@@ -111,7 +129,8 @@ class StartWarsValidationSpec extends AnyWordSpec with Matchers with FutureResul
         }
         """)
 
-      QueryValidator.default.validateQuery(StarWarsSchema, query, None) should be(Symbol("empty"))
+      QueryValidator.default.validateQuery(StarWarsSchema, query, Map.empty, None) should be(
+        Symbol("empty"))
     }
   }
 }

--- a/modules/core/src/test/scala/sangria/util/CatsSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/CatsSupport.scala
@@ -221,7 +221,7 @@ object CatsScenarioExecutor extends FutureResultSupport {
     case Validate(rules) =>
       ValidationResult(
         new RuleBasedQueryValidator(rules.toList)
-          .validateQuery(`given`.schema, QueryParser.parse(`given`.query).get, None))
+          .validateQuery(`given`.schema, QueryParser.parse(`given`.query).get, Map.empty, None))
 
     case Execute(validate, value, vars, op) =>
       val validator = if (validate) QueryValidator.default else QueryValidator.empty

--- a/modules/core/src/test/scala/sangria/util/ValidationSupport.scala
+++ b/modules/core/src/test/scala/sangria/util/ValidationSupport.scala
@@ -1,5 +1,6 @@
 package sangria.util
 
+import sangria.ast
 import sangria.parser.QueryParser
 import sangria.schema._
 import sangria.validation._
@@ -145,6 +146,13 @@ trait ValidationSupport extends Matchers {
     )
   )
 
+  val OneOfInput = InputObjectType(
+    "OneOfInput",
+    List(
+      InputField("catName", OptionInputType(StringType)),
+      InputField("dogId", OptionInputType(IntType))
+    )).withDirective(ast.Directive(OneOfDirective.name))
+
   val ComplicatedArgs = ObjectType(
     "ComplicatedArgs",
     List[TestField](
@@ -251,7 +259,13 @@ trait ValidationSupport extends Matchers {
       Field("catOrDog", OptionType(CatOrDog), resolve = _ => None),
       Field("dogOrHuman", OptionType(DogOrHuman), resolve = _ => None),
       Field("humanOrAlien", OptionType(HumanOrAlien), resolve = _ => None),
-      Field("complicatedArgs", OptionType(ComplicatedArgs), resolve = _ => None)
+      Field("complicatedArgs", OptionType(ComplicatedArgs), resolve = _ => None),
+      Field(
+        "oneOfQuery",
+        OptionType(CatOrDog),
+        arguments = List(Argument("input", OneOfInput)),
+        resolve = _ => None
+      )
     )
   )
 

--- a/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/QueryValidatorSpec.scala
@@ -42,7 +42,7 @@ class QueryValidatorSpec extends AnyWordSpec {
 
       "not limit number of errors returned if the limit is not provided" in {
         val Success(doc) = QueryParser.parse(invalidQuery)
-        val result = validator.validateQuery(schema, doc, None)
+        val result = validator.validateQuery(schema, doc, Map.empty, None)
 
         // 10 errors are expected because there are 5 input objects in the list with 2 missing fields each
         assertResult(10)(result.length)
@@ -51,7 +51,7 @@ class QueryValidatorSpec extends AnyWordSpec {
         val errorsLimit = 5
 
         val Success(doc) = QueryParser.parse(invalidQuery)
-        val result = validator.validateQuery(schema, doc, Some(errorsLimit))
+        val result = validator.validateQuery(schema, doc, Map.empty, Some(errorsLimit))
 
         assertResult(errorsLimit)(result.length)
       }

--- a/modules/core/src/test/scala/sangria/validation/rules/ExactlyOneOfFieldGivenSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/rules/ExactlyOneOfFieldGivenSpec.scala
@@ -1,0 +1,70 @@
+package sangria.validation.rules
+
+import sangria.util.{Pos, ValidationSupport}
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
+
+  override val defaultRule = Some(new ExactlyOneOfFieldGiven)
+
+  "Validate: exactly oneOf field given" should {
+    "with exactly one non-null field given" in expectPasses("""
+          query OneOfQuery {
+            oneOfQuery(input: {
+                catName: "Gretel"
+            }) {
+                ... on Cat {
+                    name
+                }
+            }
+          }
+        """)
+
+    "with exactly one null field given" in expectFails(
+      """
+          query OneOfQuery {
+            oneOfQuery(input: {
+                catName: null
+            }) {
+                ... on Cat {
+                    name
+                }
+            }
+          }
+        """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
+    )
+
+    "with no fields given" in expectFails(
+      """
+          query OneOfQuery {
+            oneOfQuery(input: {}) {
+                ... on Cat {
+                    name
+                }
+            }
+          }
+        """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
+    )
+
+    "with more than one non-null fields given" in expectFails(
+      """
+          query OneOfQuery {
+            oneOfQuery(input: {
+                catName: "Gretel",
+                dogId: 123
+            }) {
+                ... on Cat {
+                    name
+                }
+                ... on Dog {
+                    name
+                }
+            }
+          }
+        """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
+    )
+  }
+}

--- a/modules/core/src/test/scala/sangria/validation/rules/ExactlyOneOfFieldGivenSpec.scala
+++ b/modules/core/src/test/scala/sangria/validation/rules/ExactlyOneOfFieldGivenSpec.scala
@@ -8,7 +8,7 @@ class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
   override val defaultRule = Some(new ExactlyOneOfFieldGiven)
 
   "Validate: exactly oneOf field given" should {
-    "with exactly one non-null field given" in expectPasses("""
+    "pass with exactly one non-null field given" in expectPasses("""
           query OneOfQuery {
             oneOfQuery(input: {
                 catName: "Gretel"
@@ -20,7 +20,7 @@ class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
           }
         """)
 
-    "with exactly one null field given" in expectFails(
+    "fail with exactly one null field given" in expectFails(
       """
           query OneOfQuery {
             oneOfQuery(input: {
@@ -35,7 +35,7 @@ class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
       List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
     )
 
-    "with no fields given" in expectFails(
+    "fail with no fields given" in expectFails(
       """
           query OneOfQuery {
             oneOfQuery(input: {}) {
@@ -48,7 +48,7 @@ class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
       List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
     )
 
-    "with more than one non-null fields given" in expectFails(
+    "fail with more than one non-null fields given" in expectFails(
       """
           query OneOfQuery {
             oneOfQuery(input: {
@@ -65,6 +65,150 @@ class ExactlyOneOfFieldGivenSpec extends AnyWordSpec with ValidationSupport {
           }
         """,
       List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 31)))
+    )
+
+    "pass with a null variable and non-null arg given" in expectPasses(
+      """
+      query OneOfQuery($catName: String) {
+        oneOfQuery(input: {
+          catName: $catName,
+          dogId: 123
+        }) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      "$catName: String" -> """{"catName": null}"""
+    )
+
+    "fail with a non-null variable and non-null arg given" in expectFails(
+      """
+      query OneOfQuery($catName: String) {
+        oneOfQuery(input: {
+          catName: $catName,
+          dogId: 123
+        }) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 27))),
+      "$catName: String" -> """{"catName": "Gretel"}"""
+    )
+
+    "pass with a variable object with only one non-null value" in expectPasses(
+      """
+      query OneOfQuery($input: OneOfInput!) {
+        oneOfQuery(input: $input) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      "$input: OneOfInput!" -> """{"input":{"catName": "Gretel", "dogId": null}}"""
+    )
+
+    "fail with a variable object with only null values" in expectFails(
+      """
+      query OneOfQuery($input: OneOfInput!) {
+        oneOfQuery(input: $input) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 27))),
+      "$input: OneOfInput!" -> """{"input":{"catName": null}}"""
+    )
+
+    "fail with a variable object with more than one non-null values" in expectFails(
+      """
+      query OneOfQuery($input: OneOfInput!) {
+        oneOfQuery(input: $input) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 27))),
+      "$input: OneOfInput!" -> """{"input":{"catName": "Gretel", "dogId": 123}}"""
+    )
+
+    "pass with a variable object with exactly one non-null values" in expectPasses(
+      """
+      query OneOfQuery($input: OneOfInput!) {
+        oneOfQuery(input: $input) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      "$input: OneOfInput!" -> """{"input":{"dogId": 123}}"""
+    )
+
+    "pass with a variables with default value but only one resolved to non-null" in expectPasses(
+      """
+      query OneOfQuery($catName: String = "Gretel", $dogId: Int) {
+        oneOfQuery(input: {
+          catName: $catName,
+          dogId: $dogId
+        }) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      """$catName: String = "Gretel", $dogId: Int""" -> """{}"""
+    )
+
+    "fail with a variable object with default value that causes there to be more than one non-null value" in expectFails(
+      """
+      query OneOfQuery($catName: String = "Gretel", $dogId: Int) {
+        oneOfQuery(input: {
+          catName: $catName,
+          dogId: $dogId
+        }) {
+            ... on Cat {
+              name
+            }
+            ... on Dog {
+              name
+            }
+          }
+        }
+    """,
+      List("Exactly one key must be specified for oneOf type 'OneOfInput'." -> Some(Pos(3, 27))),
+      """$catName: String = "Gretel", $dogId: Int""" -> """{"dogId":123}"""
     )
   }
 }


### PR DESCRIPTION
Issue:
https://github.com/sangria-graphql/sangria/issues/1068

WIP.

The main thing I'm missing is when checking that there's "exactly one non-null field" on a query (I have the `ExactlyOneOfFieldGiven` rule), I'm struggling with validating against `ast.VariableValue` (since I need the unmarshalled input for that). (and considering default values for `VariableDefinition` -- though that seems easier than getting the actual input)

was wondering if it needs to go in the execution part for checking variables, but that seems a bit messier.

Trying to figure it out...but feel free to contribute if you have a way to go about that