### PR TITLE
Fix O(N^2) memory allocation for parsing newlines

### DIFF
--- a/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
@@ -36,15 +36,14 @@ private[parser] trait PositionTracking { this: Parser =>
     *
     * Assumes that the array is sorted in ascending order.
     */
-  private def findLastItem(arr: ArrayBuffer[Int], item: Int) = {
-    if (arr.length > 0) {
+  private def findLastItem(arr: ArrayBuffer[Int], item: Int) =
+    if (arr.nonEmpty) {
       arr.search(item) match {
         case Found(idx) => (idx + 1, arr(idx))
         case InsertionPoint(idx) if idx == 0 => (idx, arr(idx))
-        case InsertionPoint(idx) => (idx, arr(idx-1))
+        case InsertionPoint(idx) => (idx, arr(idx - 1))
       }
     } else {
       (0, 0)
     }
-  }
 }

--- a/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
@@ -4,11 +4,12 @@ import org.parboiled2._
 import sangria.ast.AstLocation
 
 import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
 
 private[parser] trait PositionTracking { this: Parser =>
 
   /** The indices (offsets into the source code) of the first characters of each line. */
-  private[this] var lineIdx = Array(0)
+  private[this] var lineIdx = ArrayBuffer.empty[int]
 
   def parseLocations: Boolean
   def sourceId: String

--- a/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
+++ b/modules/parser/src/main/scala/sangria/parser/PositionTracking.scala
@@ -3,20 +3,23 @@ package sangria.parser
 import org.parboiled2._
 import sangria.ast.AstLocation
 
-import scala.annotation.tailrec
+import scala.collection.Searching._
 import scala.collection.mutable.ArrayBuffer
 
 private[parser] trait PositionTracking { this: Parser =>
 
   /** The indices (offsets into the source code) of the first characters of each line. */
-  private[this] var lineIdx = ArrayBuffer.empty[int]
+  private[this] val lineIdx = ArrayBuffer[Int](0)
 
   def parseLocations: Boolean
   def sourceId: String
 
   def trackNewLine: Rule0 = rule {
     test(parseLocations) ~ run {
-      if (!contains(lineIdx, cursor)) lineIdx = lineIdx :+ cursor
+      lineIdx.search(cursor) match {
+        case _: InsertionPoint => lineIdx += cursor
+        case _ => None
+      }
     } | MATCH
   }
 
@@ -28,31 +31,20 @@ private[parser] trait PositionTracking { this: Parser =>
     } | push(None)
   }
 
-  /** Returns true if the array contains the given item.
-    *
-    * Assumes that the array is sorted in ascending order.
-    */
-  private def contains(arr: Array[Int], item: Int) = {
-    @tailrec def go(i: Int): Boolean =
-      if (i < 0) false
-      else if (arr(i) < item) false // no remaining values will match as the array is sorted
-      else if (arr(i) == item) true
-      else go(i - 1)
-
-    go(arr.length - 1)
-  }
-
   /** Returns the first item that is less than or equal to the given item along with the number of
     * elements that come before it.
     *
     * Assumes that the array is sorted in ascending order.
     */
-  private def findLastItem(arr: Array[Int], item: Int) = {
-    @tailrec def go(i: Int, last: Int): (Int, Int) =
-      if (i < 0) (i + 1, last)
-      else if (arr(i) <= item) (i + 1, arr(i))
-      else go(i - 1, arr(i))
-
-    go(arr.length - 1, 0)
+  private def findLastItem(arr: ArrayBuffer[Int], item: Int) = {
+    if (arr.length > 0) {
+      arr.search(item) match {
+        case Found(idx) => (idx + 1, arr(idx))
+        case InsertionPoint(idx) if idx == 0 => (idx, arr(idx))
+        case InsertionPoint(idx) => (idx, arr(idx-1))
+      }
+    } else {
+      (0, 0)
+    }
   }
 }


### PR DESCRIPTION
Immutable array appends require an array copy. So memory allocations here grow quadratically with the number of lines in a schema file.

Large repos with a large graphql schemas can have thousands of lines which makes this significant.  

Switch Array -> Mutable ArrayBuffer
Also switches from linear search to binary search

On a 300k GraphQL schema from our production environment that cut parsing time from 16 seconds down to 3 seconds with position tracking and comment parsing.

(Test is not included because I don't have the time to anonymize it, sorry)