### PR TITLE
Add Scala 3 cats-effect derivation lookups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -314,7 +314,7 @@ lazy val sangriaTestFS2 = project
 lazy val sangriaCatsEffectExperimental = project
   .in(file("modules/cats-effect-experimental"))
   .withId("sangria-cats-effect-experimental")
-  .dependsOn(core % "compile->compile;test->test")
+  .dependsOn(core % "compile->compile;test->test", derivation)
   .settings(scalacSettings ++ shellSettings)
   .settings(
     name := "sangria-cats-effect-experimental",

--- a/modules/cats-effect-experimental/src/main/scala/sangria/catseffect/schema/AsyncValue.scala
+++ b/modules/cats-effect-experimental/src/main/scala/sangria/catseffect/schema/AsyncValue.scala
@@ -1,7 +1,8 @@
 package sangria.catseffect.schema
 
-import cats.effect.Async
-import sangria.schema.LeafAction
+import cats.effect.{Async, IO}
+import sangria.macros.derive.GraphQLOutputTypeLookup
+import sangria.schema.{LeafAction, OutputType}
 
 import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
@@ -12,7 +13,23 @@ case class AsyncValue[Ctx, Val, F[_]: Async](value: F[Val]) extends LeafAction[C
     new AsyncValue(Async[F].map(value)(fn))
 }
 
-object AsyncValue {
+trait AsyncValueLowPriority {
+  implicit def asyncOutputTypeLookup[F[_]: Async, A](implicit
+      inner: GraphQLOutputTypeLookup[A]): GraphQLOutputTypeLookup[F[A]] =
+    new GraphQLOutputTypeLookup[F[A]] {
+      override val graphqlType: OutputType[F[A]] =
+        inner.graphqlType.asInstanceOf[OutputType[F[A]]]
+    }
+}
+
+object AsyncValue extends AsyncValueLowPriority {
   implicit def asyncAction[Ctx, Val, F[_]: Async](value: F[Val]): LeafAction[Ctx, Val] =
     AsyncValue(value)
+
+  implicit def ioOutputTypeLookup[A](implicit
+      inner: GraphQLOutputTypeLookup[A]): GraphQLOutputTypeLookup[IO[A]] =
+    new GraphQLOutputTypeLookup[IO[A]] {
+      override val graphqlType: OutputType[IO[A]] =
+        inner.graphqlType.asInstanceOf[OutputType[IO[A]]]
+    }
 }

--- a/modules/cats-effect-experimental/src/test/scala-3/sangria/catseffect/IOExecutionSchemeDerivationSpec.scala
+++ b/modules/cats-effect-experimental/src/test/scala-3/sangria/catseffect/IOExecutionSchemeDerivationSpec.scala
@@ -1,0 +1,88 @@
+package sangria.catseffect
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.circe.Json
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import sangria.catseffect.execution.IOExecutionScheme._
+import sangria.catseffect.schema.AsyncValue._
+import sangria.execution.Executor
+import sangria.macros._
+import sangria.macros.derive._
+import sangria.marshalling.circe._
+import sangria.schema._
+import sangria.validation.ValueCoercionViolation
+
+class IOExecutionSchemeDerivationSpec extends AnyWordSpec with Matchers {
+  import IOExecutionSchemeDerivationSpec._
+
+  "IOExecutionScheme" must {
+    "allow deriving IO-returning fields" in {
+      val query =
+        gql"""
+          query q1 {
+            users { id name }
+            firstUser { id name }
+            currentUser { id name }
+            userCount
+            noOp
+          }
+        """
+
+      val res: IO[Json] = Executor.execute(schema, query, root = new Queries)
+
+      val expected: Json = Json.obj(
+        "data" -> Json.obj(
+          "users" -> Json.arr(
+            Json.obj("id" -> Json.fromInt(1), "name" -> Json.fromString("Ada")),
+            Json.obj("id" -> Json.fromInt(2), "name" -> Json.fromString("Grace"))
+          ),
+          "firstUser" -> Json.obj("id" -> Json.fromInt(1), "name" -> Json.fromString("Ada")),
+          "currentUser" -> Json.obj("id" -> Json.fromInt(2), "name" -> Json.fromString("Grace")),
+          "userCount" -> Json.fromInt(2),
+          "noOp" -> Json.fromString("OK")
+        )
+      )
+
+      res.unsafeRunSync() must be(expected)
+    }
+  }
+}
+
+object IOExecutionSchemeDerivationSpec {
+  case object UnitCoercionViolation extends ValueCoercionViolation("Unit value is not input")
+
+  private case class User(id: Int, name: String)
+
+  private implicit val UnitType: ScalarType[Unit] = ScalarType[Unit](
+    "Unit",
+    coerceOutput = (_, _) => "OK",
+    coerceUserInput = _ => Left(UnitCoercionViolation),
+    coerceInput = _ => Left(UnitCoercionViolation)
+  )
+
+  private implicit val UserType: ObjectType[Unit, User] = deriveObjectType[Unit, User]()
+
+  private class Queries {
+    private val values = List(User(1, "Ada"), User(2, "Grace"))
+
+    @GraphQLField
+    def users: IO[List[User]] = IO.pure(values)
+
+    @GraphQLField
+    def firstUser: IO[Option[User]] = IO.pure(values.headOption)
+
+    @GraphQLField
+    def currentUser: IO[User] = IO.pure(values(1))
+
+    @GraphQLField
+    def userCount: IO[Int] = IO.pure(values.size)
+
+    @GraphQLField
+    def noOp: IO[Unit] = IO.unit
+  }
+
+  private val QueryType: ObjectType[Unit, Queries] = deriveObjectType[Unit, Queries]()
+  private val schema = Schema(QueryType)
+}

--- a/modules/cats-effect-experimental/src/test/scala/sangria/catseffect/IOExecutionSchemeSpec.scala
+++ b/modules/cats-effect-experimental/src/test/scala/sangria/catseffect/IOExecutionSchemeSpec.scala
@@ -65,6 +65,7 @@ class IOExecutionSchemeSpec extends AnyWordSpec with Matchers {
 
 object IOExecutionSchemeSpec {
   import sangria.catseffect.schema.AsyncValue._
+
   private val QueryType: ObjectType[Unit, Unit] = ObjectType(
     "Query",
     () =>


### PR DESCRIPTION
## Summary

Part of #1299.

This adds Scala 3 derivation support for cats-effect fields by exposing `GraphQLOutputTypeLookup` instances from `AsyncValue._`:

- `GraphQLOutputTypeLookup[IO[A]]` delegates to `GraphQLOutputTypeLookup[A]`
- generic `GraphQLOutputTypeLookup[F[A]]` delegates to `A` when an `Async[F]` is available

The cats-effect experimental module now depends on `sangria-derivation` so these helpers can live with the existing `AsyncValue` action conversion import.

## Scope

The regression test is Scala 3-only because Scala 3 derivation explicitly summons the field action conversion and can therefore resolve `IO[A]` through `AsyncValue`. Scala 2 derivation uses the method return type as the `Field` result type for argless methods, so a lookup alone is not sufficient to unwrap `IO[A]` there without a separate macro change.

## Validation

- `JAVA_HOME=$(cs java-home --jvm temurin:17) sbt '++3.3.7' 'sangria-cats-effect-experimental/Test/testOnly sangria.catseffect.IOExecutionSchemeSpec sangria.catseffect.IOExecutionSchemeDerivationSpec'`
- `JAVA_HOME=$(cs java-home --jvm temurin:17) sbt '++2.13.18' 'sangria-cats-effect-experimental/Test/testOnly sangria.catseffect.IOExecutionSchemeSpec'`
- `JAVA_HOME=$(cs java-home --jvm temurin:17) sbt scalafmtCheckAll`