### PR TITLE
Allow string inputs for Long Scalar type

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/package.scala
+++ b/modules/core/src/main/scala/sangria/schema/package.scala
@@ -2,6 +2,7 @@ package sangria
 
 import sangria.marshalling.MarshallerCapability
 import sangria.validation._
+import scala.util.Try
 
 /** Types that describe a GraphQL schema.
   *
@@ -47,14 +48,14 @@ package object schema {
       case i: BigInt => Right(i.longValue)
       case d: Double if d.isWhole => Right(d.toLong)
       case d: BigDecimal if d.isValidLong => Right(d.longValue)
-      case s: String if s.toLongOption.isDefined => Right(s.toLong)
+      case s: String if Try(s.toLong).isSuccess => Right(s.toLong)
       case _ => Left(LongCoercionViolation)
     },
     coerceInput = {
       case ast.IntValue(i, _, _) => Right(i: Long)
       case ast.BigIntValue(i, _, _) if !i.isValidLong => Left(BigLongCoercionViolation)
       case ast.BigIntValue(i, _, _) => Right(i.longValue)
-      case ast.StringValue(s, _, _, _, _) if s.toLongOption.isDefined => Right(s.toLong)
+      case ast.StringValue(s, _, _, _, _) if Try(s.toLong).isSuccess => Right(s.toLong)
       case _ => Left(LongCoercionViolation)
     }
   )

--- a/modules/core/src/main/scala/sangria/schema/package.scala
+++ b/modules/core/src/main/scala/sangria/schema/package.scala
@@ -47,12 +47,14 @@ package object schema {
       case i: BigInt => Right(i.longValue)
       case d: Double if d.isWhole => Right(d.toLong)
       case d: BigDecimal if d.isValidLong => Right(d.longValue)
+      case s: String if s.toLongOption.isDefined => Right(s.toLong)
       case _ => Left(LongCoercionViolation)
     },
     coerceInput = {
       case ast.IntValue(i, _, _) => Right(i: Long)
       case ast.BigIntValue(i, _, _) if !i.isValidLong => Left(BigLongCoercionViolation)
       case ast.BigIntValue(i, _, _) => Right(i.longValue)
+      case ast.StringValue(s, _, _, _, _) if s.toLongOption.isDefined => Right(s.toLong)
       case _ => Left(LongCoercionViolation)
     }
   )

--- a/modules/core/src/test/scala/sangria/schema/CoercionSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/CoercionSpec.scala
@@ -78,14 +78,16 @@ class CoercionSpec extends AnyWordSpec with Matchers {
         LongType.coerceInput(BigIntValue(BigInt("123234"))) should be(Right(123234L))
         LongType.coerceInput(BigIntValue(BigInt("1232342131243432"))) should be(
           Right(1232342131243432L))
+        LongType.coerceInput(StringValue(Long.MaxValue.toString)) should be(Right(Long.MaxValue))
         LongType
           .coerceInput(BigIntValue(BigInt("123234438749837964783648763284768372648723684763287")))
           .isLeft should be(true)
 
+
         LongType.coerceInput(FloatValue(12.34)).isLeft should be(true)
         LongType.coerceInput(BigDecimalValue(BigDecimal(12.34))).isLeft should be(true)
         LongType.coerceInput(BooleanValue(true)).isLeft should be(true)
-        LongType.coerceInput(StringValue("123")).isLeft should be(true)
+        LongType.coerceInput(StringValue("123234438749837964783648763284768372648723684763287")).isLeft should be(true)
       }
 
       "BigInt" in {
@@ -223,7 +225,10 @@ class CoercionSpec extends AnyWordSpec with Matchers {
         LongType.coerceUserInput(12.34d).isLeft should be(true)
         LongType.coerceUserInput(BigDecimal(12.34)).isLeft should be(true)
         LongType.coerceUserInput(true).isLeft should be(true)
-        LongType.coerceUserInput("123").isLeft should be(true)
+        LongType.coerceUserInput("123") should be(Right(123L))
+        LongType.coerceUserInput("").isLeft should be(true)
+        LongType.coerceUserInput("1232344387498237498732974982334324234325435").isLeft should be(true)
+        LongType.coerceUserInput("123.0").isLeft should be(true)
         LongType.coerceUserInput(new Date).isLeft should be(true)
       }
 

--- a/modules/core/src/test/scala/sangria/schema/CoercionSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/CoercionSpec.scala
@@ -83,11 +83,12 @@ class CoercionSpec extends AnyWordSpec with Matchers {
           .coerceInput(BigIntValue(BigInt("123234438749837964783648763284768372648723684763287")))
           .isLeft should be(true)
 
-
         LongType.coerceInput(FloatValue(12.34)).isLeft should be(true)
         LongType.coerceInput(BigDecimalValue(BigDecimal(12.34))).isLeft should be(true)
         LongType.coerceInput(BooleanValue(true)).isLeft should be(true)
-        LongType.coerceInput(StringValue("123234438749837964783648763284768372648723684763287")).isLeft should be(true)
+        LongType
+          .coerceInput(StringValue("123234438749837964783648763284768372648723684763287"))
+          .isLeft should be(true)
       }
 
       "BigInt" in {
@@ -227,7 +228,9 @@ class CoercionSpec extends AnyWordSpec with Matchers {
         LongType.coerceUserInput(true).isLeft should be(true)
         LongType.coerceUserInput("123") should be(Right(123L))
         LongType.coerceUserInput("").isLeft should be(true)
-        LongType.coerceUserInput("1232344387498237498732974982334324234325435").isLeft should be(true)
+        LongType
+          .coerceUserInput("1232344387498237498732974982334324234325435")
+          .isLeft should be(true)
         LongType.coerceUserInput("123.0").isLeft should be(true)
         LongType.coerceUserInput(new Date).isLeft should be(true)
       }


### PR DESCRIPTION
Solves: https://github.com/sangria-graphql/sangria/issues/1162

Let me know if this is really something that should be solved in `sangria-circe` instead?