### PR TITLE
Fix Scala 3 path-dependent method return derivation

### DIFF
--- a/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveObjectTypeMacro.scala
+++ b/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveObjectTypeMacro.scala
@@ -143,11 +143,6 @@ class DeriveObjectTypeMacro(using globalQuotes: Quotes) extends DeriveMacroSuppo
             else
               fieldWithArguments(config, field, ctxType, valType, ctxValType)
 
-          @tailrec
-          def methodResultType(typeRepr: TypeRepr): TypeRepr = typeRepr match
-            case MethodType(_, _, retType) => methodResultType(retType)
-            case retType => retType
-
           // Contextualize the method type with respect to the enclosing type
           val fieldType = methodResultType(field.onType.memberType(field.method).widen)
           val actualFieldType = findActualFieldType(fieldType)
@@ -294,17 +289,15 @@ class DeriveObjectTypeMacro(using globalQuotes: Quotes) extends DeriveMacroSuppo
           val method = Select.unique(expr.asTerm, member.method.name)
           val args = argsAst('c).map(_.map(_.asTerm))
           if (member.method.isDefDef)
-            member.method.tree match
-              case d: DefDef =>
-                d.returnTpt.tpe.asType match
-                  case '[t] =>
-                    wrappedInActionConversion[Ctx, t](
-                      args
-                        .foldLeft[Select | Apply](method) { (m, argList) =>
-                          Apply(m, argList)
-                        }
-                        .asExprOf[t]
-                    )
+            methodResultType(member.onType.memberType(member.method).widen).asType match
+              case '[t] =>
+                wrappedInActionConversion[Ctx, t](
+                  args
+                    .foldLeft[Select | Apply](method) { (m, argList) =>
+                      Apply(m, argList)
+                    }
+                    .asExprOf[t]
+                )
           else
             globalQuotes.reflect.Ref(member.method).tpe.widen.asType match {
               case '[t] =>
@@ -313,6 +306,14 @@ class DeriveObjectTypeMacro(using globalQuotes: Quotes) extends DeriveMacroSuppo
         }
       }
   }
+
+  @tailrec
+  private def methodResultType(typeRepr: globalQuotes.reflect.TypeRepr)
+      : globalQuotes.reflect.TypeRepr =
+    import globalQuotes.reflect._
+    typeRepr match
+      case MethodType(_, _, retType) => methodResultType(retType)
+      case retType => retType
 
   private def wrappedInActionConversion[Ctx: Type, T: Type](value: Expr[T]) = {
     import globalQuotes.reflect._

--- a/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveObjectTypeMacro.scala
+++ b/modules/derivation/src/main/scala-3/sangria/macros/derive/DeriveObjectTypeMacro.scala
@@ -308,8 +308,8 @@ class DeriveObjectTypeMacro(using globalQuotes: Quotes) extends DeriveMacroSuppo
   }
 
   @tailrec
-  private def methodResultType(typeRepr: globalQuotes.reflect.TypeRepr)
-      : globalQuotes.reflect.TypeRepr =
+  private def methodResultType(
+      typeRepr: globalQuotes.reflect.TypeRepr): globalQuotes.reflect.TypeRepr =
     import globalQuotes.reflect._
     typeRepr match
       case MethodType(_, _, retType) => methodResultType(retType)

--- a/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
+++ b/modules/derivation/src/test/scala/sangria/macros/derive/DeriveObjectTypeMacroSpec.scala
@@ -524,6 +524,28 @@ class DeriveObjectTypeMacroSpec extends AnyWordSpec with Matchers with FutureRes
         ))
     }
 
+    "derive methods returning a path-dependent effect type" in {
+      class Resource {
+        type F[A] = Future[A]
+
+        class Queries[G[_]](result: G[Int]) {
+          @GraphQLField
+          def value: G[Int] = result
+        }
+
+        val queryType: ObjectType[Unit, Queries[F]] =
+          deriveObjectType[Unit, Queries[F]]()
+        val queries = new Queries[F](Future.successful(42))
+      }
+
+      val resource = new Resource
+      val schema = Schema(resource.queryType)
+      val query = graphql"{ value }"
+
+      Executor.execute(schema, query, root = resource.queries).await should be(
+        Map("data" -> Map("value" -> 42)))
+    }
+
     "derive methods with arguments via annotations" in {
       object MyJsonProtocol extends DefaultJsonProtocol {
         implicit val PetFormat: JsonFormat[Pet] = jsonFormat2(Pet.apply)


### PR DESCRIPTION
## Summary

Fixes #1298.

This changes the Scala 3 object derivation macro to use the method return type as seen from the derived owner type when casting generated resolver expressions. The field type path already used this contextualized type; the resolver path still used the raw `DefDef.returnTpt.tpe`, which can differ for path-dependent higher-kinded return types.

## Why

For field holders such as `Queries[F]` derived from an outer resource with a path-dependent `F`, the generated resolver expression may type as the outer `F[A]` while the raw method declaration type is the inner type parameter `G[A]`. Using the owner-contextualized member type keeps both sides aligned.

## Validation

- `JAVA_HOME=$(cs java-home --jvm temurin:17) sbt '++3.3.7' 'sangria-derivation/Test/testOnly sangria.macros.derive.DeriveObjectTypeMacroSpec'`
- `JAVA_HOME=$(cs java-home --jvm temurin:17) sbt scalafmtCheckAll`