### PR TITLE
Fix issue with wrong Action[Ctx, _] conversion being summoned

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -254,6 +254,11 @@ lazy val derivation = project
     name := "sangria-derivation",
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
     mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-derivation" % "4.0.0"),
+    mimaBinaryIssueFilters ++= Seq(
+      // internal method
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "sangria.macros.derive.DeriveMacroSupport.unsafeSelectByName")
+    ),
     // Macros
     libraryDependencies ++= (if (isScala3.value) Seq.empty
                              else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)),

--- a/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveMacroSupport.scala
+++ b/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveMacroSupport.scala
@@ -5,7 +5,7 @@ import sangria.schema.{InputType, OutputType}
 import scala.quoted._
 import scala.reflect.ClassTag
 
-trait DeriveMacroSupport {
+private[derive] trait DeriveMacroSupport {
 
   def reportErrors(using Quotes)(errors: Seq[(PositionPointer, String)]) = {
     import quotes.reflect.report
@@ -109,11 +109,12 @@ trait DeriveMacroSupport {
     }
   }
 
-  protected def unsafeSelectByName[S](using quotes: Quotes)(using
-      Type[S])(memberExpr: Expr[_], name: String): Expr[S] = {
+  protected def unsafeSelectByName[T: Type](using quotes: Quotes)(
+      memberExpr: Expr[_],
+      name: String
+  ): Expr[T] = {
     import quotes.reflect._
-    val a = Select.unique(memberExpr.asTerm, name)
-    a.etaExpand(Symbol.spliceOwner).asExprOf[S]
+    Select.unique(memberExpr.asTerm, name).asExprOf[T]
   }
 
   protected def getClassTag[T](using Type[T], Quotes): Expr[ClassTag[T]] = {

--- a/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -836,5 +836,32 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
 
       "deriveObjectType[Unit, TestContainer[TestSubject]]()" should compile
     }
+
+    "handle Future result values correctly (issue #906)" in {
+      import Issue906Context._
+      import sangria.parser.QueryParser
+
+      val query = QueryParser
+        .parse(
+          s"""
+             query SomeTest {
+                 mySample {
+                   myFutureString
+                 }
+             }
+            """
+        )
+        .fold(throw _, identity)
+
+      Executor.execute(MySample.schema, query, MyRepository.sample).await should be(
+        Map(
+          "data" -> Map(
+            "mySample" -> Map(
+              "myFutureString" -> "Hello World"
+            )
+          )
+        )
+      )
+    }
   }
 }

--- a/modules/derivation/src/test/scala/sangria/macros/derive/Issue906Context.scala
+++ b/modules/derivation/src/test/scala/sangria/macros/derive/Issue906Context.scala
@@ -1,0 +1,64 @@
+package sangria.macros.derive
+
+import sangria.schema._
+
+import scala.concurrent.Future
+
+object Issue906Context {
+
+  @GraphQLName("SampleCaseClass")
+  @GraphQLDescription("A sample case class")
+  final case class SampleCaseClass(
+      name: String
+  ) {
+    @GraphQLField
+    @GraphQLName("myString")
+    def graphqlMyString: String = "Hello World"
+
+    @GraphQLField
+    @GraphQLName("myFutureString")
+    def graphqlMyFutureString: Future[String] = Future.successful("Hello World")
+
+  }
+
+  object SampleCaseClass {
+    val sample: SampleCaseClass = SampleCaseClass("My test")
+  }
+
+  trait MyRepository {
+    def getSampleCaseClass: SampleCaseClass
+  }
+
+  object MyRepository {
+    def sample: MyRepository = new MyRepository {
+      override def getSampleCaseClass: SampleCaseClass = SampleCaseClass.sample
+    }
+  }
+
+  object MySample {
+    val schema: Schema[MyRepository, Unit] = {
+
+      implicit val graphqlSampleCaseClass: ObjectType[MyRepository, SampleCaseClass] =
+        deriveObjectType[MyRepository, SampleCaseClass]()
+
+      val queries: ObjectType[MyRepository, Unit] = ObjectType(
+        "Query",
+        fields(
+          Field(
+            "mySample",
+            graphqlSampleCaseClass,
+            Some("test"),
+            arguments = Nil,
+            resolve = (ctx: Context[MyRepository, Unit]) => SampleCaseClass.sample
+          )
+        )
+      )
+
+      Schema(
+        query = queries,
+        mutation = None,
+        additionalTypes = Nil
+      )
+    }
+  }
+}


### PR DESCRIPTION
The actual change that fixes the issue is very simple, instead of summoning `[fieldType => Action[Ctx, fieldType]]` we summon `[fieldType => Action[Ctx, _]]`, so that we can also summon `ReduceAcrion.futureAction` and `tryAction` (previously we mistakenly limited ourselves to `defaultAction`).

I also allowed myself to simplify the code a bit, wrapping all of the faux-implicit conversions into a separate method, for readability.

Based on the minimization and research done in https://github.com/sangria-graphql/sangria/pull/1168 (I moved the test into the `DeriveObjectTypeMacroSuite`)

Fixes  #906 